### PR TITLE
fix(mcp): fence rejected spawn receipts and recover designated successors

### DIFF
--- a/src/app/api/spawn/validate/route.test.ts
+++ b/src/app/api/spawn/validate/route.test.ts
@@ -44,7 +44,7 @@ afterAll(() => {
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
-function request(body: Record<string, unknown>): NextRequest {
+function request(body: Record<string, unknown>, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest("http://127.0.0.1:8898/api/spawn/validate", {
     method: "POST",
     headers: {
@@ -52,12 +52,13 @@ function request(body: Record<string, unknown>): NextRequest {
       host: "127.0.0.1:8898",
       "sec-fetch-site": "same-origin",
       "content-type": "application/json",
+      ...headers,
     },
     body: JSON.stringify(body),
   });
 }
 
-function spawnRequest(body: Record<string, unknown>): NextRequest {
+function spawnRequest(body: Record<string, unknown>, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest("http://127.0.0.1:8898/api/spawn", {
     method: "POST",
     headers: {
@@ -65,6 +66,7 @@ function spawnRequest(body: Record<string, unknown>): NextRequest {
       host: "127.0.0.1:8898",
       "sec-fetch-site": "same-origin",
       "content-type": "application/json",
+      ...headers,
     },
     body: JSON.stringify(body),
   });
@@ -158,6 +160,55 @@ test("an admissible validation result leaves the key unfenced", async () => {
 
   expect(await response.json()).toEqual({ admissible: true, fenced: false });
   expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
+});
+
+test("an unauthenticated agent refusal does not burn its downstream key", async () => {
+  const cwd = path.join(sandbox, "unauthenticated-agent-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const body = {
+    title: "Unauthenticated refused deployer",
+    role: "deployer",
+    roleParams: { sha: "d".repeat(40), pr: "26" },
+    cwd,
+    ["prompt"]: "launch the dev deployer",
+    clientAttemptId: "spawn_admission_unauth_1",
+  };
+
+  const validation = await POST.withDependencies(request(body, { "sec-fetch-site": "none" }), { registry: () => store });
+  expect(validation.status).toBe(403);
+  expect(readSpawnAdmissionFence(body.clientAttemptId)).toBeNull();
+
+  const route = await spawnPost.withDependencies(spawnRequest(body, { "sec-fetch-site": "none" }), {
+    registry: () => store,
+  } as Parameters<typeof spawnPost.withDependencies>[1]);
+  expect(route.status).toBe(400);
+  expect(await route.json()).toEqual({ error: "deployer requires confirm: deploy" });
+  expect(readSpawnAdmissionFence(body.clientAttemptId)).toBeNull();
+});
+
+test("a malformed unrelated fence entry does not block a new refusal fence", async () => {
+  const cwd = path.join(sandbox, "malformed-entry-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const fenceFile = path.join(process.env.LLV_STATE_DIR!, "spawn-admission-fences.json");
+  fs.mkdirSync(path.dirname(fenceFile), { recursive: true });
+  fs.writeFileSync(fenceFile, JSON.stringify({ version: 1, fences: {
+    spawn_admission_malformed_1: null,
+  } }) + "\n");
+  expect(() => readSpawnAdmissionFence("spawn_admission_malformed_1")).toThrow("invalid spawn admission fence");
+  const body = {
+    title: "Refusal beside damaged history",
+    role: "deployer",
+    roleParams: { sha: "e".repeat(40), pr: "26" },
+    cwd,
+    ["prompt"]: "launch the dev deployer",
+    clientAttemptId: "spawn_admission_recover_1",
+  };
+
+  const response = await POST.withDependencies(request(body), { registry: () => store });
+  expect(await response.json()).toMatchObject({ admissible: false, fenced: true, status: 400 });
+  expect(readSpawnAdmissionFence(body.clientAttemptId)).toMatchObject({ clientAttemptId: body.clientAttemptId });
 });
 
 test("an engine override refusal uses the same request-bound fence", async () => {

--- a/src/app/api/spawn/validate/route.test.ts
+++ b/src/app/api/spawn/validate/route.test.ts
@@ -1,0 +1,213 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+import { readSpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
+import type { RuntimeHostClient } from "@/lib/runtime/client";
+
+import { POST as spawnPost } from "../route";
+import { POST } from "./route";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-admission-validate-"));
+const previousStateDir = process.env.LLV_STATE_DIR;
+const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+const previousStructuredHosts = process.env.LLV_STRUCTURED_HOSTS;
+const previousRuntimeEvents = process.env.LLV_RUNTIME_EVENTS;
+const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+const previousCodexBinary = process.env.LLV_CODEX_BINARY;
+const codexBinary = path.join(sandbox, "codex-list");
+fs.writeFileSync(codexBinary, "#!/bin/sh\nprintf '[]'\n", { mode: 0o700 });
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.LLV_SPAWN_TRANSPORT = "structured";
+process.env.LLV_STRUCTURED_HOSTS = "1";
+process.env.LLV_RUNTIME_EVENTS = "1";
+process.env.LLV_RUNTIME_HOST_SOCKET = path.join(sandbox, "runtime.sock");
+process.env.LLV_CODEX_BINARY = codexBinary;
+
+afterAll(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+  else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+  if (previousStructuredHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+  else process.env.LLV_STRUCTURED_HOSTS = previousStructuredHosts;
+  if (previousRuntimeEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+  else process.env.LLV_RUNTIME_EVENTS = previousRuntimeEvents;
+  if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+  else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+  if (previousCodexBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+  else process.env.LLV_CODEX_BINARY = previousCodexBinary;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function request(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://127.0.0.1:8898/api/spawn/validate", {
+    method: "POST",
+    headers: {
+      origin: "http://127.0.0.1:8898",
+      host: "127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function spawnRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: {
+      origin: "http://127.0.0.1:8898",
+      host: "127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function spawnDependencies(store: AgentRegistry, cwd: string): Parameters<typeof spawnPost.withDependencies>[1] {
+  const account = {
+    engine: "codex" as const,
+    accountId: "codex-test",
+    kind: "managed" as const,
+    home: path.join(cwd, "account"),
+    transcriptRoot: path.join(cwd, "projects"),
+    env: { NODE_ENV: "test" },
+  };
+  return {
+    registry: () => store,
+    assertStructuredRuntime: () => {},
+    resolveHealthySpawnAccount: async () => account,
+    resolveSpawnAccount: () => account,
+    runtimeHostClient: () => ({} as RuntimeHostClient),
+    defer: () => {},
+    storeImages: () => [],
+    spawnStructuredConversation: async () => {
+      throw new Error("spawn should stay behind the admission fence");
+    },
+  } as Parameters<typeof spawnPost.withDependencies>[1];
+}
+
+test("validation refusal writes an exact durable fence and blocks a later reservation", async () => {
+  const cwd = path.join(sandbox, "launch-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const body = {
+    title: "Recover a rejected deployer",
+    role: "deployer",
+    roleParams: { sha: "a".repeat(40), pr: "26" },
+    cwd,
+    ["prompt"]: "launch the dev deployer",
+    clientAttemptId: "spawn_admission_fence_1",
+  };
+
+  const refusal = await POST.withDependencies(request(body), { registry: () => store });
+  expect(refusal.status).toBe(200);
+  expect(await refusal.json()).toEqual({
+    admissible: false,
+    fenced: true,
+    reason: "deployer requires confirm: deploy",
+    status: 400,
+  });
+  expect(readSpawnAdmissionFence(body.clientAttemptId)).toMatchObject({
+    clientAttemptId: body.clientAttemptId,
+    status: 400,
+    error: "deployer requires confirm: deploy",
+  });
+  expect(store.spawnReceiptForClientAttempt(body.clientAttemptId)).toBeNull();
+
+  /* The real route records the same fence on the post-wire 400 path. */
+  const routeRefusal = await spawnPost.withDependencies(spawnRequest(body), {
+    registry: () => store,
+  } as Parameters<typeof spawnPost.withDependencies>[1]);
+  expect(routeRefusal.status).toBe(400);
+
+  /* A changed body cannot reuse the refusal, and the reservation is blocked
+     before any launch receipt or deferred worker is created. */
+  const changed = { ...body, confirm: "deploy" };
+  const conflict = await spawnPost.withDependencies(
+    spawnRequest(changed),
+    spawnDependencies(store, cwd),
+  );
+  expect({ status: conflict.status, body: await conflict.json() }).toEqual({
+    status: 409,
+    body: { error: "spawn attempt conflicts with its original request" },
+  });
+  expect(store.spawnReceiptForClientAttempt(body.clientAttemptId)).toBeNull();
+});
+
+test("an admissible validation result leaves the key unfenced", async () => {
+  const cwd = path.join(sandbox, "admissible-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_admission_admissible_1";
+  const response = await POST.withDependencies(request({
+    title: "Confirmed deployer",
+    role: "deployer",
+    roleParams: { sha: "b".repeat(40), pr: "26" },
+    confirm: "deploy",
+    cwd,
+    ["prompt"]: "launch the dev deployer",
+    clientAttemptId,
+  }), { registry: () => store });
+
+  expect(await response.json()).toEqual({ admissible: true, fenced: false });
+  expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
+});
+
+test("an engine override refusal uses the same request-bound fence", async () => {
+  const cwd = path.join(sandbox, "override-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_admission_override_1";
+  const response = await POST.withDependencies(request({
+    title: "Engine override refusal",
+    role: "builder",
+    engine: "claude",
+    cwd,
+    ["prompt"]: "exercise the override refusal",
+    clientAttemptId,
+  }), { registry: () => store });
+
+  expect(await response.json()).toEqual({
+    admissible: false,
+    fenced: true,
+    reason: "model is required when overriding a role engine",
+    status: 400,
+  });
+  expect(readSpawnAdmissionFence(clientAttemptId)).toMatchObject({ status: 400 });
+});
+
+test("an existing downstream launch wins over a validation refusal", async () => {
+  const cwd = path.join(sandbox, "existing-launch-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_admission_existing_1";
+  const begun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    clientAttemptId,
+    requestDigest: "c".repeat(64),
+    launchProfile: { title: "Existing launch" },
+    origin: { kind: "operator" },
+  });
+  if (begun.kind !== "created") throw new Error("expected an existing-launch fixture");
+
+  const response = await POST.withDependencies(request({
+    title: "Existing launch",
+    role: "deployer",
+    roleParams: { sha: "c".repeat(40), pr: "26" },
+    cwd,
+    ["prompt"]: "refuse after an existing launch",
+    clientAttemptId,
+  }), { registry: () => store });
+
+  expect(await response.json()).toMatchObject({ admissible: false, fenced: false, status: 400 });
+  expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
+  expect(store.spawnReceiptForClientAttempt(clientAttemptId)?.launchId).toBe(begun.receipt.launchId);
+});

--- a/src/app/api/spawn/validate/route.ts
+++ b/src/app/api/spawn/validate/route.ts
@@ -1,77 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
-import {
-  agentSpawnLineageError,
-  authenticatedAgentSpawnCaller,
-  isAgentInitiatedSpawn,
-} from "@/app/api/spawn/admission";
-import {
-  fenceSpawnAdmissionRejection,
-  productionSpawnCommandDependencies,
-  type SpawnCommandDependencies,
-} from "@/lib/agent/spawnCommand";
-import { resolveSpawnRole } from "@/lib/roles/registry";
-import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { executeSpawnAdmissionValidation } from "@/lib/agent/spawnAdmissionValidation";
+import { productionSpawnCommandDependencies } from "@/lib/agent/spawnCommand";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type SpawnValidationDependencies = Pick<SpawnCommandDependencies, "registry">;
-
-function recordBody(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null;
-}
-
-export async function executeSpawnAdmissionValidation(
-  req: NextRequest,
-  dependencies: SpawnValidationDependencies = productionSpawnCommandDependencies,
-): Promise<NextResponse> {
-  const rejection = rejectCrossOrigin(req);
-  if (rejection) return rejection;
-
-  let body: Record<string, unknown>;
-  try {
-    const parsed = recordBody(await req.json());
-    if (!parsed) return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
-    body = parsed;
-  } catch {
-    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
-  }
-
-  const lineageError = agentSpawnLineageError(req, body);
-  if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
-
-  /* Establish the same caller identity as `/api/spawn` before this endpoint is
-     allowed to write a fence. A stranger may learn only the ordinary refusal,
-     never burn another caller's downstream key. */
-  if (isAgentInitiatedSpawn(req)) {
-    let caller: ReturnType<typeof authenticatedAgentSpawnCaller>;
-    try {
-      caller = authenticatedAgentSpawnCaller(req, body.src, dependencies.registry());
-    } catch (error) {
-      return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 503 });
-    }
-    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
-  }
-
-  const role = resolveSpawnRole(body);
-  if (!role.ok) {
-    const fence = fenceSpawnAdmissionRejection(body, 400, role.error, dependencies);
-    return NextResponse.json({
-      admissible: false,
-      fenced: fence?.kind === "fenced",
-      reason: role.error,
-      status: 400,
-    });
-  }
-
-  return NextResponse.json({ admissible: true, fenced: false });
-}
-
 export const POST = Object.assign(
-  async (req: NextRequest): Promise<NextResponse> => await executeSpawnAdmissionValidation(req),
+  async (req: NextRequest) => await executeSpawnAdmissionValidation(req),
   {
     withDependencies: executeSpawnAdmissionValidation,
     productionDependencies: productionSpawnCommandDependencies,

--- a/src/app/api/spawn/validate/route.ts
+++ b/src/app/api/spawn/validate/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  agentSpawnLineageError,
+  authenticatedAgentSpawnCaller,
+  isAgentInitiatedSpawn,
+} from "@/app/api/spawn/admission";
+import {
+  fenceSpawnAdmissionRejection,
+  productionSpawnCommandDependencies,
+  type SpawnCommandDependencies,
+} from "@/lib/agent/spawnCommand";
+import { resolveSpawnRole } from "@/lib/roles/registry";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type SpawnValidationDependencies = Pick<SpawnCommandDependencies, "registry">;
+
+function recordBody(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export async function executeSpawnAdmissionValidation(
+  req: NextRequest,
+  dependencies: SpawnValidationDependencies = productionSpawnCommandDependencies,
+): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(req);
+  if (rejection) return rejection;
+
+  let body: Record<string, unknown>;
+  try {
+    const parsed = recordBody(await req.json());
+    if (!parsed) return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+    body = parsed;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const lineageError = agentSpawnLineageError(req, body);
+  if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
+
+  /* Establish the same caller identity as `/api/spawn` before this endpoint is
+     allowed to write a fence. A stranger may learn only the ordinary refusal,
+     never burn another caller's downstream key. */
+  if (isAgentInitiatedSpawn(req)) {
+    let caller: ReturnType<typeof authenticatedAgentSpawnCaller>;
+    try {
+      caller = authenticatedAgentSpawnCaller(req, body.src, dependencies.registry());
+    } catch (error) {
+      return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 503 });
+    }
+    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
+  }
+
+  const role = resolveSpawnRole(body);
+  if (!role.ok) {
+    const fence = fenceSpawnAdmissionRejection(body, 400, role.error, dependencies);
+    return NextResponse.json({
+      admissible: false,
+      fenced: fence?.kind === "fenced",
+      reason: role.error,
+      status: 400,
+    });
+  }
+
+  return NextResponse.json({ admissible: true, fenced: false });
+}
+
+export const POST = Object.assign(
+  async (req: NextRequest): Promise<NextResponse> => await executeSpawnAdmissionValidation(req),
+  {
+    withDependencies: executeSpawnAdmissionValidation,
+    productionDependencies: productionSpawnCommandDependencies,
+  },
+);

--- a/src/lib/agent/spawnAdmission.ts
+++ b/src/lib/agent/spawnAdmission.ts
@@ -121,7 +121,7 @@ function normalizeSpawnAdmissionFence(value: unknown, key: string): SpawnAdmissi
   };
 }
 
-function readSpawnAdmissionFenceFile(): SpawnAdmissionFenceFile {
+function readSpawnAdmissionFenceFile(requestedClientAttemptId?: string): SpawnAdmissionFenceFile {
   let raw: string;
   try {
     raw = fs.readFileSync(spawnAdmissionFencePath(), "utf8");
@@ -144,7 +144,15 @@ function readSpawnAdmissionFenceFile(): SpawnAdmissionFenceFile {
   }
   const fences: Record<string, SpawnAdmissionFence> = {};
   for (const [key, value] of Object.entries((parsed as { fences: Record<string, unknown> }).fences)) {
-    fences[key] = normalizeSpawnAdmissionFence(value, key);
+    try {
+      fences[key] = normalizeSpawnAdmissionFence(value, key);
+    } catch (error) {
+      /* A damaged entry must still make recovery of that exact key unknown.
+         An unrelated damaged key has no bearing on this lookup and must not
+         turn every new reservation into a 500. A later atomic write drops the
+         unusable entry from the normalized file. */
+      if (key === requestedClientAttemptId) throw error;
+    }
   }
   return { version: 1, fences };
 }
@@ -161,7 +169,7 @@ function writeSpawnAdmissionFenceFile(file: SpawnAdmissionFenceFile): void {
     original outcome unknown. */
 export function readSpawnAdmissionFence(clientAttemptId: string): SpawnAdmissionFence | null {
   if (!validClientAttemptId(clientAttemptId)) return null;
-  return readSpawnAdmissionFenceFile().fences[clientAttemptId] ?? null;
+  return readSpawnAdmissionFenceFile(clientAttemptId).fences[clientAttemptId] ?? null;
 }
 
 /** Atomically persist a validation refusal only when no downstream launch
@@ -182,7 +190,7 @@ export function recordSpawnAdmissionRejection(input: {
   return withAccountMutationLock(() => {
     const existingReceipt = currentReceipt();
     if (existingReceipt) return { kind: "existing-receipt", receipt: existingReceipt };
-    const file = readSpawnAdmissionFenceFile();
+    const file = readSpawnAdmissionFenceFile(input.clientAttemptId);
     const existing = file.fences[input.clientAttemptId];
     const requestDigest = input.requestDigest.toLowerCase();
     if (existing) {

--- a/src/lib/agent/spawnAdmission.ts
+++ b/src/lib/agent/spawnAdmission.ts
@@ -1,3 +1,9 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { withAccountMutationLock } from "@/lib/accounts/accountMutation";
+import { statePath } from "@/lib/configDir";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 import type { RegistryFile, SpawnReceipt } from "./registry";
@@ -39,6 +45,163 @@ export interface SpawnRejection {
   maxDepth: number;
   guidance: string;
   rejectedAt: string;
+}
+
+/** A request-bound admission refusal written before a launch reservation. The
+    fence is deliberately separate from SpawnReceipt: it prevents a late
+    reservation for the same downstream key while keeping launch-receipt counts
+    truthful at zero. */
+export interface SpawnAdmissionFence {
+  version: 1;
+  clientAttemptId: string;
+  requestDigest: string;
+  status: number;
+  error: string;
+  rejectedAt: string;
+}
+
+export type SpawnAdmissionFenceResult =
+  | { kind: "fenced"; fence: SpawnAdmissionFence }
+  | { kind: "existing-receipt"; receipt: SpawnReceipt }
+  | { kind: "conflict" };
+
+export class SpawnAdmissionFenceError extends Error {
+  constructor(readonly fence: SpawnAdmissionFence) {
+    super(fence.error);
+    this.name = "SpawnAdmissionFenceError";
+  }
+}
+
+export class SpawnAdmissionFenceConflictError extends Error {
+  constructor() {
+    super("spawn attempt conflicts with its original request");
+    this.name = "SpawnAdmissionFenceConflictError";
+  }
+}
+
+interface SpawnAdmissionFenceFile {
+  version: 1;
+  fences: Record<string, SpawnAdmissionFence>;
+}
+
+function spawnAdmissionFencePath(): string {
+  return statePath("spawn-admission-fences.json");
+}
+
+function emptySpawnAdmissionFenceFile(): SpawnAdmissionFenceFile {
+  return { version: 1, fences: {} };
+}
+
+function validClientAttemptId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{8,128}$/.test(value);
+}
+
+function normalizeSpawnAdmissionFence(value: unknown, key: string): SpawnAdmissionFence {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid spawn admission fence");
+  const fence = value as Partial<SpawnAdmissionFence>;
+  const status = fence.status;
+  if (fence.version !== 1
+    || fence.clientAttemptId !== key
+    || typeof fence.clientAttemptId !== "string"
+    || !validClientAttemptId(fence.clientAttemptId)
+    || typeof fence.requestDigest !== "string"
+    || !/^[0-9a-f]{64}$/i.test(fence.requestDigest)
+    || typeof status !== "number" || !Number.isInteger(status) || status < 400 || status > 499
+    || typeof fence.error !== "string" || !fence.error.trim() || fence.error.length > 500
+    || typeof fence.rejectedAt !== "string" || !fence.rejectedAt) {
+    throw new Error("invalid spawn admission fence");
+  }
+  return {
+    version: 1,
+    clientAttemptId: fence.clientAttemptId,
+    requestDigest: fence.requestDigest.toLowerCase(),
+    status,
+    error: fence.error,
+    rejectedAt: fence.rejectedAt,
+  };
+}
+
+function readSpawnAdmissionFenceFile(): SpawnAdmissionFenceFile {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(spawnAdmissionFencePath(), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptySpawnAdmissionFenceFile();
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error("spawn admission fence store could not be read", { cause: error });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)
+    || (parsed as { version?: unknown }).version !== 1
+    || !((parsed as { fences?: unknown }).fences)
+    || typeof (parsed as { fences: unknown }).fences !== "object"
+    || Array.isArray((parsed as { fences: unknown }).fences)) {
+    throw new Error("spawn admission fence store has an unsupported schema");
+  }
+  const fences: Record<string, SpawnAdmissionFence> = {};
+  for (const [key, value] of Object.entries((parsed as { fences: Record<string, unknown> }).fences)) {
+    fences[key] = normalizeSpawnAdmissionFence(value, key);
+  }
+  return { version: 1, fences };
+}
+
+function writeSpawnAdmissionFenceFile(file: SpawnAdmissionFenceFile): void {
+  const filename = spawnAdmissionFencePath();
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  fs.writeFileSync(temporary, JSON.stringify(file, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(temporary, filename);
+}
+
+/** Read one durable fence. An unreadable store throws so recovery keeps the
+    original outcome unknown. */
+export function readSpawnAdmissionFence(clientAttemptId: string): SpawnAdmissionFence | null {
+  if (!validClientAttemptId(clientAttemptId)) return null;
+  return readSpawnAdmissionFenceFile().fences[clientAttemptId] ?? null;
+}
+
+/** Atomically persist a validation refusal only when no downstream launch
+    receipt already owns the same key. The caller supplies that read so the
+    fence and the route's reservation share the existing account lock. */
+export function recordSpawnAdmissionRejection(input: {
+  clientAttemptId: string;
+  requestDigest: string;
+  status: number;
+  error: string;
+  rejectedAt?: string;
+}, currentReceipt: () => SpawnReceipt | null): SpawnAdmissionFenceResult {
+  if (!validClientAttemptId(input.clientAttemptId)) throw new Error("invalid spawn admission fence clientAttemptId");
+  if (!/^[0-9a-f]{64}$/i.test(input.requestDigest)) throw new Error("invalid spawn admission fence request digest");
+  if (!Number.isInteger(input.status) || input.status < 400 || input.status > 499) throw new Error("invalid spawn admission fence status");
+  const error = input.error.trim().slice(0, 500);
+  if (!error) throw new Error("spawn admission fence error is required");
+  return withAccountMutationLock(() => {
+    const existingReceipt = currentReceipt();
+    if (existingReceipt) return { kind: "existing-receipt", receipt: existingReceipt };
+    const file = readSpawnAdmissionFenceFile();
+    const existing = file.fences[input.clientAttemptId];
+    const requestDigest = input.requestDigest.toLowerCase();
+    if (existing) {
+      return existing.requestDigest === requestDigest
+        ? { kind: "fenced", fence: existing }
+        : { kind: "conflict" };
+    }
+    const fence: SpawnAdmissionFence = {
+      version: 1,
+      clientAttemptId: input.clientAttemptId,
+      requestDigest,
+      status: input.status,
+      error,
+      rejectedAt: input.rejectedAt ?? new Date().toISOString(),
+    };
+    file.fences[input.clientAttemptId] = fence;
+    writeSpawnAdmissionFenceFile(file);
+    return { kind: "fenced", fence };
+  });
 }
 
 /** Typed terminal admission rejection (#393): the receipt is durable and

--- a/src/lib/agent/spawnAdmissionValidation.ts
+++ b/src/lib/agent/spawnAdmissionValidation.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  agentSpawnLineageError,
+  authenticatedAgentSpawnCaller,
+  isAgentInitiatedSpawn,
+} from "@/app/api/spawn/admission";
+import {
+  fenceSpawnAdmissionRejection,
+  productionSpawnCommandDependencies,
+  type SpawnCommandDependencies,
+} from "@/lib/agent/spawnCommand";
+import { resolveSpawnRole } from "@/lib/roles/registry";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+
+type SpawnValidationDependencies = Pick<SpawnCommandDependencies, "registry">;
+
+function recordBody(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/** Validate the role admission that can strand an MCP spawn claim. A refusal
+    is useful to recovery only after the shared downstream fence is written. */
+export async function executeSpawnAdmissionValidation(
+  req: NextRequest,
+  dependencies: SpawnValidationDependencies = productionSpawnCommandDependencies,
+): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(req);
+  if (rejection) return rejection;
+
+  let body: Record<string, unknown>;
+  try {
+    const parsed = recordBody(await req.json());
+    if (!parsed) return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+    body = parsed;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const lineageError = agentSpawnLineageError(req, body);
+  if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
+
+  /* Establish the same caller identity as `/api/spawn` before this endpoint is
+     allowed to write a fence. A stranger may learn only the ordinary refusal,
+     never burn another caller's downstream key. */
+  if (isAgentInitiatedSpawn(req)) {
+    let caller: ReturnType<typeof authenticatedAgentSpawnCaller>;
+    try {
+      caller = authenticatedAgentSpawnCaller(req, body.src, dependencies.registry());
+    } catch (error) {
+      return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 503 });
+    }
+    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
+  }
+
+  const role = resolveSpawnRole(body);
+  if (!role.ok) {
+    const fence = fenceSpawnAdmissionRejection(body, 400, role.error, dependencies);
+    return NextResponse.json({
+      admissible: false,
+      fenced: fence?.kind === "fenced",
+      reason: role.error,
+      status: 400,
+    });
+  }
+
+  return NextResponse.json({ admissible: true, fenced: false });
+}

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -241,12 +241,30 @@ export async function executeSpawnRequest(
   const lineageError = agentSpawnLineageError(req, body);
   if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
   const agentInitiated = isAgentInitiatedSpawn(req);
+  let registryForCaller: ReturnType<SpawnCommandDependencies["registry"]> | null = null;
+  let authenticatedCaller: AuthenticatedSpawnCaller | null = null;
+  let authenticatedCallerError: { error: string; status?: number } | null = null;
+  if (agentInitiated) {
+    try {
+      registryForCaller = dependencies.registry();
+      const caller = authenticatedAgentSpawnCaller(req, body.src, registryForCaller);
+      if ("error" in caller) authenticatedCallerError = caller;
+      else authenticatedCaller = caller;
+    } catch (error) {
+      authenticatedCallerError = {
+        error: error instanceof Error ? error.message : String(error),
+        status: 503,
+      };
+    }
+  }
   if (body.allowSubagents !== undefined && typeof body.allowSubagents !== "boolean") {
     return NextResponse.json({ error: "allowSubagents must be a boolean" }, { status: 400 });
   }
   const role = resolveSpawnRole(body);
   if (!role.ok) {
-    fenceSpawnAdmissionRejection(body as Record<string, unknown>, 400, role.error, dependencies);
+    if (!authenticatedCallerError) {
+      fenceSpawnAdmissionRejection(body as Record<string, unknown>, 400, role.error, dependencies);
+    }
     return NextResponse.json({ error: role.error }, { status: 400 });
   }
   if (role.value?.role === "reviewer" && (typeof body.reviews !== "string" || !body.reviews.trim())) {
@@ -327,7 +345,7 @@ export async function executeSpawnRequest(
     }
   }
 
-  const registry = dependencies.registry();
+  const registry = registryForCaller ?? dependencies.registry();
   const clientAttemptId = typeof body.clientAttemptId === "string" ? body.clientAttemptId : null;
   const existingAttempt = clientAttemptId ? registry.spawnReceiptForClientAttempt(clientAttemptId) : null;
   if (!explicitTitle && !existingAttempt) {
@@ -340,11 +358,8 @@ export async function executeSpawnRequest(
     return NextResponse.json({ error: SPAWN_TITLE_REQUIRED_ERROR }, { status: 400 });
   }
 
-  let authenticatedCaller: AuthenticatedSpawnCaller | null = null;
-  if (agentInitiated) {
-    const caller = authenticatedAgentSpawnCaller(req, body.src, registry);
-    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
-    authenticatedCaller = caller;
+  if (agentInitiated && authenticatedCallerError) {
+    return NextResponse.json({ error: authenticatedCallerError.error }, { status: authenticatedCallerError.status ?? 403 });
   }
   if (agentInitiated && body.allowSubagents === true && authenticatedCaller?.kind !== "operator") {
     return NextResponse.json({ error: "allowSubagents requires an authenticated Viewer operator spawn" }, { status: 403 });

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -18,10 +18,18 @@ import { codexModelSupportsImages, defaultModelFor, modelFromBody, validateLaunc
 import { directOperatorActivityAuthority } from "@/lib/agent/operatorAuthority";
 import { resolveSpawnRole } from "@/lib/roles/registry";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
-import { spawnContentDigest, spawnParentSelector, spawnRequestDigests } from "@/lib/agent/spawnIdentity";
+import { spawnAdmissionBodyDigest, spawnContentDigest, spawnParentSelector, spawnRequestDigests } from "@/lib/agent/spawnIdentity";
 import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { resolveSpawnLineage, SpawnParentError } from "@/lib/agent/spawnParent";
-import { SpawnAdmissionError, isSpawnDeniedRole } from "@/lib/agent/spawnAdmission";
+import {
+  SpawnAdmissionError,
+  SpawnAdmissionFenceConflictError,
+  SpawnAdmissionFenceError,
+  isSpawnDeniedRole,
+  readSpawnAdmissionFence,
+  recordSpawnAdmissionRejection,
+  type SpawnAdmissionFenceResult,
+} from "@/lib/agent/spawnAdmission";
 import { spawnRejectionResponse, spawnReplayStatus, spawnResponseForReceipt, type SpawnResponse } from "@/lib/agent/spawnResponse";
 import { applyClaudeSpawnPolicy, prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
@@ -124,6 +132,29 @@ export const productionSpawnCommandDependencies: SpawnCommandDependencies = {
   recordOperatorActivity: recordDirectOperatorWakatimeActivity,
 };
 
+/** Record a request-bound pre-reservation refusal. The shared durable fence is
+    the authoritative downstream evidence; if it cannot be written, recovery
+    must retain unknown rather than trusting the HTTP error. */
+export function fenceSpawnAdmissionRejection(
+  body: Record<string, unknown>,
+  status: number,
+  error: string,
+  dependencies: Pick<SpawnCommandDependencies, "registry">,
+): SpawnAdmissionFenceResult | null {
+  const clientAttemptId = typeof body.clientAttemptId === "string" ? body.clientAttemptId : null;
+  if (!clientAttemptId || !/^[A-Za-z0-9_-]{8,128}$/.test(clientAttemptId)) return null;
+  try {
+    return recordSpawnAdmissionRejection({
+      clientAttemptId,
+      requestDigest: spawnAdmissionBodyDigest(body),
+      status,
+      error,
+    }, () => dependencies.registry().spawnReceiptForClientAttempt(clientAttemptId));
+  } catch {
+    return null;
+  }
+}
+
 interface SuggestResponse {
   dirs: string[];
   /** Working directory of the `src` transcript when one was requested. */
@@ -214,7 +245,10 @@ export async function executeSpawnRequest(
     return NextResponse.json({ error: "allowSubagents must be a boolean" }, { status: 400 });
   }
   const role = resolveSpawnRole(body);
-  if (!role.ok) return NextResponse.json({ error: role.error }, { status: 400 });
+  if (!role.ok) {
+    fenceSpawnAdmissionRejection(body as Record<string, unknown>, 400, role.error, dependencies);
+    return NextResponse.json({ error: role.error }, { status: 400 });
+  }
   if (role.value?.role === "reviewer" && (typeof body.reviews !== "string" || !body.reviews.trim())) {
     return NextResponse.json({ error: "reviewer requires reviews" }, { status: 400 });
   }
@@ -734,6 +768,19 @@ export async function executeSpawnRequest(
       ? body.accountId
       : account.accountId;
     const begun = await withAccountMutationLockAsync(async () => {
+      if (!existingAttempt && clientAttemptId) {
+        /* The validation endpoint may have fenced this exact downstream key
+           while an older request was between validation and reservation. Both
+           checks run under the same account lock, so a fence either precedes
+           this reservation or observes the receipt that won before it. */
+        const admissionFence = readSpawnAdmissionFence(clientAttemptId);
+        if (admissionFence) {
+          if (admissionFence.requestDigest === spawnAdmissionBodyDigest(body as Record<string, unknown>)) {
+            throw new SpawnAdmissionFenceError(admissionFence);
+          }
+          throw new SpawnAdmissionFenceConflictError();
+        }
+      }
       if (!existingAttempt) {
         const current = dependencies.resolveSpawnAccount(engine, account.accountId);
         if (current.accountId !== account.accountId || current.kind !== account.kind) {
@@ -1051,6 +1098,8 @@ export async function executeSpawnRequest(
       deleteInboxImages(imagePaths);
     }
     if (error instanceof SpawnParentError) return NextResponse.json({ error: error.message }, { status: error.status });
+    if (error instanceof SpawnAdmissionFenceConflictError) return NextResponse.json({ error: error.message }, { status: 409 });
+    if (error instanceof SpawnAdmissionFenceError) return NextResponse.json({ error: error.fence.error, code: "spawn_admission_refused" }, { status: error.fence.status });
     /* Typed terminal admission rejection (#393): the durable receipt already
        exists and no transcript or process was created. */
     if (error instanceof SpawnAdmissionError) return NextResponse.json(spawnRejectionResponse(error), { status: 403 });

--- a/src/lib/agent/spawnIdentity.ts
+++ b/src/lib/agent/spawnIdentity.ts
@@ -32,6 +32,13 @@ export function spawnContentDigest(input: unknown): string {
   return digest(input);
 }
 
+/** Digest of the exact JSON body presented to the spawn admission route. The
+    downstream admission fence compares this identity before it can close a
+    stranded MCP claim, so a changed body cannot inherit the old refusal. */
+export function spawnAdmissionBodyDigest(input: unknown): string {
+  return digest(input);
+}
+
 export function spawnParentSelector(body: { src?: unknown; parent?: unknown; parentConversationId?: unknown }): SpawnParentSelector {
   if (typeof body.parentConversationId === "string") return { conversationId: body.parentConversationId };
   if (typeof body.parent === "string") return { path: body.parent };

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -14,6 +15,7 @@ import { CORPUS_BODY_MARKERS, pipelineCorpus } from "@/lib/pipelines/fixtures/co
 import type { Pipeline } from "@/lib/pipelines/types";
 import { listRoles } from "@/lib/roles/registry";
 import type { RoleDefinition } from "@/lib/roles/types";
+import { beginOrchestratorSeatIntent, completeOrchestratorSeatIntent } from "@/lib/orchestrator/seats";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
@@ -22,7 +24,9 @@ import { queryLifecycleEvents } from "@/lib/lifecycle/journal";
 import { productionLivenessSources } from "@/lib/lifecycle/liveness";
 import { refreshLifecycleJournal } from "@/lib/lifecycle/projector";
 
-import { defaultMcpSpawnRoleParams, viewerMcpBindings } from "./bindings";
+import { defaultMcpSpawnRoleParams, spawnDispatchBody, viewerMcpBindings } from "./bindings";
+import type { SpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
+import { spawnAdmissionBodyDigest } from "@/lib/agent/spawnIdentity";
 import { SEAT_TICK_PROMPT_LIMIT } from "@/lib/monitor/seatTickSettings";
 import {
   createMcpToolService,
@@ -3071,6 +3075,155 @@ test("spawn recovery maps the launch receipt to the closed outcome set and estab
 
   const broken = viewerMcpRecoverableTools({ registrySnapshot: () => { throw new Error("registry unreadable"); } } as never);
   expect(await broken.spawn_agent!.recover(...binding("child_attempt_1"))).toMatchObject({ outcome: "unknown", evidence: "spawn-receipt", reason: expect.stringContaining("registry unreadable") });
+});
+
+test("spawn recovery requires an exact durable admission fence and keeps a bare refusal unknown", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-spawn-admission-fence-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const registry = new AgentRegistry(path.join(sandbox, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const args = {
+    clientRequestId: "spawn-admission-fence-1",
+    cwd: sandbox,
+    ["prompt"]: "launch the deployer",
+    title: "Admission fence fixture",
+    role: "deployer",
+    roleParams: { sha: "a".repeat(40), pr: "26" },
+  };
+  const downstreamKey = `mcp_spawn_${crypto.createHash("sha256").update(args.clientRequestId).digest("hex")}`;
+  const body = spawnDispatchBody(args, downstreamKey);
+  const binding = {
+    version: 1,
+    toolName: "spawn_agent",
+    clientRequestId: args.clientRequestId,
+    caller: { kind: "worker", conversationId: "conversation_caller", project: null },
+    target: { project: null, identity: sandbox },
+    downstreamKey,
+    owner: { pid: process.pid, startIdentity: null },
+    claimedAt: new Date().toISOString(),
+  } as never;
+  let fence: SpawnAdmissionFence | null = null;
+  let probes = 0;
+  const recoverable = viewerMcpRecoverableTools({
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    readSpawnAdmissionFence: () => fence,
+    validateSpawnAdmission: async (actual: Record<string, unknown>) => {
+      probes += 1;
+      expect(actual).toEqual(body);
+      fence = {
+        version: 1,
+        clientAttemptId: downstreamKey,
+        requestDigest: spawnAdmissionBodyDigest(actual),
+        status: 400,
+        error: "deployer requires confirm: deploy",
+        rejectedAt: "2026-09-08T12:00:00.000Z",
+      };
+      return { admissible: false, fenced: true };
+    },
+  } as never);
+
+  const first = await recoverable.spawn_agent!.recover(binding, { legacy: false, args });
+  expect(first).toMatchObject({
+    outcome: "not-executed",
+    evidence: "spawn-admission-fence",
+    reason: "deployer requires confirm: deploy",
+    facts: { status: 400 },
+  });
+  expect(probes).toBe(1);
+  expect(registry.readOnlySnapshot().receipts).toEqual({});
+
+  const replay = await recoverable.spawn_agent!.recover(binding, { legacy: false, args });
+  expect(replay).toMatchObject({ outcome: "not-executed", evidence: "spawn-admission-fence" });
+  expect(probes).toBe(1);
+
+  const bareRefusal = viewerMcpRecoverableTools({
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    readSpawnAdmissionFence: () => null,
+    validateSpawnAdmission: async () => ({ admissible: false, fenced: false }),
+  } as never);
+  expect(await bareRefusal.spawn_agent!.recover(binding, { legacy: false, args })).toMatchObject({
+    outcome: "unknown",
+    evidence: "none",
+    reason: expect.stringContaining("atomic downstream fence"),
+  });
+});
+
+test("spawn binding derives predecessor lineage from the active same-project seat", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-spawn-seat-lineage-"));
+  sandboxes.push(sandbox);
+  process.env.LLV_STATE_DIR = sandbox;
+  const predecessor = "conversation_predecessor";
+  const successor = "conversation_successor";
+  const first = beginOrchestratorSeatIntent({
+    project: "proj-a",
+    mandate: "old mandate",
+    clientRequestId: "seat-lineage-old",
+    mode: "existing",
+    conversationId: predecessor,
+  });
+  expect(first.kind).toBe("begun");
+  expect(completeOrchestratorSeatIntent({
+    project: "proj-a",
+    clientRequestId: "seat-lineage-old",
+    conversationId: predecessor,
+    path: "/repo/predecessor.jsonl",
+  }).kind).toBe("activated");
+  const second = beginOrchestratorSeatIntent({
+    project: "proj-a",
+    mandate: "new mandate",
+    clientRequestId: "seat-lineage-new",
+    mode: "existing",
+    conversationId: successor,
+  });
+  expect(second.kind).toBe("begun");
+  expect(completeOrchestratorSeatIntent({
+    project: "proj-a",
+    clientRequestId: "seat-lineage-new",
+    conversationId: successor,
+    path: "/repo/successor.jsonl",
+  }).kind).toBe("activated");
+
+  const base = new AgentRegistry(path.join(sandbox, "registry.json"), undefined, undefined, { sqliteMode: "off" }).readOnlySnapshot();
+  const snapshot = {
+    ...base,
+    conversations: {
+      [successor]: {
+        id: successor,
+        engine: "codex",
+        generations: [],
+        continuityPaths: [],
+        abandonedContinuityPaths: [],
+        providerForkPaths: [],
+        projectOwnership: { project: "proj-a", source: "operator", setAt: "2026-09-08T12:00:00.000Z", operationId: "seat-lineage" },
+        migration: null,
+        migrationOptOut: null,
+        supersededBy: null,
+        agentRole: null,
+        delegationDepth: null,
+        turn: { state: "idle", source: "unknown", terminalAt: null, observedAt: null },
+        createdAt: "2026-09-08T12:00:00.000Z",
+        updatedAt: "2026-09-08T12:00:00.000Z",
+      },
+    },
+  } as never;
+  const recoverable = viewerMcpRecoverableTools({
+    registrySnapshot: () => snapshot,
+    attentionAuthority: () => ({ kind: "worker", conversationId: successor, role: null }),
+  } as never);
+  const binding = recoverable.spawn_agent!.bind({
+    clientRequestId: "seat-lineage-bind",
+    cwd: "/repo",
+    ["prompt"]: "inspect",
+    title: "Seat lineage",
+  });
+  expect(binding).toMatchObject({
+    caller: {
+      kind: "worker",
+      conversationId: successor,
+      project: "proj-a",
+      predecessors: [predecessor],
+    },
+  });
 });
 
 

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -3154,6 +3154,7 @@ test("spawn binding derives predecessor lineage from the active same-project sea
   process.env.LLV_STATE_DIR = sandbox;
   const predecessor = "conversation_predecessor";
   const successor = "conversation_successor";
+  const finalSuccessor = "conversation_final_successor";
   const first = beginOrchestratorSeatIntent({
     project: "proj-a",
     mandate: "old mandate",
@@ -3182,13 +3183,41 @@ test("spawn binding derives predecessor lineage from the active same-project sea
     conversationId: successor,
     path: "/repo/successor.jsonl",
   }).kind).toBe("activated");
+  const third = beginOrchestratorSeatIntent({
+    project: "proj-a",
+    mandate: "final mandate",
+    clientRequestId: "seat-lineage-final",
+    mode: "existing",
+    conversationId: finalSuccessor,
+  });
+  expect(third.kind).toBe("begun");
+  expect(completeOrchestratorSeatIntent({
+    project: "proj-a",
+    clientRequestId: "seat-lineage-final",
+    conversationId: finalSuccessor,
+    path: "/repo/final.jsonl",
+  }).kind).toBe("activated");
+  const otherProjectSeat = beginOrchestratorSeatIntent({
+    project: "proj-b",
+    mandate: "other project mandate",
+    clientRequestId: "seat-lineage-other-project",
+    mode: "existing",
+    conversationId: "conversation_other_project",
+  });
+  expect(otherProjectSeat.kind).toBe("begun");
+  expect(completeOrchestratorSeatIntent({
+    project: "proj-b",
+    clientRequestId: "seat-lineage-other-project",
+    conversationId: "conversation_other_project",
+    path: "/other-project/current.jsonl",
+  }).kind).toBe("activated");
 
   const base = new AgentRegistry(path.join(sandbox, "registry.json"), undefined, undefined, { sqliteMode: "off" }).readOnlySnapshot();
   const snapshot = {
     ...base,
     conversations: {
-      [successor]: {
-        id: successor,
+      [finalSuccessor]: {
+        id: finalSuccessor,
         engine: "codex",
         generations: [],
         continuityPaths: [],
@@ -3208,7 +3237,7 @@ test("spawn binding derives predecessor lineage from the active same-project sea
   } as never;
   const recoverable = viewerMcpRecoverableTools({
     registrySnapshot: () => snapshot,
-    attentionAuthority: () => ({ kind: "worker", conversationId: successor, role: null }),
+    attentionAuthority: () => ({ kind: "worker", conversationId: finalSuccessor, role: null }),
   } as never);
   const binding = recoverable.spawn_agent!.bind({
     clientRequestId: "seat-lineage-bind",
@@ -3219,9 +3248,9 @@ test("spawn binding derives predecessor lineage from the active same-project sea
   expect(binding).toMatchObject({
     caller: {
       kind: "worker",
-      conversationId: successor,
+      conversationId: finalSuccessor,
       project: "proj-a",
-      predecessors: [predecessor],
+      predecessors: [successor, predecessor],
     },
   });
 });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -94,11 +94,13 @@ import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
 import { listRoles, resolveSpawnRole } from "@/lib/roles/registry";
 import type { RoleDefinition, RoleParameter } from "@/lib/roles/types";
+import { readSpawnAdmissionFence, type SpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
 import type { RuntimeHostRequestHealth } from "@/lib/runtime/client";
 import type { ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import { messageOriginRole, type MessageOrigin } from "@/lib/runtime/messageOrigin";
 import { ledgerDeployment, ledgerDeployments } from "@/lib/runtime/deploymentLedger";
 import { resolveOriginalSend, resolveSendReceipt, type SendSettlementPorts } from "@/lib/runtime/sendSettlement";
+import { spawnAdmissionBodyDigest } from "@/lib/agent/spawnIdentity";
 import {
   SELECTED_TAIL_MAX_BYTES,
   SELECTED_TAIL_MAX_LINES,
@@ -645,6 +647,14 @@ export interface ViewerMcpDomainDependencies {
   /** #1490: the ports the original-key send lookup settles through. Absent
       means production (the shared registry and the runtime host socket). */
   sendSettlementPorts?(): SendSettlementPorts;
+  /** #1582: a read-only-looking admission check that may return a refusal only
+      after the downstream route atomically fences the exact request. */
+  validateSpawnAdmission?(body: Record<string, unknown>, context?: McpToolCallContext): Promise<Record<string, unknown>>;
+  /** Server-derived predecessor identities of the caller's active project seat.
+      The caller cannot supply this lineage. */
+  recoveryPredecessors?(project: string, conversationId: string): readonly string[];
+  /** #1582: read one request-bound spawn admission fence. */
+  readSpawnAdmissionFence?(clientAttemptId: string): SpawnAdmissionFence | null;
 }
 
 /**
@@ -671,6 +681,33 @@ function callerProjectFromSnapshot(snapshot: RegistrySnapshot, conversationId: s
   if (conversation.projectOwnership?.project) return conversation.projectOwnership.project;
   const cwd = conversation.generations.at(-1)?.launchProfile?.cwd?.trim();
   return cwd ? projectForCwd(cwd) : null;
+}
+
+/** Walk only the active seat in the caller's own canonical project. The active
+    seat supplies the immediate predecessor; revocations supply older links.
+    Any contradictory edge makes lineage unavailable rather than widening it. */
+function productionRecoveryPredecessors(project: string, conversationId: string): readonly string[] {
+  const canonicalProject = canonicalOrchestratorProject(project);
+  const active = orchestratorSeatFor(canonicalProject).active;
+  if (!active || active.conversationId !== conversationId || active.project !== canonicalProject) return [];
+  const predecessorBySuccessor = new Map<string, string>();
+  const ambiguousSuccessors = new Set<string>();
+  for (const revocation of orchestratorRevocations()) {
+    if (revocation.project !== canonicalProject || !revocation.successorConversationId) continue;
+    const previous = predecessorBySuccessor.get(revocation.successorConversationId);
+    if (previous && previous !== revocation.conversationId) ambiguousSuccessors.add(revocation.successorConversationId);
+    else predecessorBySuccessor.set(revocation.successorConversationId, revocation.conversationId);
+  }
+  const predecessors: string[] = [];
+  const seen = new Set<string>([conversationId]);
+  let current = active.predecessorConversationId;
+  while (current) {
+    if (seen.has(current) || ambiguousSuccessors.has(current)) return [];
+    seen.add(current);
+    predecessors.push(current);
+    current = predecessorBySuccessor.get(current) ?? null;
+  }
+  return predecessors;
 }
 
 /** Server-derived origin of the current caller. Shared by the attention record
@@ -831,6 +868,14 @@ export const productionDomainDependencies: ViewerMcpDomainDependencies = {
   selectedContext: productionSelectedContextDependencies,
   completedFileScan,
   registrySnapshot: () => agentRegistry().readOnlySnapshot(),
+  readSpawnAdmissionFence,
+  validateSpawnAdmission: (body, context) => productionViewerControlDependencies().post(
+    "/api/spawn/validate",
+    body,
+    callerCapabilityHeaders(),
+    context,
+  ),
+  recoveryPredecessors: productionRecoveryPredecessors,
   canonicalSeatConversationId: productionCanonicalSeatConversationId,
   boardFor,
   applyBoardCommand: (input, snapshot) => applyBoardCommand(input, { registrySnapshot: () => snapshot }),
@@ -986,6 +1031,19 @@ export function defaultMcpSpawnRoleParams(
   return Object.keys(resolved).length ? resolved : source;
 }
 
+/** The exact body handed to `/api/spawn`, shared by the one dispatch and the
+    request-bound admission recovery probe. Keeping this construction in one
+    seam makes the downstream fence digest compare the original payload. */
+export function spawnDispatchBody(args: McpToolArgs, clientAttemptId: string): Record<string, unknown> {
+  const body = withoutKeys(args, ["clientRequestId", "recoveryOnly"]);
+  const roleParams = defaultMcpSpawnRoleParams(args);
+  return {
+    ...body,
+    ...(roleParams ? { roleParams } : {}),
+    clientAttemptId,
+  };
+}
+
 /** The durable identity one `request_attention` call writes on its record —
     exported so tests and evidence can construct the record an interrupted run
     would have left behind. */
@@ -1012,13 +1070,7 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies,
       );
     }
   }
-  const body = withoutKeys(args, ["clientRequestId", "recoveryOnly"]);
-  const roleParams = defaultMcpSpawnRoleParams(args);
-  const result = await dispatchControl(control)("/api/spawn", {
-    ...body,
-    ...(roleParams ? { roleParams } : {}),
-    clientAttemptId,
-  }, {
+  const result = await dispatchControl(control)("/api/spawn", spawnDispatchBody(args, clientAttemptId), {
     ...internalServiceHeaders("mcp"),
     [VIEWER_SPAWN_CAPABILITY_HEADER]: ensureOperatorSpawnCapability(),
   });
@@ -3826,7 +3878,7 @@ export function viewerMcpToolPolicy(
     projection the call already holds — never a separately resolved guess. An
     authority or registry that faults reads as unidentified, which fails both
     a fresh claim and a recovery closed. */
-function recoveryCaller(dependencies: Partial<Pick<ViewerMcpDomainDependencies, "attentionAuthority" | "registrySnapshot">>): McpRequestCaller {
+function recoveryCaller(dependencies: Partial<Pick<ViewerMcpDomainDependencies, "attentionAuthority" | "registrySnapshot" | "recoveryPredecessors">>): McpRequestCaller {
   const unidentified: McpRequestCaller = { kind: "unidentified", conversationId: null, project: null };
   let authority: AttentionCallerAuthority;
   try {
@@ -3843,7 +3895,22 @@ function recoveryCaller(dependencies: Partial<Pick<ViewerMcpDomainDependencies, 
   } catch {
     return unidentified;
   }
-  return { kind: authority.kind, conversationId: authority.conversationId, project };
+  let predecessors: string[] = [];
+  if (project) {
+    try {
+      predecessors = [...(dependencies.recoveryPredecessors ?? productionRecoveryPredecessors)(project, authority.conversationId)]
+        .filter((candidate, index, all) => /^conversation_[A-Za-z0-9_-]{1,128}$/.test(candidate) && all.indexOf(candidate) === index)
+        .slice(0, 32);
+    } catch {
+      predecessors = [];
+    }
+  }
+  return {
+    kind: authority.kind,
+    conversationId: authority.conversationId,
+    project,
+    ...(predecessors.length ? { predecessors } : {}),
+  };
 }
 
 function spawnCwd(args: McpToolArgs): string {
@@ -3976,17 +4043,78 @@ async function recoverSpawn(
   legacy: boolean,
   dependencies: ViewerMcpDomainDependencies,
   args?: McpToolArgs,
+  context?: McpToolCallContext,
 ): Promise<McpRecoveryEvidence> {
+  const key = legacy ? spawnAttemptId(binding.clientRequestId) : binding.downstreamKey;
+  const unknown = (reason = RECOVERY_ABSENT_REASON): McpRecoveryEvidence => ({
+    outcome: "unknown",
+    evidence: "none",
+    reason,
+    ids: {},
+    ...(legacy ? { ownership: "unknown" as const } : {}),
+  });
+  const fencedEvidence = (fence: SpawnAdmissionFence): McpRecoveryEvidence => ({
+    outcome: "not-executed",
+    evidence: "spawn-admission-fence",
+    reason: fence.error,
+    ids: {},
+    facts: { status: fence.status, rejectedAt: fence.rejectedAt },
+  });
   let snapshot: RegistrySnapshot;
   try {
     snapshot = dependencies.registrySnapshot();
   } catch (error) {
     return { outcome: "unknown", evidence: "spawn-receipt", reason: `the launch record could not be read: ${error instanceof Error ? error.message : String(error)}`, ids: {} };
   }
-  const key = legacy ? spawnAttemptId(binding.clientRequestId) : binding.downstreamKey;
-  const receipts = Object.values(snapshot.receipts).filter((receipt) => receipt.clientAttemptId === key);
+  let receipts = Object.values(snapshot.receipts).filter((receipt) => receipt.clientAttemptId === key);
   if (receipts.length === 0) {
-    return { outcome: "unknown", evidence: "none", reason: RECOVERY_ABSENT_REASON, ids: {}, ...(legacy ? { ownership: "unknown" as const } : {}) };
+    if (legacy || !args || typeof args.role !== "string" || !args.role.trim() || !dependencies.validateSpawnAdmission) return unknown();
+    let body: Record<string, unknown>;
+    try {
+      body = spawnDispatchBody(args, key);
+    } catch (error) {
+      return unknown(`the spawn admission request could not be reconstructed (${error instanceof Error ? error.message : String(error)})`);
+    }
+    const requestDigest = spawnAdmissionBodyDigest(body);
+    if (!dependencies.readSpawnAdmissionFence) return unknown("spawn admission fencing is unavailable; execution remains possible");
+    let existingFence: SpawnAdmissionFence | null;
+    try {
+      existingFence = dependencies.readSpawnAdmissionFence(key);
+    } catch (error) {
+      return unknown(`the spawn admission fence could not be read (${error instanceof Error ? error.message : String(error)})`);
+    }
+    if (existingFence) {
+      if (existingFence.requestDigest === requestDigest) return fencedEvidence(existingFence);
+      return unknown("the downstream admission fence contradicts the bound request");
+    }
+    let probe: Record<string, unknown>;
+    try {
+      probe = await dependencies.validateSpawnAdmission(body, context);
+    } catch (error) {
+      return unknown(`the spawn admission fence could not be established (${error instanceof Error ? error.message : String(error)})`);
+    }
+    /* A current refusal is only a hint. The response must say the downstream
+       CAS fence was written; the registry read below is the authoritative
+       check that makes validator drift and in-flight races safe. */
+    if (probe.admissible !== false || probe.fenced !== true) {
+      return unknown("spawn admission did not establish an atomic downstream fence; execution remains possible");
+    }
+    try {
+      snapshot = dependencies.registrySnapshot();
+    } catch (error) {
+      return { outcome: "unknown", evidence: "spawn-receipt", reason: `the launch record could not be read after admission fencing: ${error instanceof Error ? error.message : String(error)}`, ids: {} };
+    }
+    receipts = Object.values(snapshot.receipts).filter((receipt) => receipt.clientAttemptId === key);
+    let fence: SpawnAdmissionFence | null;
+    try {
+      fence = dependencies.readSpawnAdmissionFence(key);
+    } catch (error) {
+      return unknown(`the spawn admission fence could not be read after admission fencing (${error instanceof Error ? error.message : String(error)})`);
+    }
+    if (!fence || fence.requestDigest !== requestDigest) {
+      return unknown("the reported admission refusal could not be verified against the exact downstream fence");
+    }
+    if (receipts.length === 0) return fencedEvidence(fence);
   }
   if (receipts.length > 1) {
     return { outcome: "unknown", evidence: "spawn-receipt", reason: "more than one launch receipt claims this key; the match is ambiguous", ids: {}, ...(legacy ? { ownership: "unknown" as const } : {}) };
@@ -4046,7 +4174,7 @@ export function viewerMcpRecoverableTools(
   return {
     spawn_agent: {
       bind: (args) => bindSpawn(args, domainDependencies),
-      recover: (binding, options) => recoverSpawn(binding, options.legacy, domainDependencies, options.args),
+      recover: (binding, options) => recoverSpawn(binding, options.legacy, domainDependencies, options.args, options.context),
     },
     send_message: {
       bind: (args) => bindSend(args, domainDependencies),

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -872,7 +872,7 @@ export const productionDomainDependencies: ViewerMcpDomainDependencies = {
   validateSpawnAdmission: (body, context) => productionViewerControlDependencies().post(
     "/api/spawn/validate",
     body,
-    callerCapabilityHeaders(),
+    spawnControlHeaders(),
     context,
   ),
   recoveryPredecessors: productionRecoveryPredecessors,
@@ -1070,10 +1070,7 @@ async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies,
       );
     }
   }
-  const result = await dispatchControl(control)("/api/spawn", spawnDispatchBody(args, clientAttemptId), {
-    ...internalServiceHeaders("mcp"),
-    [VIEWER_SPAWN_CAPABILITY_HEADER]: ensureOperatorSpawnCapability(),
-  });
+  const result = await dispatchControl(control)("/api/spawn", spawnDispatchBody(args, clientAttemptId), spawnControlHeaders());
   // A readable body alone establishes no acceptance. Validate the fields
   // this binding publishes before the service can persist a successful replay.
   if (!text(result.launchId) || !text(result.conversationId)
@@ -2181,6 +2178,16 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
     effect that must replay with its parent call. */
 function derivedRequestId(base: string, suffix: string): string {
   return spawnAttemptId(`${base}:${suffix}`);
+}
+
+/** The capability used by both the spawn dispatch and its admission probe.
+    Keeping these control calls on one header path prevents a future route
+    authentication change from admitting the dispatch while refusing recovery. */
+function spawnControlHeaders(): Record<string, string> {
+  return {
+    ...internalServiceHeaders("mcp"),
+    [VIEWER_SPAWN_CAPABILITY_HEADER]: ensureOperatorSpawnCapability(),
+  };
 }
 
 /**

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1996,6 +1996,21 @@ describe("original-key recovery (#1490)", () => {
       operationId: "op_lineage",
     });
 
+    /* A row claimed by the successor stays owned by that successor. Its
+       predecessor may recover rows it originally claimed, while a reverse
+       lookup cannot widen authority to the successor's live work. */
+    const successorOwned = recoveryHarness(successor.caller, store, {
+      bindingImpl: async () => ({ operationId: "op_successor_owned", outcome: "queued" }),
+    });
+    const successorOwnedArgs = { ...SPAWN, clientRequestId: "successor-owned-1" };
+    expect(await successorOwned.service.callTool("spawn_agent", successorOwnedArgs)).toMatchObject({ ok: true, operationId: "op_successor_owned" });
+    const predecessorLookup = recoveryHarness(OWNER, store);
+    expect(await predecessorLookup.service.callTool("spawn_agent", { ...successorOwnedArgs, recoveryOnly: true })).toMatchObject({
+      ok: false,
+      code: "recovery_not_permitted",
+    });
+    expect(predecessorLookup.recoverCalls).toHaveLength(0);
+
     const unrelated = recoveryHarness({
       kind: "worker",
       conversationId: "conversation_unrelated",

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1974,6 +1974,51 @@ describe("original-key recovery (#1490)", () => {
     expect(await store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled", binding: { caller: OWNER } });
   });
 
+  test("a same-project successor with server-derived predecessor lineage can recover a spawn, while unrelated lineage cannot", async () => {
+    const store = new MemoryMcpReceiptStore();
+    const predecessor = recoveryHarness(OWNER, store, {
+      bindingImpl: async () => ({ operationId: "op_lineage", outcome: "queued" }),
+    });
+    expect(await predecessor.service.callTool("spawn_agent", SPAWN)).toMatchObject({ ok: true, operationId: "op_lineage" });
+
+    const successor = recoveryHarness({
+      kind: "worker",
+      conversationId: "conversation_successor",
+      project: "proj-a",
+      predecessors: ["conversation_owner"],
+    }, store, {
+      evidence: { outcome: "accepted", evidence: "delivery-record", reason: "accepted", ids: { operationId: "op_lineage" } },
+    });
+    expect(await successor.service.callTool("spawn_agent", { ...SPAWN, recoveryOnly: true })).toMatchObject({
+      ok: true,
+      recovered: true,
+      outcome: "accepted",
+      operationId: "op_lineage",
+    });
+
+    const unrelated = recoveryHarness({
+      kind: "worker",
+      conversationId: "conversation_unrelated",
+      project: "proj-a",
+      predecessors: ["conversation_other"],
+    }, store);
+    expect(await unrelated.service.callTool("spawn_agent", { ...SPAWN, recoveryOnly: true })).toMatchObject({
+      ok: false,
+      code: "recovery_not_permitted",
+    });
+
+    const crossProject = recoveryHarness({
+      kind: "worker",
+      conversationId: "conversation_successor",
+      project: "proj-b",
+      predecessors: ["conversation_owner"],
+    }, store);
+    expect(await crossProject.service.callTool("spawn_agent", { ...SPAWN, recoveryOnly: true })).toMatchObject({
+      ok: false,
+      code: "recovery_not_permitted",
+    });
+  });
+
   test("a duplicate in the same process is authenticated and answered from the durable record, never joined to the original", async () => {
     const store = new MemoryMcpReceiptStore();
     let release!: () => void;
@@ -2143,6 +2188,77 @@ describe("original-key recovery (#1490)", () => {
     expect(await harness.store.lookup("send_message:recover-1")).toMatchObject({ stage: "settled", result: { ok: true, recovered: true, outcome: "settled", operationId: "op_found" } });
     harness.evidence = { outcome: "unknown", evidence: "none", reason: "gone", ids: {} };
     expect(await harness.service.callTool("send_message", SEND)).toMatchObject({ ok: true, outcome: "settled", operationId: "op_found", replayed: true });
+  });
+
+  test("a post-wire spawn validation refusal closes only after an atomic downstream fence", async () => {
+    const fenced = recoveryHarness(OWNER, undefined, {
+      bindingImpl: async (_args, context) => {
+        context!.dispatch!.attempted = true;
+        throw new McpDispatchVerdictError("deployer requires confirm: deploy", { status: 400 });
+      },
+      evidence: {
+        outcome: "not-executed",
+        evidence: "spawn-admission-fence",
+        reason: "the downstream admission fence refused this exact request before launch reservation",
+        ids: {},
+        facts: { status: 400 },
+      },
+    });
+
+    const first = await fenced.service.callTool("spawn_agent", SPAWN);
+    expect(first).toMatchObject({
+      ok: false,
+      code: "not_executed",
+      replayed: false,
+      details: {
+        outcome: "not-executed",
+        evidence: "spawn-admission-fence",
+        nextAction: "new-request-permitted",
+      },
+    });
+    expect(await fenced.store.lookup("spawn_agent:recover-1")).toMatchObject({
+      stage: "not-executed",
+      result: { code: "not_executed", details: { outcome: "not-executed" } },
+    });
+
+    const replay = await fenced.service.callTool("spawn_agent", SPAWN);
+    expect(replay).toMatchObject({ ok: false, code: "not_executed", replayed: true });
+    expect(fenced.bindingCalls).toHaveLength(1);
+    expect(fenced.recoverCalls).toHaveLength(1);
+  });
+
+  test("a fenced not-executed spawn recovery replays after the MCP receipt store reopens", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-spawn-fence-reopen-"));
+    scratch.push(directory);
+    const filename = path.join(directory, "mcp-receipts.sqlite");
+    const firstStore = new SqliteMcpReceiptStore(filename);
+    const original = recoveryHarness(OWNER, firstStore, {
+      bindingImpl: async (_args, context) => {
+        context!.dispatch!.attempted = true;
+        throw new McpDispatchVerdictError("deployer requires confirm: deploy", { status: 400 });
+      },
+      evidence: { outcome: "not-executed", evidence: "spawn-admission-fence", reason: "atomic refusal", ids: {}, facts: { status: 400 } },
+    });
+    expect(await original.service.callTool("spawn_agent", SPAWN)).toMatchObject({ ok: false, code: "not_executed" });
+    expect(await firstStore.lookup("spawn_agent:recover-1")).toMatchObject({ stage: "not-executed" });
+    firstStore.close();
+
+    const reopenedStore = new SqliteMcpReceiptStore(filename);
+    const reopened = recoveryHarness(OWNER, reopenedStore, {
+      bindingImpl: async () => { throw new Error("reopened recovery must not dispatch"); },
+      evidence: { outcome: "unknown", evidence: "none", reason: "downstream unavailable", ids: {} },
+    });
+    for (const args of [SPAWN, { ...SPAWN, recoveryOnly: true }]) {
+      expect(await reopened.service.callTool("spawn_agent", args)).toMatchObject({
+        ok: false,
+        code: "not_executed",
+        replayed: true,
+        details: { outcome: "not-executed", nextAction: "new-request-permitted" },
+      });
+    }
+    expect(reopened.bindingCalls).toHaveLength(0);
+    expect(reopened.recoverCalls).toHaveLength(0);
+    reopenedStore.close();
   });
 
   test("terminal evidence recovered while the original still dispatches is persisted, so a delayed admitted error cannot replace it — across store instances and a reopen", async () => {

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -377,6 +377,8 @@ export interface McpRequestCaller {
   kind: "root" | "worker" | "unidentified";
   conversationId: string | null;
   project: string | null;
+  /** Server-derived predecessor seats that the current caller may recover. */
+  predecessors?: string[];
 }
 
 export interface McpRequestTarget {
@@ -482,7 +484,7 @@ function terminalReceiptResult(result: McpToolResult | null | undefined): result
   return Boolean(result && (result.ok
     ? result.outcome === "settled" || result.settled === true
       || (result.toolName === "spawn_agent" && result.state === "settled")
-    : result.details?.outcome === "settled"));
+    : result.details?.outcome === "settled" || result.details?.outcome === "not-executed"));
 }
 
 function receiptSettlement(
@@ -495,7 +497,7 @@ function receiptSettlement(
   if (receipt.recoveryResult) return { receipt, result: receipt.recoveryResult };
   if (receipt.result) {
     if (recovery && !terminalReceiptResult(receipt.result) && receipt.stage !== "not-executed") {
-      return { receipt: { ...receipt, recoveryResult: result }, result };
+      return { receipt: { ...receipt, recoveryResult: result, stage }, result };
     }
     return { receipt, result: receipt.result };
   }
@@ -647,7 +649,11 @@ export function validRequestBinding(value: unknown, toolName?: McpToolName, requ
   if (typeof value.claimedAt !== "string") return false;
   const { caller, target, owner } = value;
   if (!isRecord(caller) || !["root", "worker", "unidentified"].includes(String(caller.kind))
-    || !nullableString(caller.conversationId) || !nullableString(caller.project)) return false;
+    || !nullableString(caller.conversationId) || !nullableString(caller.project)
+    || (caller.predecessors !== undefined
+      && (!Array.isArray(caller.predecessors)
+        || caller.predecessors.length > 32
+        || caller.predecessors.some((predecessor) => typeof predecessor !== "string" || !/^conversation_[A-Za-z0-9_-]{1,128}$/.test(predecessor))))) return false;
   if (!isRecord(target) || !nullableString(target.project) || !nullableString(target.identity)) return false;
   if (!isRecord(owner) || typeof owner.pid !== "number" || !nullableString(owner.startIdentity)) return false;
   return true;
@@ -1970,8 +1976,9 @@ export class McpDispatchVerdictError extends McpToolRefusal {
 
 function sameCaller(recorded: McpRequestCaller, current: McpRequestCaller): boolean {
   return recorded.kind === current.kind
-    && recorded.conversationId === current.conversationId
-    && recorded.project === current.project;
+    && recorded.project === current.project
+    && (recorded.conversationId === current.conversationId
+      || (recorded.conversationId !== null && (current.predecessors ?? []).includes(recorded.conversationId)));
 }
 
 function identifiedCaller(caller: McpRequestCaller): boolean {
@@ -2238,10 +2245,16 @@ export function createMcpToolService(
             replayed: true,
           };
           const answer = recoveryAnswer(typedTool, requestId, evidence, replayed, previous);
-          if (evidence.outcome !== "settled") return answer;
+          if (evidence.outcome !== "settled" && evidence.outcome !== "not-executed") return answer;
           let stored: McpToolResult;
           try {
-            stored = await store.settle(key, digest, answer, "settled", true);
+            stored = await store.settle(
+              key,
+              digest,
+              answer,
+              evidence.outcome === "not-executed" ? "not-executed" : "settled",
+              true,
+            );
           } catch {
             // A failed write can race a successful terminal recovery.
             try {
@@ -2284,6 +2297,10 @@ export function createMcpToolService(
           if (record.digest !== digest) {
             outcome = "conflict";
             return failure(typedTool, requestId, "idempotency_conflict", "clientRequestId was already used with different arguments", false, true);
+          }
+          if (record.recoveryResult && record.stage === "not-executed") {
+            outcome = "replay";
+            return { ...record.recoveryResult, replayed: true };
           }
           if (record.result && (!recoveryOnly || record.stage === "not-executed")) {
             outcome = "replay";

--- a/src/lib/mcp/spawnRecovery.integration.test.ts
+++ b/src/lib/mcp/spawnRecovery.integration.test.ts
@@ -1,0 +1,234 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { executeSpawnAdmissionValidation } from "@/app/api/spawn/validate/route";
+import { AgentRegistry } from "@/lib/agent/registry";
+import { readSpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
+import { executeSpawnRequest, type SpawnCommandDependencies } from "@/lib/agent/spawnCommand";
+import type { RuntimeHostClient } from "@/lib/runtime/client";
+
+import {
+  viewerMcpBindings,
+  viewerMcpRecoverableTools,
+  type ViewerControlDependencies,
+  type ViewerMcpDomainDependencies,
+} from "./bindings";
+import {
+  createMcpToolService,
+  McpDispatchVerdictError,
+  MemoryMcpReceiptStore,
+  type McpToolCallContext,
+} from "./server";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-spawn-recovery-integration-"));
+const previousStateDir = process.env.LLV_STATE_DIR;
+const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+const previousStructuredHosts = process.env.LLV_STRUCTURED_HOSTS;
+const previousRuntimeEvents = process.env.LLV_RUNTIME_EVENTS;
+const previousRuntimeSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+const previousRuntimeUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+const previousCodexBinary = process.env.LLV_CODEX_BINARY;
+const codexBinary = path.join(sandbox, "codex-list");
+fs.writeFileSync(codexBinary, "#!/bin/sh\nprintf '[]'\n", { mode: 0o700 });
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.LLV_SPAWN_TRANSPORT = "structured";
+process.env.LLV_STRUCTURED_HOSTS = "1";
+process.env.LLV_RUNTIME_EVENTS = "1";
+process.env.LLV_RUNTIME_HOST_SOCKET = path.join(sandbox, "runtime.sock");
+process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+process.env.LLV_CODEX_BINARY = codexBinary;
+
+afterAll(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+  else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+  if (previousStructuredHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+  else process.env.LLV_STRUCTURED_HOSTS = previousStructuredHosts;
+  if (previousRuntimeEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+  else process.env.LLV_RUNTIME_EVENTS = previousRuntimeEvents;
+  if (previousRuntimeSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+  else process.env.LLV_RUNTIME_HOST_SOCKET = previousRuntimeSocket;
+  if (previousRuntimeUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+  else process.env.NEXT_PUBLIC_RUNTIME_UI = previousRuntimeUi;
+  if (previousCodexBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+  else process.env.LLV_CODEX_BINARY = previousCodexBinary;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function routeRequest(pathname: string, body: Record<string, unknown>, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(`http://127.0.0.1:8898${pathname}`, {
+    method: "POST",
+    headers: {
+      origin: "http://127.0.0.1:8898",
+      host: "127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function spawnDependencies(registry: AgentRegistry, cwd: string): SpawnCommandDependencies {
+  const account = {
+    engine: "codex" as const,
+    accountId: "codex-test",
+    kind: "managed" as const,
+    home: path.join(cwd, "account"),
+    transcriptRoot: path.join(cwd, "projects"),
+    env: { NODE_ENV: "test" as const },
+  };
+  return {
+    registry: () => registry,
+    resolveHealthySpawnAccount: async () => account,
+    resolveSpawnAccount: () => account,
+    assertStructuredRuntime: () => {},
+    runtimeHostClient: () => ({} as RuntimeHostClient),
+    defer: () => {},
+    storeImages: () => [],
+    spawnStructuredConversation: async () => {
+      throw new Error("the fenced spawn must not reach structured launch");
+    },
+  };
+}
+
+function domainDependencies(registry: AgentRegistry, validate = true): ViewerMcpDomainDependencies {
+  return {
+    registrySnapshot: () => registry.readOnlySnapshot(),
+    readSpawnAdmissionFence,
+    attentionAuthority: () => ({ kind: "root", conversationId: null, role: null }),
+    ...(validate ? {
+      validateSpawnAdmission: async (body: Record<string, unknown>, _context?: McpToolCallContext) => {
+        const response = await executeSpawnAdmissionValidation(
+          routeRequest("/api/spawn/validate", body),
+          { registry: () => registry },
+        );
+        return await response.json() as Record<string, unknown>;
+      },
+    } : {}),
+  } as unknown as ViewerMcpDomainDependencies;
+}
+
+function routeControl(dependencies: SpawnCommandDependencies, dispatches: { count: number }): ViewerControlDependencies {
+  return {
+    post: async () => { throw new Error("unexpected non-dispatch control call"); },
+    dispatch: async (pathname, body, headers, context) => {
+      if (pathname !== "/api/spawn") throw new Error(`unexpected control path: ${pathname}`);
+      dispatches.count += 1;
+      if (context?.dispatch) context.dispatch.attempted = true;
+      const response = await executeSpawnRequest(routeRequest(pathname, body, headers), dependencies);
+      const payload = await response.json() as Record<string, unknown>;
+      if (!response.ok) {
+        throw new McpDispatchVerdictError(String(payload.error ?? "spawn refused"), {
+          status: response.status,
+          ...(typeof payload.code === "string" ? { code: payload.code } : {}),
+        });
+      }
+      return payload;
+    },
+  };
+}
+
+function service(
+  registry: AgentRegistry,
+  store: MemoryMcpReceiptStore,
+  control: ViewerControlDependencies,
+  domain: ViewerMcpDomainDependencies,
+) {
+  return createMcpToolService(
+    viewerMcpBindings(undefined, control, domain),
+    store,
+    undefined,
+    { recovery: viewerMcpRecoverableTools(domain) },
+  );
+}
+
+function spawnArgs(clientRequestId: string, cwd: string): Record<string, unknown> {
+  return {
+    clientRequestId,
+    role: "deployer",
+    roleParams: { sha: "a".repeat(40), pr: "26" },
+    cwd,
+    ["prompt"]: "launch the dev deployer",
+    title: "Rejected deployer integration",
+  };
+}
+
+test("a real post-wire HTTP 400 is fenced once and an existing stranded claim recovers without redispatch", async () => {
+  const cwd = path.join(sandbox, "launch-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+
+  const liveDispatches = { count: 0 };
+  const liveStore = new MemoryMcpReceiptStore();
+  const live = service(registry, liveStore, routeControl(spawnDependencies(registry, cwd), liveDispatches), domainDependencies(registry));
+  const liveArgs = spawnArgs("spawn_post_wire_live_1", cwd);
+  const liveAnswer = await live.callTool("spawn_agent", liveArgs);
+  expect(liveAnswer).toMatchObject({
+    ok: false,
+    code: "not_executed",
+    details: {
+      outcome: "not-executed",
+      evidence: "spawn-admission-fence",
+      nextAction: "new-request-permitted",
+    },
+  });
+  expect(liveDispatches.count).toBe(1);
+  expect(registry.readOnlySnapshot().receipts).toEqual({});
+  const liveDownstreamKey = "mcp_spawn_" + crypto.createHash("sha256").update(String(liveArgs.clientRequestId)).digest("hex");
+  expect(readSpawnAdmissionFence(liveDownstreamKey)).toMatchObject({ status: 400 });
+  expect(await live.callTool("spawn_agent", liveArgs)).toMatchObject({ ok: false, code: "not_executed", replayed: true });
+  expect(liveDispatches.count).toBe(1);
+
+  const historicalDispatches = { count: 0 };
+  const historicalStore = new MemoryMcpReceiptStore();
+  const oldControl: ViewerControlDependencies = {
+    post: async () => { throw new Error("unexpected old control call"); },
+    dispatch: async (_pathname, _body, _headers, context) => {
+      historicalDispatches.count += 1;
+      if (context?.dispatch) context.dispatch.attempted = true;
+      throw new McpDispatchVerdictError("deployer requires confirm: deploy", { status: 400 });
+    },
+  };
+  const historicalArgs = spawnArgs("spawn_post_wire_stranded_1", cwd);
+  const oldService = service(registry, historicalStore, oldControl, domainDependencies(registry, false));
+  const oldAnswer = await oldService.callTool("spawn_agent", historicalArgs);
+  expect(oldAnswer).toMatchObject({ ok: false, code: "outcome_unknown", details: { outcome: "unknown" } });
+  expect(historicalDispatches.count).toBe(1);
+  const downstreamKey = "mcp_spawn_" + crypto.createHash("sha256").update(String(historicalArgs.clientRequestId)).digest("hex");
+  const stranded = await historicalStore.lookup(`spawn_agent:${historicalArgs.clientRequestId}`);
+  expect(stranded).toMatchObject({ stage: "dispatching", result: null });
+
+  const recoveryDispatches = { count: 0 };
+  const recovered = service(
+    registry,
+    historicalStore,
+    {
+      post: async () => { throw new Error("historical recovery must not dispatch"); },
+      dispatch: async () => {
+        recoveryDispatches.count += 1;
+        throw new Error("historical recovery must not dispatch");
+      },
+    },
+    domainDependencies(registry),
+  );
+  const recoveredAnswer = await recovered.callTool("spawn_agent", { ...historicalArgs, recoveryOnly: true });
+  expect(recoveredAnswer).toMatchObject({
+    ok: false,
+    code: "not_executed",
+    replayed: true,
+    details: { outcome: "not-executed", evidence: "spawn-admission-fence" },
+  });
+  expect(recoveryDispatches.count).toBe(0);
+  const closed = await historicalStore.lookup(`spawn_agent:${historicalArgs.clientRequestId}`);
+  expect(closed).toMatchObject({ stage: "not-executed" });
+  expect(closed?.digest).toBe(stranded?.digest);
+  expect(closed?.binding).toEqual(stranded?.binding);
+  expect(registry.readOnlySnapshot().receipts).toEqual({});
+  expect(readSpawnAdmissionFence(downstreamKey)).toMatchObject({ status: 400 });
+});

--- a/src/lib/mcp/spawnRecovery.integration.test.ts
+++ b/src/lib/mcp/spawnRecovery.integration.test.ts
@@ -5,13 +5,16 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
+import { POST as spawnAdmissionPost } from "@/app/api/spawn/validate/route";
 import { executeSpawnAdmissionValidation } from "@/lib/agent/spawnAdmissionValidation";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { readSpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
+import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { executeSpawnRequest, type SpawnCommandDependencies } from "@/lib/agent/spawnCommand";
 import type { RuntimeHostClient } from "@/lib/runtime/client";
 
 import {
+  productionDomainDependencies,
   viewerMcpBindings,
   viewerMcpRecoverableTools,
   type ViewerControlDependencies,
@@ -21,11 +24,16 @@ import {
   createMcpToolService,
   McpDispatchVerdictError,
   MemoryMcpReceiptStore,
+  SqliteMcpReceiptStore,
+  type McpRecoveryReceiptStore,
+  type McpRequestBinding,
   type McpToolCallContext,
 } from "./server";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-spawn-recovery-integration-"));
 const previousStateDir = process.env.LLV_STATE_DIR;
+const previousHome = process.env.HOME;
+const previousConfigHome = process.env.XDG_CONFIG_HOME;
 const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
 const previousStructuredHosts = process.env.LLV_STRUCTURED_HOSTS;
 const previousRuntimeEvents = process.env.LLV_RUNTIME_EVENTS;
@@ -35,6 +43,8 @@ const previousCodexBinary = process.env.LLV_CODEX_BINARY;
 const codexBinary = path.join(sandbox, "codex-list");
 fs.writeFileSync(codexBinary, "#!/bin/sh\nprintf '[]'\n", { mode: 0o700 });
 process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.HOME = path.join(sandbox, "home");
+process.env.XDG_CONFIG_HOME = path.join(sandbox, "config");
 process.env.LLV_SPAWN_TRANSPORT = "structured";
 process.env.LLV_STRUCTURED_HOSTS = "1";
 process.env.LLV_RUNTIME_EVENTS = "1";
@@ -45,6 +55,10 @@ process.env.LLV_CODEX_BINARY = codexBinary;
 afterAll(() => {
   if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
   else process.env.LLV_STATE_DIR = previousStateDir;
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
+  if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = previousConfigHome;
   if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
   else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
   if (previousStructuredHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
@@ -136,7 +150,7 @@ function routeControl(dependencies: SpawnCommandDependencies, dispatches: { coun
 
 function service(
   registry: AgentRegistry,
-  store: MemoryMcpReceiptStore,
+  store: McpRecoveryReceiptStore,
   control: ViewerControlDependencies,
   domain: ViewerMcpDomainDependencies,
 ) {
@@ -186,7 +200,7 @@ test("a real post-wire HTTP 400 is fenced once and an existing stranded claim re
   expect(liveDispatches.count).toBe(1);
 
   const historicalDispatches = { count: 0 };
-  const historicalStore = new MemoryMcpReceiptStore();
+  const historicalStore = new SqliteMcpReceiptStore(path.join(sandbox, "historical-receipts.sqlite"));
   const oldControl: ViewerControlDependencies = {
     post: async () => { throw new Error("unexpected old control call"); },
     dispatch: async (_pathname, _body, _headers, context) => {
@@ -231,4 +245,55 @@ test("a real post-wire HTTP 400 is fenced once and an existing stranded claim re
   expect(closed?.binding).toEqual(stranded?.binding);
   expect(registry.readOnlySnapshot().receipts).toEqual({});
   expect(readSpawnAdmissionFence(downstreamKey)).toMatchObject({ status: 400 });
+  historicalStore.close();
+});
+
+test("production recovery probes the exported validate route over HTTP with the dispatch capability", async () => {
+  const cwd = path.join(sandbox, "http-probe-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const requests: { pathname: string; capability: string | null }[] = [];
+  const viewer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      requests.push({
+        pathname: new URL(request.url).pathname,
+        capability: request.headers.get(VIEWER_SPAWN_CAPABILITY_HEADER),
+      });
+      return spawnAdmissionPost.withDependencies(
+        new NextRequest(request),
+        { registry: () => registry },
+      );
+    },
+  });
+  const previousControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+  process.env.LLV_VIEWER_CONTROL_URL = viewer.url.origin;
+  try {
+    const args = spawnArgs("spawn_post_wire_http_1", cwd);
+    const tools = viewerMcpRecoverableTools({
+      ...productionDomainDependencies,
+      registrySnapshot: () => registry.readOnlySnapshot(),
+      attentionAuthority: () => ({ kind: "root", conversationId: null, role: null }),
+      recoveryPredecessors: () => [],
+    });
+    const bindingInput = await tools.spawn_agent!.bind(args);
+    const binding: McpRequestBinding = {
+      ...bindingInput,
+      version: 1,
+      toolName: "spawn_agent",
+      clientRequestId: String(args.clientRequestId),
+      owner: { pid: process.pid, startIdentity: null },
+      claimedAt: new Date().toISOString(),
+    };
+    const recovered = await tools.spawn_agent!.recover(binding, { legacy: false, args });
+    expect(recovered).toMatchObject({ outcome: "not-executed", evidence: "spawn-admission-fence" });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ pathname: "/api/spawn/validate", capability: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) });
+    expect(readSpawnAdmissionFence(binding.downstreamKey)).toMatchObject({ status: 400 });
+  } finally {
+    viewer.stop(true);
+    if (previousControlUrl === undefined) delete process.env.LLV_VIEWER_CONTROL_URL;
+    else process.env.LLV_VIEWER_CONTROL_URL = previousControlUrl;
+  }
 });

--- a/src/lib/mcp/spawnRecovery.integration.test.ts
+++ b/src/lib/mcp/spawnRecovery.integration.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
-import { executeSpawnAdmissionValidation } from "@/app/api/spawn/validate/route";
+import { executeSpawnAdmissionValidation } from "@/lib/agent/spawnAdmissionValidation";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { readSpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
 import { executeSpawnRequest, type SpawnCommandDependencies } from "@/lib/agent/spawnCommand";


### PR DESCRIPTION
## Summary

- Persist exact request-bound spawn admission fences under the shared mutation lock.
- Settle live post-wire validation refusals and recover existing stranded claims only after the durable fence is verified.
- Preserve unknown for bare refusals, uncertain transport, unreadable evidence, and roleless requests.
- Allow recovery by server-derived same-project designated successor lineage while refusing unrelated and cross-project callers.

## Safety

An existing downstream launch wins over a refusal. A changed body cannot reuse a fence. The original MCP digest, payload, and caller binding remain unchanged, and recovery never redispatches the spawn.

Issue: https://github.com/Latand/live-log-viewer-next/issues/1582

## Verification

- Production build: passed
- MCP server: 76 passed
- MCP bindings: 60 passed
- Spawn route: 57 passed
- Validation route: 4 passed
- Causal post-wire and stranded-row integration: 1 passed
- Stdio integration: 30 passed
- TypeScript check: passed
- Privacy publication gate: passed
- PR CI at `195a0cc8e456d0260e032aa708589b8a8becd2ba`: all required checks passed
