### PR TITLE
fix(delivery): reconcile canonical original receipts without replay

### DIFF
--- a/src/lib/runtime/canonicalDeliveryRecovery.test.ts
+++ b/src/lib/runtime/canonicalDeliveryRecovery.test.ts
@@ -19,7 +19,7 @@ function fixture() {
   const registry = new AgentRegistry(path.join(directory, "registry.json"));
   const conversation = registry.ensureConversation("codex", transcript, null);
   const filename = path.join(directory, "runtime.sqlite");
-  let journal = new RuntimeJournal(filename, { structuredHosts: true });
+  let journal = new RuntimeJournal(filename, { structuredHosts: true, maxEvents: 100_000 });
   const operationId = "original-operation";
   const clientKey = "original-client-key";
   const text = "[viewer context — selected reviewer]\nOriginal т instruction 🎯";
@@ -56,7 +56,7 @@ function fixture() {
   }), operationId, { enabled: () => true, registry: () => registry, client: () => client, kick: () => { kicks++; } });
   return { directory, transcript, filename, registry, conversation, operationId, clientKey, command, contentDigest, selectedContext, wire, dedup, text,
     journal: () => journal, client, echo, write, request, kicks: () => kicks,
-    restart: () => { journal.close(); journal = new RuntimeJournal(filename, { structuredHosts: true }); },
+    restart: () => { journal.close(); journal = new RuntimeJournal(filename, { structuredHosts: true, maxEvents: 100_000 }); },
     close: () => { journal.close(); fs.rmSync(directory, { recursive: true, force: true }); },
   };
 }
@@ -175,5 +175,76 @@ test("verified delivered truth is not downgraded by a stale uncertain journal an
     expect(await resolveOriginalSend({ conversationId: f.conversation.id, clientMessageId: f.clientKey }, { registry: f.registry, client }))
       .toMatchObject({ current: { readable: true, value: { state: "delivered" } } });
     expect(reads).toBe(0);
+  } finally { f.close(); }
+});
+
+
+test("recovery refuses an incomplete 256-item journal window", async () => {
+  const f = fixture();
+  try {
+    for (let index = 0; index < 255; index++) f.journal().append({ scope: { type: "session", id: f.conversation.id }, kind: "item",
+      payload: { conversationId: f.conversation.id, turnId: "noise", phase: "completed", item: { type: "userMessage", clientId: `unrelated-${index}`, content: [] } } });
+    f.echo("conflicting-turn", f.wire, 999);
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId)).rejects.toThrow();
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+    expect(f.journal().effectBatch()).toEqual([]);
+  } finally { f.close(); }
+});
+
+test("recovery refuses an incomplete 50000-sequence journal window", async () => {
+  const f = fixture();
+  try {
+    for (let index = 0; index < 50_001; index++) f.journal().append({ scope: { type: "session", id: "noise" }, kind: "item", payload: { index } });
+    f.echo("conflicting-turn", f.wire, 999);
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId)).rejects.toThrow();
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+  } finally { f.close(); }
+}, 90_000);
+
+test("a conflicting turn arriving during canonical verification prevents settlement", async () => {
+  const f = fixture();
+  try {
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId, async (pathname, entry) => {
+      const proof = await readCanonicalCodexDelivery(pathname, entry);
+      f.echo("late-conflicting-turn", f.wire, 2);
+      return proof;
+    })).rejects.toThrow();
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+    expect(f.journal().effectBatch()).toEqual([]);
+  } finally { f.close(); }
+});
+
+test("a supplied digest cannot replace verification of the actual canonical text", async () => {
+  const f = fixture();
+  try {
+    f.write(encodeCodexStructuredUserText("different instruction", f.contentDigest, f.selectedContext, { kind: "operator" }, f.dedup));
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId)).rejects.toThrow();
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+  } finally { f.close(); }
+});
+
+test("recovery checks collisions before the canonical 16 MiB tail", async () => {
+  const f = fixture();
+  try {
+    f.write(encodeCodexStructuredUserText("different instruction", undefined, f.selectedContext, { kind: "operator" }, f.dedup));
+    fs.appendFileSync(f.transcript, JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "x".repeat(17 * 1024 * 1024) } }) + "\n");
+    fs.appendFileSync(f.transcript, JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: f.wire }] } }) + "\n");
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId)).rejects.toThrow();
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+  } finally { f.close(); }
+});
+
+
+test("canonical evidence appended during verification prevents settlement", async () => {
+  const f = fixture();
+  try {
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId, async (pathname, entry) => {
+      const proof = await readCanonicalCodexDelivery(pathname, entry);
+      fs.appendFileSync(pathname, JSON.stringify({ type: "response_item", payload: { type: "message", role: "user",
+        content: [{ type: "input_text", text: encodeCodexStructuredUserText("conflicting instruction", undefined, f.selectedContext, { kind: "operator" }, f.dedup) }] } }) + "\n");
+      return proof;
+    })).rejects.toThrow();
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+    expect(f.journal().effectBatch()).toEqual([]);
   } finally { f.close(); }
 });

--- a/src/lib/runtime/canonicalDeliveryRecovery.test.ts
+++ b/src/lib/runtime/canonicalDeliveryRecovery.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import { AgentRegistry } from "@/lib/agent/registry";
+import { RuntimeJournal } from "@/runtime-host/journal";
+import { encodeCodexStructuredUserText } from "./codexStructuredUserText";
+import { structuredContent } from "./structuredContent";
+import { handleRuntimeRetry } from "./http";
+import { resolveOriginalSend, resolveSendReceipt, sendReceiptFor } from "./sendSettlement";
+import { readCanonicalCodexDelivery } from "./codexAppServerHost";
+import type { RuntimeHostClient } from "./client";
+
+function fixture() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "canonical-original-"));
+  const transcript = path.join(directory, "native-generation.jsonl");
+  const registry = new AgentRegistry(path.join(directory, "registry.json"));
+  const conversation = registry.ensureConversation("codex", transcript, null);
+  const filename = path.join(directory, "runtime.sqlite");
+  let journal = new RuntimeJournal(filename, { structuredHosts: true });
+  const operationId = "original-operation";
+  const clientKey = "original-client-key";
+  const text = "[viewer context — selected reviewer]\nOriginal т instruction 🎯";
+  const selectedContext = { version: 1 as const, state: "selected" as const,
+    conversationId: ["conversation", "selected-card"].join("_"), capturedAt: "2026-09-08T09:21:00.000Z", label: "reviewer" };
+  const dedup = createHash("sha256").update(operationId).digest("hex");
+  const wire = encodeCodexStructuredUserText(text, undefined, selectedContext, { kind: "operator" }, dedup);
+  const contentDigest = structuredContent(text, []).contentDigest;
+  const metadata = { conversationId: conversation.id, sessionKey: { engine: "codex", sessionId: "native-generation" },
+    hostKind: "codex-app-server", host: "hosted", turn: "idle", activeTurnId: null, provenance: "structured",
+    artifactPath: transcript, capabilities: { steer: true, structuredAttention: true } };
+  journal.append({ scope: { type: "session", id: conversation.id }, kind: "session-status", payload: metadata });
+  const command = { kind: "send" as const, operationId, conversationId: conversation.id, idempotencyKey: clientKey,
+    text, contentDigest, selectedContext, policy: "queue" as const };
+  journal.executeOperation(command);
+  journal.transitionOperation(operationId, "delivering", { turnId: null });
+  const held = registry.holdDelivery(conversation.id, text, clientKey, "text", [], contentDigest, { operationId, kind: "send", policy: "queue" });
+  registry.recordDeliveryOutcome(held.id, "failed", "payload echo unverified", "unverified");
+  const echo = (turnId: string, content = wire, seq = 1) => journal.append({ scope: { type: "session", id: conversation.id }, kind: "item",
+    producer: { kind: "codex-app-server", eventKey: `engine-host:codex:native-generation:${seq}` },
+    payload: { conversationId: conversation.id, turnId, phase: "started", item: { type: "userMessage", clientId: operationId, content: [{ type: "text", text: content }] } } });
+  echo("original-turn");
+  journal.transitionOperation(operationId, "uncertain", { reason: "Codex queue entry id belongs to a different payload" });
+  const write = (value: string) => fs.writeFileSync(transcript, JSON.stringify({ type: "response_item", payload: { type: "message", role: "user",
+    content: [{ type: "input_text", text: value }] } }) + "\n");
+  write(wire);
+  let kicks = 0;
+  const client = { operationStatus: async (id: string) => journal.operationResult(id), reconcileDelivery: (id: string, expected: import("./contracts").RuntimeCanonicalDeliveryBinding) => journal.reconcileCanonicalDelivery(id, undefined, expected),
+    retryOperation: async () => { throw new Error("reconciliation must never retry"); },
+    claimDeliveryAction: async () => { throw new Error("reconciliation must never claim a retry"); },
+  } as unknown as RuntimeHostClient;
+  const request = (body: unknown = { action: "reconcile-delivery" }) => handleRuntimeRetry(new NextRequest(`http://127.0.0.1/api/runtime/operations/${operationId}`, {
+    method: "POST", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify(body),
+  }), operationId, { enabled: () => true, registry: () => registry, client: () => client, kick: () => { kicks++; } });
+  return { directory, transcript, filename, registry, conversation, operationId, clientKey, command, contentDigest, selectedContext, wire, dedup, text,
+    journal: () => journal, client, echo, write, request, kicks: () => kicks,
+    restart: () => { journal.close(); journal = new RuntimeJournal(filename, { structuredHosts: true }); },
+    close: () => { journal.close(); fs.rmSync(directory, { recursive: true, force: true }); },
+  };
+}
+
+test("the original-key reconcile API settles canonical delivery without retry and survives query/snapshot/restart", async () => {
+  const f = fixture();
+  try {
+    expect(sendReceiptFor(f.registry.readOnlySnapshot(), f.operationId)).toMatchObject({ state: "failed", resend: "verify-first" });
+    const result = await f.request();
+    expect(result.status).toBe(200);
+    expect(await result.json()).toMatchObject({ operationId: f.operationId, receipt: { status: "delivered", idempotencyKey: f.clientKey, turnId: "original-turn" }, send: { state: "delivered" } });
+    expect(f.kicks()).toBe(0);
+    expect(f.journal().effectBatch()).toEqual([]);
+    const revision = f.journal().operationResult(f.operationId)!.receipt.revision;
+    expect(f.journal().snapshot().recentOperations.find((receipt) => receipt.operationId === f.operationId)?.status).toBe("delivered");
+    f.restart();
+    expect(f.journal().operationResult(f.operationId)!.receipt).toMatchObject({ status: "delivered", idempotencyKey: f.clientKey, revision });
+    expect((await f.request()).status).toBe(200);
+    expect(f.journal().operationResult(f.operationId)!.receipt.revision).toBe(revision);
+    expect(await resolveOriginalSend({ conversationId: f.conversation.id, clientMessageId: f.clientKey, text: f.text }, { registry: f.registry, client: f.client }))
+      .toMatchObject({ kind: "found", operationId: f.operationId, current: { readable: true, value: { state: "delivered", resend: "not-needed" } } });
+    expect(f.journal().executeOperation(f.command).receipt.status).toBe("delivered");
+  } finally { f.close(); }
+});
+
+test("a journal-first crash repairs the stale unverified registry projection through the original receipt query", async () => {
+  const f = fixture();
+  try {
+    await f.journal().reconcileCanonicalDelivery(f.operationId);
+    expect(sendReceiptFor(f.registry.readOnlySnapshot(), f.operationId)?.state).toBe("failed");
+    f.restart();
+    expect(await resolveSendReceipt(f.operationId, { registry: f.registry, client: f.client })).toMatchObject({ state: "delivered", resend: "not-needed" });
+    expect(sendReceiptFor(f.registry.readOnlySnapshot(), f.operationId)?.state).toBe("delivered");
+    expect(f.kicks()).toBe(0);
+  } finally { f.close(); }
+});
+
+for (const invalid of ["wrong-key", "changed-payload", "changed-context", "unreadable", "ambiguous"] as const) test(`canonical reconciliation refuses ${invalid} evidence without effects`, async () => {
+  const f = fixture();
+  try {
+    if (invalid === "wrong-key") f.write(encodeCodexStructuredUserText(f.text, undefined, f.selectedContext, { kind: "operator" }, "f".repeat(64)));
+    if (invalid === "changed-payload") f.write(encodeCodexStructuredUserText("different text", undefined, f.selectedContext, { kind: "operator" }, f.dedup));
+    if (invalid === "changed-context") f.write(encodeCodexStructuredUserText(f.text, undefined, { ...f.selectedContext, label: "changed context" }, { kind: "operator" }, f.dedup));
+    if (invalid === "unreadable") fs.unlinkSync(f.transcript);
+    if (invalid === "ambiguous") f.echo("another-turn", f.wire, 2);
+    const response = await f.request();
+    expect(response.status).not.toBe(200);
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+    expect(sendReceiptFor(f.registry.readOnlySnapshot(), f.operationId)).toMatchObject({ state: "failed", resend: "verify-first" });
+    expect(f.journal().effectBatch()).toEqual([]);
+    expect(f.kicks()).toBe(0);
+  } finally { f.close(); }
+});
+
+test("a discard/retry action winning during proof verification prevents canonical settlement", async () => {
+  const f = fixture();
+  try {
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId, async (pathname, entry) => {
+      const proof = await readCanonicalCodexDelivery(pathname, entry);
+      f.journal().claimDeliveryAction(f.operationId, "discard");
+      return proof;
+    })).rejects.toThrow("moved");
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+    expect(f.journal().effectBatch()).toEqual([]);
+  } finally { f.close(); }
+});
+
+test("reconciliation cannot accept a replacement key or caller-supplied delivery claim", async () => {
+  const f = fixture();
+  try {
+    expect((await f.request({ action: "reconcile-delivery", idempotencyKey: "replacement" })).status).toBe(400);
+    expect((await f.request({ action: "reconcile-delivery", status: "delivered" })).status).toBe(400);
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+  } finally { f.close(); }
+});
+
+
+test("runtime-host RPC reconciliation uses the original generation after a later session rotation", async () => {
+  const { RuntimeHost } = await import("@/runtime-host/host");
+  const f = fixture();
+  try {
+    f.journal().append({ scope: { type: "session", id: f.conversation.id }, kind: "session-status", payload: {
+      conversationId: f.conversation.id, sessionKey: { engine: "codex", sessionId: "successor-generation" },
+      artifactPath: path.join(f.directory, "successor.jsonl"), hostKind: "codex-app-server", host: "hosted", turn: "idle", activeTurnId: null,
+    } });
+    const host = new RuntimeHost(f.journal(), undefined, undefined, true);
+    expect(await host.handle({ id: "original-proof-request", method: "operation-reconcile-delivery", params: { operationId: f.operationId,
+      expected: { conversationId: f.conversation.id, idempotencyKey: f.clientKey, contentDigest: f.contentDigest } } }))
+      .toMatchObject({ ok: true, result: { operationId: f.operationId, receipt: { status: "delivered", canonicalDelivery: { generation: "native-generation" } } } });
+    expect(f.journal().effectBatch()).toEqual([]);
+  } finally { f.close(); }
+});
+
+
+test("a contradictory registry expectation cannot mutate the original journal receipt", async () => {
+  const f = fixture();
+  try {
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId, undefined,
+      { conversationId: f.conversation.id, idempotencyKey: "wrong-client-key", contentDigest: f.contentDigest })).rejects.toThrow("binding");
+    await expect(f.journal().reconcileCanonicalDelivery(f.operationId, undefined,
+      { conversationId: f.conversation.id, idempotencyKey: f.clientKey, contentDigest: "f".repeat(64) })).rejects.toThrow("binding");
+    expect(f.journal().operationResult(f.operationId)?.receipt.status).toBe("uncertain");
+    expect(f.journal().effectBatch()).toEqual([]);
+  } finally { f.close(); }
+});
+
+
+test("verified delivered truth is not downgraded by a stale uncertain journal answer", async () => {
+  const f = fixture();
+  try {
+    const stale = f.journal().operationResult(f.operationId)!;
+    expect((await f.request()).status).toBe(200);
+    let reads = 0;
+    const client = { ...f.client, operationStatus: async () => { reads++; return stale; } };
+    expect(await resolveSendReceipt(f.operationId, { registry: f.registry, client })).toMatchObject({ state: "delivered", resend: "not-needed" });
+    expect(await resolveOriginalSend({ conversationId: f.conversation.id, clientMessageId: f.clientKey }, { registry: f.registry, client }))
+      .toMatchObject({ current: { readable: true, value: { state: "delivered" } } });
+    expect(reads).toBe(0);
+  } finally { f.close(); }
+});

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -1,3 +1,4 @@
+import type { RuntimeCanonicalDeliveryBinding } from "./contracts";
 import net from "node:net";
 
 import type { RuntimeDeliveryAction, RuntimeDeliveryActionClaim, RuntimeEventInput, RuntimeOperationCommand, RuntimeOperationResult, RuntimePendingEffect, RuntimeReceiptStatus, RuntimeReplay, RuntimeRetryOptions, RuntimeSnapshot, RuntimeSocketRequest, RuntimeSocketResponse, RuntimeTransitionOptions, ViewerDeploymentReceipt, ViewerDeploymentRequest, ViewerDeploymentStatus } from "./contracts";
@@ -93,6 +94,7 @@ export interface RuntimeHostClient {
   operationStatus(operationId: string, options?: { currentRetryLeaf?: boolean }): Promise<RuntimeOperationResult | null>;
   claimDeliveryAction(operationId: string, action: RuntimeDeliveryAction): Promise<RuntimeDeliveryActionClaim>;
   retryOperation(operationId: string, nextIdempotencyKey?: string, options?: RuntimeRetryOptions): Promise<RuntimeOperationResult>;
+  reconcileDelivery?(operationId: string, expected: RuntimeCanonicalDeliveryBinding): Promise<RuntimeOperationResult>;
   producerCursor(producerKind: string, eventKeyPrefix: string): Promise<number>;
   effectBatch(kinds?: readonly string[], afterEventSeq?: number): Promise<RuntimePendingEffect[]>;
   transitionOperation(
@@ -138,6 +140,9 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
         ? { requireHostedConversationId: options.requireHostedConversationId }
         : {}),
     }) as Promise<RuntimeOperationResult>;
+  }
+  reconcileDelivery(operationId: string, expected: RuntimeCanonicalDeliveryBinding): Promise<RuntimeOperationResult> {
+    return this.call("operation-reconcile-delivery", { operationId, expected }) as Promise<RuntimeOperationResult>;
   }
   producerCursor(producerKind: string, eventKeyPrefix: string): Promise<number> { return this.call("producer-cursor", { producerKind, eventKeyPrefix }) as Promise<number>; }
   effectBatch(kinds?: readonly string[], afterEventSeq = 0): Promise<RuntimePendingEffect[]> {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -5158,3 +5158,89 @@ test("a host with no live call releases without a stray hangup", async () => {
   await host.release();
   expect(server.requests.some((request) => request.method === "thread/realtime/stop")).toBe(false);
 });
+
+
+test("UTF-8 split inside a completed user echo preserves the original payload and receipt", async () => {
+  const server = new FakeAppServer();
+  server.autoCompleteUserMessage = false;
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    const text = "A multiline instruction\nUnicode: т 🎯 漢字";
+    const sent = host.send({ id: "utf8-original-operation", text });
+    const outcome = sent.then((receipt) => ({ receipt }), (error: Error) => ({ error: error.message }));
+    await waitForCondition(() => server.requests.some((request) => request.method === "turn/start"), "start must reach fixture");
+    const request = server.requests.find((request) => request.method === "turn/start")!;
+    const content = (request.params as { input: unknown[] }).input;
+    const params = { threadId: host.identity.threadId, turnId: "turn-1",
+      item: { type: "userMessage", clientId: "utf8-original-operation", content } };
+    server.notify("item/started", params);
+    const frame = Buffer.from(JSON.stringify({ jsonrpc: "2.0", method: "item/completed", params }) + "\n");
+    const split = frame.indexOf(Buffer.from("т")) + 1;
+    expect(split).toBeGreaterThan(0);
+    server.stdout.write(frame.subarray(0, split));
+    server.stdout.write(frame.subarray(split));
+    expect(await outcome).toEqual({ receipt: { outcome: "turn-started", turnId: "turn-1" } });
+    expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+  } finally { await host.release(); }
+});
+
+
+test("a poisoned confirmation cache needs exact canonical proof and never accepts a changed payload", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "codex-canonical-repair-"));
+  const server = new FakeAppServer();
+  server.threadPath = path.join(directory, "thread.jsonl");
+  server.autoCompleteUserMessage = false;
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  const entry = { id: "original-operation", text: "Original т instruction" };
+  try {
+    const send = host.send(entry).then((receipt) => ({ receipt }), (error: Error) => ({ error: error.message }));
+    await waitForCondition(() => server.requests.some((request) => request.method === "turn/start"), "start reaches fixture");
+    server.notify("item/completed", { threadId: host.identity.threadId, turnId: "turn-1",
+      item: { type: "userMessage", clientId: entry.id, content: [{ type: "text", text: encodeCodexStructuredUserText("Original �� instruction", undefined, undefined, undefined, deliveryDedup(entry.id)) }] } });
+    expect(await send).toHaveProperty("error");
+    await expect(host.send({ ...entry, text: "Original �� instruction" })).rejects.toThrow("different payload");
+    fs.writeFileSync(server.threadPath, JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text",
+      text: encodeCodexStructuredUserText(entry.text, undefined, undefined, undefined, deliveryDedup(entry.id)) }] } }) + "\n");
+    expect(await host.send(entry)).toMatchObject({ outcome: "turn-started" });
+    await expect(host.send({ ...entry, text: "changed instruction" })).rejects.toThrow("different payload");
+    expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+  } finally { await host.release(); fs.rmSync(directory, { recursive: true, force: true }); }
+});
+
+
+for (const character of ["т", "漢", "🎯"]) test(`every UTF-8 split of ${character} preserves selected-context receipt identity`, async () => {
+  for (let offset = 1; offset < Buffer.byteLength(character); offset++) {
+    const server = new FakeAppServer();
+    server.autoCompleteUserMessage = false;
+    const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+    try {
+      const entry = { id: `split-operation-${offset}`, text: `before ${character} after`, selectedContext: {
+        version: 1 as const, state: "selected" as const, conversationId: ["conversation", "selected"].join("_"), capturedAt: "2026-09-08T09:21:00.000Z" } };
+      const sent = host.send(entry);
+      await waitForCondition(() => server.requests.some((request) => request.method === "turn/start"), "start reaches fixture");
+      const request = server.requests.find((request) => request.method === "turn/start")!;
+      const frame = Buffer.from(JSON.stringify({ jsonrpc: "2.0", method: "item/completed", params: { threadId: host.identity.threadId,
+        turnId: "turn-1", item: { type: "userMessage", clientId: entry.id, content: (request.params as { input: unknown[] }).input } } }) + "\n");
+      const split = frame.indexOf(Buffer.from(character)) + offset;
+      server.stdout.write(frame.subarray(0, split));
+      server.stdout.write(frame.subarray(split));
+      expect(await sent).toMatchObject({ outcome: "turn-started" });
+      expect(await host.send(entry)).toMatchObject({ outcome: "turn-started" });
+      expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+    } finally { await host.release(); }
+  }
+});
+
+test("stdout EOF flushes an incomplete UTF-8 frame as unverified without a delivery receipt", async () => {
+  const server = new FakeAppServer();
+  server.autoCompleteUserMessage = false;
+  const host = await CodexAppServerHost.start({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) });
+  try {
+    const result = host.send({ id: "partial-operation", text: "т" }).then(() => "delivered", () => "unverified");
+    await waitForCondition(() => server.requests.some((request) => request.method === "turn/start"), "start reaches fixture");
+    const partial = Buffer.concat([Buffer.from('{"incomplete":"'), Buffer.from("т").subarray(0, 1)]);
+    server.stdout.end(partial);
+    expect(await result).toBe("unverified");
+    expect((await host.health()).status).toBe("dead");
+  } finally { await host.release(); }
+});

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -506,7 +506,7 @@ function codexDeliveryDedup(operationId: string): string {
   return createHash("sha256").update(operationId).digest("hex");
 }
 type RolloutStructuredUserDelivery =
-  | { payloadKind: "text" | "content"; payloadDigest: string; contextDigest?: string }
+  | { payloadKind: "text" | "content"; payloadDigest: string; textDigest: string; contextDigest?: string }
   | { payloadKind: "conflict"; payloadDigest: null };
 
 interface RolloutTurnsCacheEntry {
@@ -540,16 +540,17 @@ function rememberRolloutStructuredUser(
   if (!decoded.deliveryDedup) return;
   const current = deliveries.get(decoded.deliveryDedup);
   const contextDigest = createHash("sha256").update(JSON.stringify(decoded.selectedContext)).digest("hex");
+  const textDigest = createHash("sha256").update(decoded.text).digest("hex");
   const observed: RolloutStructuredUserDelivery = decoded.contentDigest
-    ? { payloadKind: "content", payloadDigest: decoded.contentDigest, contextDigest }
-    : { payloadKind: "text", payloadDigest: createHash("sha256").update(decoded.text).digest("hex"), contextDigest };
+    ? { payloadKind: "content", payloadDigest: decoded.contentDigest, textDigest, contextDigest }
+    : { payloadKind: "text", payloadDigest: textDigest, textDigest, contextDigest };
   if (!current) {
     deliveries.set(decoded.deliveryDedup, observed);
     return;
   }
   if (current.payloadKind === "conflict") return;
   if (current.payloadKind !== observed.payloadKind || current.payloadDigest !== observed.payloadDigest
-    || current.contextDigest !== observed.contextDigest) {
+    || current.contextDigest !== observed.contextDigest || current.textDigest !== observed.textDigest) {
     deliveries.set(decoded.deliveryDedup, { payloadKind: "conflict", payloadDigest: null });
   }
 }
@@ -920,7 +921,8 @@ function rolloutDeliveryReceipt(
       .digest("hex");
   }
   const contextDigest = createHash("sha256").update(JSON.stringify(parseSelectedContextRef(entry.selectedContext))).digest("hex");
-  if (!payloadMatches || (delivery.payloadKind !== "conflict" && delivery.contextDigest !== contextDigest)) {
+  if (!payloadMatches || (delivery.payloadKind !== "conflict" && (delivery.contextDigest !== contextDigest
+    || delivery.textDigest !== createHash("sha256").update(entry.text ?? entry.content?.text ?? "").digest("hex")))) {
     throw new Error("Codex queue entry id belongs to a different payload");
   }
   /* The legacy `event_msg/user_message` record carries no turn id. Its durable
@@ -2765,7 +2767,7 @@ export class CodexAppServerHost implements EngineHost {
       catch (error) {
         // A damaged transport echo cannot overrule matching canonical evidence.
         // Missing, ambiguous or different canonical payloads keep the refusal.
-        const canonical = await rolloutConfirmedDelivery(this.identity.path, entry);
+        const canonical = this.identity.path ? await readCanonicalCodexDelivery(this.identity.path, entry) : null;
         if (!canonical) throw error;
         this.confirmedDeliveries.set(entry.id, { receipt: canonical, text: entry.text ?? null, contentDigest: entry.contentDigest ?? null });
         return canonical;
@@ -2832,9 +2834,8 @@ export class CodexAppServerHost implements EngineHost {
     entry: QueueEntry,
     confirmed: { receipt: DeliveryReceipt; text: string | null; contentDigest: string | null },
   ): DeliveryReceipt {
-    const payloadMatches = confirmed.contentDigest
-      ? confirmed.contentDigest === entry.contentDigest
-      : confirmed.text === entry.text;
+    const payloadMatches = confirmed.text === entry.text
+      && (!confirmed.contentDigest || confirmed.contentDigest === entry.contentDigest);
     if (!payloadMatches) {
       throw new Error("Codex queue entry id belongs to a different payload");
     }
@@ -2853,7 +2854,7 @@ export class CodexAppServerHost implements EngineHost {
     const previous = this.confirmedDeliveries.get(clientId);
     const pending = this.pendingDeliveries.get(clientId);
     const mismatch = Boolean(previous && (previous.text !== text || previous.contentDigest !== contentDigest))
-      || Boolean(pending && (contentDigest ? contentDigest !== pending.contentDigest : text !== pending.text));
+      || Boolean(pending && (text !== pending.text || (contentDigest !== null && contentDigest !== pending.contentDigest)));
     const confirmed = {
       receipt: previous?.receipt ?? pending?.receipt ?? { outcome: "turn-started" as const, turnId },
       text: mismatch ? null : text,
@@ -3542,5 +3543,9 @@ export class CodexAppServerHost implements EngineHost {
 
 export async function readCanonicalCodexDelivery(pathname: string, entry: QueueEntry): Promise<DeliveryReceipt | null> {
   const normalized = normalizeQueueEntry(entry);
-  return await rolloutConfirmedDelivery(pathname, { ...entry, text: normalized.content.text, content: normalized.content, contentDigest: normalized.contentDigest });
+  const index = await rolloutDeliveryIndexFromDisk(pathname);
+  if (index.readState === "unavailable" || index.scanOffset !== index.size) {
+    throw new Error("Canonical delivery evidence coverage is incomplete");
+  }
+  return rolloutDeliveryReceipt({ ...entry, text: normalized.content.text, content: normalized.content, contentDigest: normalized.contentDigest }, index.deliveries.get(codexDeliveryDedup(entry.id)));
 }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1,3 +1,5 @@
+import { parseSelectedContextRef } from "@/lib/selection/selectedContext";
+import { StringDecoder } from "node:string_decoder";
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
 import { createHash, type Hash } from "node:crypto";
@@ -504,7 +506,7 @@ function codexDeliveryDedup(operationId: string): string {
   return createHash("sha256").update(operationId).digest("hex");
 }
 type RolloutStructuredUserDelivery =
-  | { payloadKind: "text" | "content"; payloadDigest: string }
+  | { payloadKind: "text" | "content"; payloadDigest: string; contextDigest?: string }
   | { payloadKind: "conflict"; payloadDigest: null };
 
 interface RolloutTurnsCacheEntry {
@@ -537,14 +539,17 @@ function rememberRolloutStructuredUser(
   const decoded = decodeCodexStructuredUserText(wireText);
   if (!decoded.deliveryDedup) return;
   const current = deliveries.get(decoded.deliveryDedup);
+  const contextDigest = createHash("sha256").update(JSON.stringify(decoded.selectedContext)).digest("hex");
   const observed: RolloutStructuredUserDelivery = decoded.contentDigest
-    ? { payloadKind: "content", payloadDigest: decoded.contentDigest }
-    : { payloadKind: "text", payloadDigest: createHash("sha256").update(decoded.text).digest("hex") };
+    ? { payloadKind: "content", payloadDigest: decoded.contentDigest, contextDigest }
+    : { payloadKind: "text", payloadDigest: createHash("sha256").update(decoded.text).digest("hex"), contextDigest };
   if (!current) {
     deliveries.set(decoded.deliveryDedup, observed);
     return;
   }
-  if (current.payloadKind !== observed.payloadKind || current.payloadDigest !== observed.payloadDigest) {
+  if (current.payloadKind === "conflict") return;
+  if (current.payloadKind !== observed.payloadKind || current.payloadDigest !== observed.payloadDigest
+    || current.contextDigest !== observed.contextDigest) {
     deliveries.set(decoded.deliveryDedup, { payloadKind: "conflict", payloadDigest: null });
   }
 }
@@ -556,6 +561,11 @@ function rememberRolloutStructuredUsersFromRecord(
   const payload = record(record(value)?.payload);
   if (!payload) return;
   const payloadType = stringField(payload, "type");
+  if (record(value)?.type === "response_item" && payloadType === "message" && payload.role === "user") {
+    const message = userMessageText(payload);
+    if (message !== null) rememberRolloutStructuredUser(deliveries, message);
+    return;
+  }
   if (payloadType === "user_message") {
     const message = stringField(payload, "message");
     if (message !== null) rememberRolloutStructuredUser(deliveries, message);
@@ -909,7 +919,10 @@ function rolloutDeliveryReceipt(
       .update(entry.text ?? entry.content?.text ?? "")
       .digest("hex");
   }
-  if (!payloadMatches) throw new Error("Codex queue entry id belongs to a different payload");
+  const contextDigest = createHash("sha256").update(JSON.stringify(parseSelectedContextRef(entry.selectedContext))).digest("hex");
+  if (!payloadMatches || (delivery.payloadKind !== "conflict" && delivery.contextDigest !== contextDigest)) {
+    throw new Error("Codex queue entry id belongs to a different payload");
+  }
   /* The legacy `event_msg/user_message` record carries no turn id. Its durable
      dedup identity is enough to prove the recipient already owns this message;
      the operation id is a stable historical turn reference for the receipt. */
@@ -1147,6 +1160,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly bufferedTerminalTurnIds = new Set<string>();
   private bufferedNotificationOverlap: string[] = [];
   private nextRpcId = 1;
+  private readonly stdoutDecoder = new StringDecoder("utf8");
   private stdoutBuffer = "";
   private stderrTail = "";
   private preRestoreBytes = 0;
@@ -1205,7 +1219,12 @@ export class CodexAppServerHost implements EngineHost {
     });
     this.cursor = options.initialEventCursor ?? 0;
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
-    child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
+    child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(typeof chunk === "string" ? chunk : this.stdoutDecoder.write(chunk)));
+    child.stdout.on("end", () => {
+      const tail = this.stdoutDecoder.end();
+      if (tail) this.acceptStdout(tail);
+      if (this.stdoutBuffer || this.replayReduction) this.fail(new Error("Codex app-server stdout ended inside a JSONL frame"));
+    });
     child.stderr.on("data", (chunk: Buffer | string) => this.acceptStderr(String(chunk)));
     child.stdin.on("error", (error) => {
       if (!this.releasing && !this.released) this.fail(new Error(`Codex app-server stdin failed: ${safeError(error)}`));
@@ -2741,7 +2760,17 @@ export class CodexAppServerHost implements EngineHost {
 
   private async confirmedDelivery(entry: QueueEntry): Promise<DeliveryReceipt | null> {
     const known = this.confirmedDeliveries.get(entry.id);
-    if (known) return this.confirmedReceipt(entry, known);
+    if (known) {
+      try { return this.confirmedReceipt(entry, known); }
+      catch (error) {
+        // A damaged transport echo cannot overrule matching canonical evidence.
+        // Missing, ambiguous or different canonical payloads keep the refusal.
+        const canonical = await rolloutConfirmedDelivery(this.identity.path, entry);
+        if (!canonical) throw error;
+        this.confirmedDeliveries.set(entry.id, { receipt: canonical, text: entry.text ?? null, contentDigest: entry.contentDigest ?? null });
+        return canonical;
+      }
+    }
     const persistedRead = rolloutConfirmedDelivery(this.identity.path, entry);
     const persisted = persistedRead instanceof Promise ? await persistedRead : persistedRead;
     if (persisted) return persisted;
@@ -2823,10 +2852,12 @@ export class CodexAppServerHost implements EngineHost {
     const contentDigest = decoded?.contentDigest ?? null;
     const previous = this.confirmedDeliveries.get(clientId);
     const pending = this.pendingDeliveries.get(clientId);
+    const mismatch = Boolean(previous && (previous.text !== text || previous.contentDigest !== contentDigest))
+      || Boolean(pending && (contentDigest ? contentDigest !== pending.contentDigest : text !== pending.text));
     const confirmed = {
       receipt: previous?.receipt ?? pending?.receipt ?? { outcome: "turn-started" as const, turnId },
-      text: previous && (previous.text !== text || previous.contentDigest !== contentDigest) ? null : text,
-      contentDigest: previous && (previous.text !== text || previous.contentDigest !== contentDigest) ? null : contentDigest,
+      text: mismatch ? null : text,
+      contentDigest: mismatch ? null : contentDigest,
     };
     this.confirmedDeliveries.set(clientId, confirmed);
     if (!pending) return;
@@ -3506,4 +3537,10 @@ export class CodexAppServerHost implements EngineHost {
     clearTimeout(pending.timer);
     pending.reject(new Error(safeError(error)));
   }
+}
+
+
+export async function readCanonicalCodexDelivery(pathname: string, entry: QueueEntry): Promise<DeliveryReceipt | null> {
+  const normalized = normalizeQueueEntry(entry);
+  return await rolloutConfirmedDelivery(pathname, { ...entry, text: normalized.content.text, content: normalized.content, contentDigest: normalized.contentDigest });
 }

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -164,6 +164,8 @@ export interface RuntimeAttention {
 
 export interface RuntimeOperationReceipt {
   operationId: string;
+  /** Original-key delivery established by canonical content, without replay. */
+  canonicalDelivery?: { contentDigest: string; generation: string; eventSeq: number };
   /** The terminal attempt this operation replaces, when it was created by Retry. */
   retryOfOperationId?: string | null;
   /** Stable reducer identity used to replace the visible retry ancestor. */
@@ -196,6 +198,12 @@ export interface RuntimeOperationReceipt {
   revision: number;
 }
 export type RuntimeReceipt = RuntimeOperationReceipt;
+
+export interface RuntimeCanonicalDeliveryBinding {
+  conversationId: string;
+  idempotencyKey: string;
+  contentDigest: string;
+}
 
 export interface RuntimeTransitionOptions {
   /** Compare-and-set fence evaluated inside the journal write transaction. */
@@ -725,7 +733,7 @@ export interface RuntimeReplay {
 
 export interface RuntimeSocketRequest {
   id: string;
-  method: "runtime-host-health" | "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-delivery-action" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "viewer-deployment-cancel" | "mcp-health-probe-admission";
+  method: "runtime-host-health" | "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-delivery-action" | "operation-retry" | "operation-reconcile-delivery" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "viewer-deployment-cancel" | "mcp-health-probe-admission";
   params?: Record<string, unknown>;
 }
 

--- a/src/lib/runtime/http.ts
+++ b/src/lib/runtime/http.ts
@@ -15,7 +15,7 @@ import { parseRuntimeCommand } from "./commands";
 import { runtimePresentationReceipt, type RuntimeOperationKind } from "./contracts";
 import { runtimeEventsEnabled, runtimeEventsRolledBack, structuredHostsEnabled, RUNTIME_PLANE_ABSENT } from "./flags";
 import { readEvidence, type Evidence } from "./evidence";
-import { journalVerdict, resolveSendReceipt, runtimeReceiptForSend, SEND_DISCARDED_REASON, sendReceiptFor, type SendReceipt } from "./sendSettlement";
+import { canonicalReceiptMatches, journalVerdict, resolveSendReceipt, runtimeReceiptForSend, SEND_DISCARDED_REASON, sendReceiptFor, type SendReceipt } from "./sendSettlement";
 import { republishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { recoverDeadStructuredConversation } from "./structuredRecovery";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
@@ -569,7 +569,7 @@ export async function handleRuntimeRetry(
   if (!client) return NextResponse.json({ error: "runtime host socket is unavailable" }, { status: 503 });
   try {
     let nextIdempotencyKey: string | undefined;
-    let action: "retry-uncertain" | undefined;
+    let action: "retry-uncertain" | "reconcile-delivery" | undefined;
     const rawBody = await request.text();
     if (rawBody.trim()) {
       let value: { idempotencyKey?: unknown; action?: unknown };
@@ -592,10 +592,13 @@ export async function handleRuntimeRetry(
         nextIdempotencyKey = value.idempotencyKey;
       }
       if (value.action !== undefined) {
-        if (value.action !== "retry-uncertain") {
+        if (value.action !== "retry-uncertain" && value.action !== "reconcile-delivery") {
           return NextResponse.json({ error: "runtime retry action is invalid" }, { status: 400 });
         }
         action = value.action;
+      }
+      if (action === "reconcile-delivery" && Object.keys(value).some((key) => key !== "action")) {
+        return NextResponse.json({ error: "canonical reconciliation accepts only the original operation identity" }, { status: 400 });
       }
       if (action && nextIdempotencyKey) {
         return NextResponse.json({ error: "uncertain retry keeps the original idempotency key" }, { status: 400 });
@@ -618,6 +621,7 @@ export async function handleRuntimeRetry(
       return NextResponse.json({ error: "runtime operation does not support retry" }, { status: 409 });
     }
     if (previous.receipt.status === "failed" && previous.receipt.reason === SEND_DISCARDED_REASON) {
+      if (action === "reconcile-delivery") return NextResponse.json({ error: "discarded delivery cannot be reconciled" }, { status: 409 });
       const claim = await client.claimDeliveryAction(previous.operationId, "retry");
       return NextResponse.json({
         error: `runtime delivery ${claim.winner} already won; retry refused`,
@@ -626,6 +630,26 @@ export async function handleRuntimeRetry(
     const registry = (dependencies.registry ?? agentRegistry)();
     const deliverySnapshot = registry.readOnlySnapshot();
     const deliveryRecord = sendReceiptFor(deliverySnapshot, previous.operationId);
+    if (action === "reconcile-delivery") {
+      if (previous.operationId !== operationId || !deliveryRecord
+        || (deliveryRecord.state === "failed" && deliveryRecord.resend !== "verify-first")) {
+        return NextResponse.json({ error: "canonical reconciliation requires the original unresolved delivery" }, { status: 409 });
+      }
+      if (!client.reconcileDelivery) return NextResponse.json({ error: "canonical delivery reconciliation is unavailable" }, { status: 503 });
+      const owner = deliverySnapshot.deliveryOperationOwners[operationId];
+      if (!owner?.contentDigest || owner.clientMessageId !== previous.receipt.idempotencyKey
+        || deliveryRecord.conversationId !== previous.receipt.conversationId) {
+        return NextResponse.json({ error: "original delivery binding is inconsistent" }, { status: 409 });
+      }
+      const result = await client.reconcileDelivery(operationId, { conversationId: previous.receipt.conversationId,
+        idempotencyKey: owner.clientMessageId!, contentDigest: owner.contentDigest });
+      if (!canonicalReceiptMatches(deliverySnapshot, operationId, deliveryRecord, result.receipt)) {
+        return NextResponse.json({ error: "canonical delivery proof does not match the original binding" }, { status: 409 });
+      }
+      registry.recordDeliveryOutcomeForOperation(deliveryRecord.conversationId as `conversation_${string}`, operationId, "delivered", null, "delivered");
+      const send = await resolveSendReceipt(operationId, { registry, client });
+      return NextResponse.json({ operationId, receipt: runtimePresentationReceipt(result.receipt), send });
+    }
     if (previous.operationId === operationId
       && previous.receipt.status !== "failed"
       && previous.receipt.status !== "rejected"

--- a/src/lib/runtime/sendSettlement.ts
+++ b/src/lib/runtime/sendSettlement.ts
@@ -539,18 +539,25 @@ export async function resolveSendReceipt(
 ): Promise<SendReceipt | null> {
   const registry = ports.registry ?? agentRegistry();
   const projected = sendReceiptFor(registry.readOnlySnapshot(), operationId);
-  if (!projected || projected.state !== "in-flight") return projected;
+  if (!projected) return projected;
+  const terminalUnknown = projected.state === "failed" && projected.resend === "verify-first";
+  if (projected.state !== "in-flight" && !terminalUnknown) return projected;
   const client = ports.client === undefined ? runtimeHostClient() : ports.client;
   /* The journal read, keeping whether it happened at all. A socket that is not
      there is the runtime host being unreachable, which is the same answer as a
      read that threw: nothing was asked, so nothing was learned. */
   const journal = client
     ? await readEvidence(
-      () => client.operationStatus(operationId, { currentRetryLeaf: true }),
+      () => client.operationStatus(operationId, { currentRetryLeaf: !terminalUnknown }),
       "runtime host is unavailable",
     )
     : unreadableEvidence("runtime host socket is unavailable");
   const receipt = journal.readable ? journal.value?.receipt ?? null : null;
+  if (terminalUnknown) {
+    if (!receipt || !canonicalReceiptMatches(registry.readOnlySnapshot(), operationId, projected, receipt)) return projected;
+    registry.recordDeliveryOutcomeForOperation(projected.conversationId as `conversation_${string}`, operationId, "delivered", null, "delivered");
+    return { ...projected, state: "delivered", reason: null, duplicateRisk: false, resend: "not-needed", settledAt: receipt.at, evidence: "delivery-journal" };
+  }
   const status = receipt?.status ?? null;
   const verdict = journalVerdict(status, receipt?.reason);
   if (verdict) return settleProjection(registry, operationId, projected, verdict);
@@ -731,30 +738,39 @@ export type OriginalSendEvidence =
   | { kind: "unreadable"; reason: string }
   | { kind: "contradictory" };
 
-/**
- * The CURRENT answer for one found operation, projected without writing.
- *
- * A durable record that is already terminal is the answer. One still in flight
- * is checked against the journal's current retry leaf, and a terminal verdict
- * there is REPORTED — never written back onto the reservation, never fenced,
- * never aged past a deadline. A journal that cannot be read leaves the durable
- * projection standing and says so. Where {@link resolveSendReceipt} may end a
- * send, this only looks at it.
- */
+/** Match the journal's canonical proof to the registry's immutable owner binding. */
+export function canonicalReceiptMatches(
+  file: RegistryFile, operationId: string, projected: SendReceipt, receipt: RuntimeOperationReceipt,
+): boolean {
+  const owner = file.deliveryOperationOwners[operationId];
+  return receipt.status === "delivered" && receipt.operationId === operationId
+    && receipt.conversationId === projected.conversationId && Boolean(receipt.canonicalDelivery)
+    && Boolean(owner && owner.clientMessageId === receipt.idempotencyKey
+      && owner.contentDigest === receipt.canonicalDelivery!.contentDigest);
+}
+
+/** Read current truth without writes. Only bound canonical proof can supersede
+    an unverified terminal projection; delivered truth remains absorbing. */
 async function projectCurrentSend(
   projected: SendReceipt,
   operationId: string,
   ports: SendSettlementPorts,
 ): Promise<Evidence<SendReceipt>> {
-  if (projected.state !== "in-flight") return { readable: true, value: projected };
+  const terminalUnknown = projected.state === "failed" && projected.resend === "verify-first";
+  if (projected.state !== "in-flight" && !terminalUnknown) return { readable: true, value: projected };
   const client = ports.client === undefined ? runtimeHostClient() : ports.client;
   if (!client) return { readable: true, value: { ...projected, evidence: "delivery-record" } };
   const journal = await readEvidence(
-    () => client.operationStatus(operationId, { currentRetryLeaf: true }),
+    () => client.operationStatus(operationId, { currentRetryLeaf: !terminalUnknown }),
     "runtime host is unavailable",
   );
   if (!journal.readable) return journal;
   const receipt = journal.value?.receipt ?? null;
+  if (terminalUnknown) {
+    const registry = ports.registry ?? agentRegistry();
+    if (!receipt || !canonicalReceiptMatches(registry.readOnlySnapshot(), operationId, projected, receipt)) return { readable: true, value: projected };
+    return { readable: true, value: { ...projected, state: "delivered", reason: null, duplicateRisk: false, resend: "not-needed", settledAt: receipt.at, evidence: "delivery-journal" } };
+  }
   const verdict = journalVerdict(receipt?.status ?? null, receipt?.reason);
   if (!verdict) return { readable: true, value: { ...projected, evidence: "delivery-journal" } };
   if (verdict.state === "delivered") {

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -126,6 +126,13 @@ export class RuntimeHost {
           String(request.params?.operationId ?? ""),
           action,
         );
+      } else if (request.method === "operation-reconcile-delivery") {
+        if (!this.structuredHosts) throw new Error("structured hosts are disabled");
+        const expected = request.params?.expected as { conversationId?: unknown; idempotencyKey?: unknown; contentDigest?: unknown } | undefined;
+        if (!expected || typeof expected.conversationId !== "string" || typeof expected.idempotencyKey !== "string"
+          || typeof expected.contentDigest !== "string" || !/^[a-f0-9]{64}$/.test(expected.contentDigest)) throw new Error("canonical delivery binding is invalid");
+        result = await this.journal.reconcileCanonicalDelivery(String(request.params?.operationId ?? ""), undefined,
+          { conversationId: expected.conversationId, idempotencyKey: expected.idempotencyKey, contentDigest: expected.contentDigest });
       } else if (request.method === "operation-retry") {
         if (!this.structuredHosts) throw new Error("structured hosts are disabled");
         const nextIdempotencyKey = request.params?.nextIdempotencyKey;

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1,3 +1,7 @@
+import type { RuntimeCanonicalDeliveryBinding } from "@/lib/runtime/contracts";
+import path from "node:path";
+import { decodeCodexStructuredUserText } from "@/lib/runtime/codexStructuredUserText";
+import { normalizeQueueEntry, type QueueEntry } from "@/lib/runtime/engineHost";
 import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs";
 
@@ -572,6 +576,98 @@ export class RuntimeJournal {
       receipt = byOperationId.get(child)!;
     }
     return { operationId: currentOperationId, receipt, replayed: currentOperationId !== operationId };
+  }
+
+  /** Reconcile one uncertain original operation from owned, canonical evidence.
+      No send, retry, host control, or outbox activation is performed here. */
+  async reconcileCanonicalDelivery(operationId: string, readCanonical = async (pathname: string, entry: QueueEntry) => {
+    const { readCanonicalCodexDelivery } = await import("@/lib/runtime/codexAppServerHost");
+    return readCanonicalCodexDelivery(pathname, entry);
+  }, expected?: RuntimeCanonicalDeliveryBinding): Promise<RuntimeOperationResult> {
+    this.assertHealthy();
+    const openingHostEpoch = this.meta("host_epoch");
+    const opening = this.db.query<{ request_json: string; request_hash: string; receipt_json: string }, [string]>(
+      "SELECT request_json, request_hash, receipt_json FROM operations WHERE operation_id = ?").get(operationId);
+    if (!opening) throw new Error("runtime operation is unknown");
+    const command = JSON.parse(opening.request_json) as RuntimeOperationCommand;
+    const receipt = JSON.parse(opening.receipt_json) as RuntimeOperationReceipt;
+    if (command.kind !== "send" && command.kind !== "steer") throw new Error("canonical delivery reconciliation requires a send");
+    if (receipt.status === "delivered") {
+      if (expected && (expected.conversationId !== receipt.conversationId || expected.idempotencyKey !== receipt.idempotencyKey
+        || expected.contentDigest !== receipt.canonicalDelivery?.contentDigest)) throw new Error("original delivery binding does not match the journal");
+      return { operationId, receipt, replayed: true };
+    }
+    if (receipt.status !== "uncertain") throw new Error("canonical delivery reconciliation requires an uncertain original operation");
+    const admission = this.db.query<{ seq: number }, [string]>(
+      "SELECT seq FROM events WHERE scope = ? ORDER BY revision ASC LIMIT 1").get(`operation:${operationId}`);
+    if (!admission) throw new Error("canonical delivery evidence is unavailable");
+    // A bounded historical window. Absence beyond it remains unknown.
+    const echoes = this.db.query<{ seq: number; payload_json: string; producer_key: string | null }, [number, number, string]>(
+      "SELECT seq, payload_json, producer_key FROM events NOT INDEXED WHERE seq BETWEEN ? AND ? AND scope = ? AND kind = 'item' ORDER BY seq LIMIT 256"
+    ).all(admission.seq, admission.seq + 50_000, `session:${command.conversationId}`);
+    const dedup = createHash("sha256").update(operationId).digest("hex");
+    const entry = normalizeQueueEntry({ id: operationId, text: command.text, images: command.images, contentDigest: command.contentDigest,
+      ...(command.selectedContext ? { selectedContext: command.selectedContext } : {}) });
+    if (expected && (expected.conversationId !== command.conversationId || expected.idempotencyKey !== command.idempotencyKey
+      || expected.contentDigest !== entry.contentDigest)) throw new Error("original delivery binding does not match the journal");
+    const contextsEqual = (left: unknown, right: unknown) => stableJson(left ?? null) === stableJson(right ?? null);
+    const candidates = new Map<string, { turnId: string; generation: string; pathname: string; seq: number }>();
+    for (const echo of echoes) {
+      const payload = JSON.parse(echo.payload_json) as { turnId?: unknown; item?: { type?: unknown; clientId?: unknown; content?: unknown } };
+      if (payload.item?.type !== "userMessage" || payload.item.clientId !== operationId || typeof payload.turnId !== "string") continue;
+      const content = payload.item.content;
+      if (!Array.isArray(content)) continue;
+      const wire = content.map((part) => typeof part?.text === "string" ? part.text : "").join("");
+      const decoded = decodeCodexStructuredUserText(wire);
+      if (decoded.deliveryDedup !== dedup || decoded.text !== command.text
+        || (decoded.contentDigest !== null && decoded.contentDigest !== entry.contentDigest)
+        || !contextsEqual(decoded.selectedContext, command.selectedContext)) continue;
+      const metadata = this.db.query<{ payload_json: string }, [string, number]>(
+        "SELECT payload_json FROM events WHERE scope = ? AND kind = 'session-status' AND seq <= ? ORDER BY revision DESC LIMIT 1"
+      ).get(`session:${command.conversationId}`, echo.seq);
+      if (!metadata) continue;
+      const session = JSON.parse(metadata.payload_json) as { sessionKey?: { engine?: unknown; sessionId?: unknown }; artifactPath?: unknown };
+      const generation = session.sessionKey?.sessionId;
+      if (session.sessionKey?.engine !== "codex" || typeof generation !== "string" || typeof session.artifactPath !== "string"
+        || !path.isAbsolute(session.artifactPath) || !echo.producer_key?.startsWith(`engine-host:codex:${generation}:`)) continue;
+      candidates.set(`${generation}:${payload.turnId}`, { turnId: payload.turnId, generation, pathname: session.artifactPath, seq: echo.seq });
+    }
+    if (candidates.size !== 1) throw new Error("canonical delivery binding is missing or ambiguous");
+    const evidence = [...candidates.values()][0]!;
+    if (!await readCanonical(evidence.pathname, { ...entry, text: entry.content.text })) throw new Error("canonical delivery is unproven");
+    this.assertHealthy();
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      if (this.meta("host_epoch") !== openingHostEpoch) throw new Error("runtime host changed before canonical reconciliation");
+      const current = this.db.query<{ request_hash: string; receipt_json: string }, [string]>(
+        "SELECT request_hash, receipt_json FROM operations WHERE operation_id = ?").get(operationId);
+      if (!current || current.request_hash !== opening.request_hash) throw new Error("original operation binding changed");
+      const previous = JSON.parse(current.receipt_json) as RuntimeOperationReceipt;
+      if (previous.status === "delivered") {
+        this.db.exec("COMMIT");
+        return { operationId, receipt: previous, replayed: true };
+      }
+      if (previous.status !== "uncertain" || previous.revision !== receipt.revision
+        || this.db.query("SELECT winner FROM delivery_operation_actions WHERE operation_id = ?").get(operationId)) {
+        throw new Error("original delivery moved before canonical reconciliation");
+      }
+      const next: RuntimeOperationReceipt = { ...previous, status: "delivered", reason: null, resend: "not-needed", queuePosition: null,
+        turnId: evidence.turnId, at: new Date(this.now()).toISOString(), revision: previous.revision + 1,
+        canonicalDelivery: { contentDigest: entry.contentDigest, generation: evidence.generation, eventSeq: evidence.seq } };
+      const event = this.appendInTransaction(normalizeRuntimeEventInput({ scope: { type: "operation", id: operationId }, kind: "receipt", operationId,
+        producer: { kind: "runtime-effect", eventKey: `operation:${operationId}:canonical-delivery`, hostEpoch: Number(this.meta("host_epoch")) },
+        payload: next as unknown as Record<string, unknown> }));
+      const committed = { ...next, revision: event.revision };
+      this.upsertEntity("operation", operationId, event.revision, committed, event.seq);
+      this.db.query("UPDATE operations SET receipt_json = ?, event_seq = ? WHERE operation_id = ?").run(stableJson(committed), event.seq, operationId);
+      this.db.query("UPDATE outbox SET state = 'completed', payload_json = '{}' WHERE id = ?").run(`effect:${operationId}`);
+      this.db.exec("COMMIT");
+      this.notifyWaiters();
+      return { operationId, receipt: committed, replayed: false };
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch {}
+      throw error;
+    }
   }
 
   completeOperation(

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -598,13 +598,22 @@ export class RuntimeJournal {
       return { operationId, receipt, replayed: true };
     }
     if (receipt.status !== "uncertain") throw new Error("canonical delivery reconciliation requires an uncertain original operation");
-    const admission = this.db.query<{ seq: number }, [string]>(
-      "SELECT seq FROM events WHERE scope = ? ORDER BY revision ASC LIMIT 1").get(`operation:${operationId}`);
-    if (!admission) throw new Error("canonical delivery evidence is unavailable");
+    const admission = this.db.query<{ seq: number; revision: number }, [string]>(
+      "SELECT seq, revision FROM events WHERE scope = ? ORDER BY revision ASC LIMIT 1").get(`operation:${operationId}`);
+    if (!admission || admission.revision !== 1) throw new Error("canonical delivery evidence is unavailable");
+    const evidenceScope = `session:${command.conversationId}`;
+    const evidenceHead = () => this.db.query<{ seq: number }, [string]>(
+      "SELECT seq FROM events WHERE scope = ? ORDER BY revision DESC LIMIT 1").get(evidenceScope)?.seq;
+    const openingEvidenceHead = evidenceHead();
+    const openingAnchor = this.meta("anchor_seq");
+    if (openingEvidenceHead === undefined || openingEvidenceHead > admission.seq + 50_000) {
+      throw new Error("canonical delivery journal coverage is incomplete");
+    }
     // A bounded historical window. Absence beyond it remains unknown.
     const echoes = this.db.query<{ seq: number; payload_json: string; producer_key: string | null }, [number, number, string]>(
-      "SELECT seq, payload_json, producer_key FROM events NOT INDEXED WHERE seq BETWEEN ? AND ? AND scope = ? AND kind = 'item' ORDER BY seq LIMIT 256"
+      "SELECT seq, payload_json, producer_key FROM events NOT INDEXED WHERE seq BETWEEN ? AND ? AND scope = ? AND kind = 'item' ORDER BY seq LIMIT 257"
     ).all(admission.seq, admission.seq + 50_000, `session:${command.conversationId}`);
+    if (echoes.length > 256) throw new Error("canonical delivery journal coverage is incomplete");
     const dedup = createHash("sha256").update(operationId).digest("hex");
     const entry = normalizeQueueEntry({ id: operationId, text: command.text, images: command.images, contentDigest: command.contentDigest,
       ...(command.selectedContext ? { selectedContext: command.selectedContext } : {}) });
@@ -634,11 +643,20 @@ export class RuntimeJournal {
     }
     if (candidates.size !== 1) throw new Error("canonical delivery binding is missing or ambiguous");
     const evidence = [...candidates.values()][0]!;
+    const canonicalRevision = () => {
+      const stat = fs.statSync(evidence.pathname, { bigint: true });
+      return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`;
+    };
+    const openingCanonicalRevision = canonicalRevision();
     if (!await readCanonical(evidence.pathname, { ...entry, text: entry.content.text })) throw new Error("canonical delivery is unproven");
     this.assertHealthy();
     this.db.exec("BEGIN IMMEDIATE");
     try {
       if (this.meta("host_epoch") !== openingHostEpoch) throw new Error("runtime host changed before canonical reconciliation");
+      if (evidenceHead() !== openingEvidenceHead || this.meta("anchor_seq") !== openingAnchor
+        || canonicalRevision() !== openingCanonicalRevision) {
+        throw new Error("canonical delivery evidence changed before reconciliation");
+      }
       const current = this.db.query<{ request_hash: string; receipt_json: string }, [string]>(
         "SELECT request_hash, receipt_json FROM operations WHERE operation_id = ?").get(operationId);
       if (!current || current.request_hash !== opening.request_hash) throw new Error("original operation binding changed");


### PR DESCRIPTION
Refs #1576 and #1577.

Codex stdout was decoded one Buffer at a time. Splitting a Cyrillic character between chunks changes the completed user echo into two replacement characters, so a message that reached the recipient becomes delivery-uncertain. Decode stdout incrementally, flush at EOF, and recover a damaged confirmation cache only from exact canonical evidence. Canonical response_item user records now participate in the existing bounded dedup reader, including selected-context comparison.

Add `POST /api/runtime/operations/{originalOperationId}` with `{"action":"reconcile-delivery"}`. The request supplies no delivery claim or replacement key. The runtime host checks the persisted operation/client/payload binding, one attributable native generation/turn, and the matching canonical record. A transaction fences receipt revision, host epoch and discard/retry arbitration before recording an absorbing delivered receipt. It never invokes send, retry, queue activation, or host control. Original-key queries recover a stale registry projection after a journal-first crash.

Validation:
- A split UTF-8 fixture reproduced the exact payload-conflict error before the decoder fix.
- Two-, three-, and four-byte splits, selected-context headers, duplicate calls, true collisions, poisoned caches, and incomplete EOF are covered.
- Twelve focused canonical recovery tests pass: HTTP/RPC, restart/snapshot/query, generation rotation, wrong key/payload/context, missing and ambiguous evidence, concurrent discard, stale uncertainty, and replacement-key refusal.
- Existing adapter, HTTP, receipt, journal, operation-query and structured-delivery suites passed in fresh isolated processes under Bun 1.4.0. TypeScript and privacy checks passed.
- A private replay of the captured operation, runtime echoes and exact canonical message settled the original operation/key with its original turn and digest, with zero pending effects and zero live writes.

Recovery requires this Viewer and runtime-host code to be deployed together. Evidence outside the bounded retained journal window stays unresolved. Root retains deployment and the production recovery call; no live receipt, host, queue, browser, or transcript was changed. Frontend PR #1575 and tick PR #1571 remain separate.
