### PR TITLE
fix(turn-state): release completed Codex continuations after restart (#1589)

### DIFF
--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -101,6 +101,45 @@ test("a Codex abort closes the turn and ignores late tool output", () => {
   });
 });
 
+test("a prefix-truncated Codex window whose only tool evidence is an unmatched output stays busy", () => {
+  /* The 128 KiB tail window of a long rollout: the `function_call` sits above
+     the window and only its oversized output survives, so nothing in the
+     window is a terminal boundary. Reading this as `unknown` would let the
+     engine settle a running stage on a mid-turn message. */
+  const records = [
+    { type: "response_item", timestamp: "2026-09-09T07:00:00.000Z", payload: { type: "custom_tool_call_output", call_id: "call-above-the-window", output: "x" } },
+    { type: "event_msg", timestamp: "2026-09-09T07:00:01.000Z", payload: { type: "agent_message", message: "interim progress" } },
+    { type: "event_msg", timestamp: "2026-09-09T07:00:02.000Z", payload: { type: "token_count" } },
+  ];
+
+  expect(turnStateFromRecords(records, "codex")).toEqual({
+    state: "busy",
+    source: "lifecycle",
+    terminalAt: null,
+  });
+
+  /* An anonymous unmatched output before any boundary is the same shape. */
+  expect(turnStateFromRecords([
+    { type: "response_item", timestamp: "2026-09-09T07:10:00.000Z", payload: { type: "function_call_output", output: "x" } },
+  ], "codex").state).toBe("busy");
+});
+
+test("a truncated window that later reaches its own terminal boundary is terminal", () => {
+  /* The unmatched output must not become a second kind of open tool: it holds
+     the turn open only until this window shows the turn ending. */
+  const records = [
+    { type: "response_item", timestamp: "2026-09-09T07:20:00.000Z", payload: { type: "custom_tool_call_output", call_id: "call-above-the-window", output: "x" } },
+    { type: "event_msg", timestamp: "2026-09-09T07:20:01.000Z", payload: { type: "agent_message", message: "finished" } },
+    { type: "event_msg", timestamp: "2026-09-09T07:20:02.000Z", payload: { type: "task_complete", turn_id: "windowed-turn" } },
+  ];
+
+  expect(turnStateFromRecords(records, "codex")).toEqual({
+    state: "terminal",
+    source: "lifecycle",
+    terminalAt: "2026-09-09T07:20:02.000Z",
+  });
+});
+
 test("late and duplicate Codex tool output cannot reopen a terminal turn", () => {
   const records = [
     { type: "event_msg", timestamp: "2026-09-09T06:10:00.000Z", payload: { type: "task_started", turn_id: "finished-turn" } },

--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -71,6 +71,51 @@ test("later work after a terminal event reopens the Codex turn", () => {
   expect(turnStateFromRecords(records, "codex").state).toBe("busy");
 });
 
+test("issue 1589 clears a cut-off tool ledger at the next Codex turn boundary", () => {
+  const records = [
+    { type: "response_item", timestamp: "2026-09-09T05:36:42.000Z", payload: { type: "function_call", call_id: "old-tool" } },
+    { type: "event_msg", timestamp: "2026-09-09T05:38:44.000Z", payload: { type: "task_started", turn_id: "continued-turn" } },
+    { type: "event_msg", timestamp: "2026-09-09T05:40:17.000Z", payload: { type: "agent_message", message: "finished" } },
+    { type: "event_msg", timestamp: "2026-09-09T05:40:18.000Z", payload: { type: "task_complete", turn_id: "continued-turn" } },
+  ];
+
+  expect(turnStateFromRecords(records, "codex")).toEqual({
+    state: "terminal",
+    source: "lifecycle",
+    terminalAt: "2026-09-09T05:40:18.000Z",
+  });
+});
+
+test("a Codex abort closes the turn and ignores late tool output", () => {
+  const records = [
+    { type: "event_msg", timestamp: "2026-09-09T06:00:00.000Z", payload: { type: "task_started", turn_id: "aborted-turn" } },
+    { type: "response_item", timestamp: "2026-09-09T06:00:01.000Z", payload: { type: "function_call", call_id: "aborted-tool" } },
+    { type: "event_msg", timestamp: "2026-09-09T06:00:02.000Z", payload: { type: "turn_aborted", turn_id: "aborted-turn" } },
+    { type: "response_item", timestamp: "2026-09-09T06:00:03.000Z", payload: { type: "function_call_output", call_id: "aborted-tool" } },
+  ];
+
+  expect(turnStateFromRecords(records, "codex")).toEqual({
+    state: "terminal",
+    source: "lifecycle",
+    terminalAt: "2026-09-09T06:00:02.000Z",
+  });
+});
+
+test("late and duplicate Codex tool output cannot reopen a terminal turn", () => {
+  const records = [
+    { type: "event_msg", timestamp: "2026-09-09T06:10:00.000Z", payload: { type: "task_started", turn_id: "finished-turn" } },
+    { type: "event_msg", timestamp: "2026-09-09T06:10:01.000Z", payload: { type: "task_complete", turn_id: "finished-turn" } },
+    { type: "response_item", timestamp: "2026-09-09T06:10:02.000Z", payload: { type: "function_call_output", call_id: "late-tool" } },
+    { type: "response_item", timestamp: "2026-09-09T06:10:03.000Z", payload: { type: "function_call_output", call_id: "late-tool" } },
+  ];
+
+  expect(turnStateFromRecords(records, "codex")).toEqual({
+    state: "terminal",
+    source: "lifecycle",
+    terminalAt: "2026-09-09T06:10:01.000Z",
+  });
+});
+
 test("Claude migration waits for a top-level result event", () => {
   const assistant = {
     type: "assistant",

--- a/src/lib/accounts/migration/turnState.ts
+++ b/src/lib/accounts/migration/turnState.ts
@@ -136,12 +136,28 @@ export function turnStateFromRecords(records: RecordLike[], engine: TranscriptEn
       const type = stringValue(payload.type);
       if (!type) continue;
       if (type === "task_started" || type === "turn_started" || type === "user_message") {
+        /* A re-hosted continuation starts a fresh provider turn. Tool calls
+           from the interrupted turn have no future output, so carrying them
+           forward would make every later completion look premature. */
+        openTools.clear();
+        anonymousTools = 0;
         turnOpen = true;
         terminalAt = null;
         terminalSeen = false;
         continue;
       }
-      if (type === "task_complete" || type === "turn_complete" || type === "turn_completed" || type === "turn_aborted") {
+      if (type === "turn_aborted") {
+        /* Abort is itself the terminal boundary. Any tools still in the
+           ledger belong to the aborted turn and late results must not reopen
+           it or affect a later turn. */
+        openTools.clear();
+        anonymousTools = 0;
+        turnOpen = false;
+        terminalAt = timestamp(record);
+        terminalSeen = true;
+        continue;
+      }
+      if (type === "task_complete" || type === "turn_complete" || type === "turn_completed") {
         if (openTools.size === 0 && anonymousTools === 0) {
           turnOpen = false;
           terminalAt = timestamp(record);
@@ -160,8 +176,9 @@ export function turnStateFromRecords(records: RecordLike[], engine: TranscriptEn
       if (!isTool) continue;
       const id = stringValue(payload.call_id) ?? stringValue(payload.callId) ?? stringValue(payload.id);
       if (isOutput) {
-        if (id) openTools.delete(id);
-        else if (anonymousTools > 0) anonymousTools -= 1;
+        const matched = id ? openTools.delete(id) : anonymousTools > 0;
+        if (!matched) continue;
+        if (!id) anonymousTools -= 1;
       } else if (id) {
         openTools.add(id);
       } else {

--- a/src/lib/accounts/migration/turnState.ts
+++ b/src/lib/accounts/migration/turnState.ts
@@ -138,7 +138,21 @@ export function turnStateFromRecords(records: RecordLike[], engine: TranscriptEn
       if (type === "task_started" || type === "turn_started" || type === "user_message") {
         /* A re-hosted continuation starts a fresh provider turn. Tool calls
            from the interrupted turn have no future output, so carrying them
-           forward would make every later completion look premature. */
+           forward would make every later completion look premature.
+
+           `user_message` is in this set deliberately, and it OVERRIDES
+           `docs/design/pipeline-account-contention.md` §4.4 (shipping on a
+           separate branch), which carved it out on the premise that a steer
+           mid-turn must not drop the turn's own tools. Measured over the
+           August rollouts (967 files), a `user_message` arrives 55 times in 5
+           files while a named tool is outstanding, and of the 506 calls
+           outstanding at those steers, 0 were ever answered anywhere later in
+           the same file. A steer abandons the in-flight call, so carrying it
+           forward reproduces exactly the #1589 poisoning. Replaying both
+           shapes over the 128 KiB tail of 4,906 readable rollouts, clearing
+           here changes no final-tail verdict, so this is about keeping one
+           rule at every turn boundary rather than one that holds only for
+           restarts. */
         openTools.clear();
         anonymousTools = 0;
         turnOpen = true;
@@ -177,8 +191,17 @@ export function turnStateFromRecords(records: RecordLike[], engine: TranscriptEn
       const id = stringValue(payload.call_id) ?? stringValue(payload.callId) ?? stringValue(payload.id);
       if (isOutput) {
         const matched = id ? openTools.delete(id) : anonymousTools > 0;
-        if (!matched) continue;
-        if (!id) anonymousTools -= 1;
+        /* An unmatched output is only ignorable AFTER a terminal boundary,
+           where it is late or duplicate evidence for a turn that already
+           closed. Before any boundary it is the opposite: the tail window is
+           128 KiB of a longer file, so an output whose call sits above the
+           window is the only proof a turn is in flight. Dropping it there
+           projects `unknown` over a mid-turn transcript, and the engine's
+           settlement gate (`pipelines/engine.ts`, the pane-less `busy` return)
+           stops firing — a recovered idle host could then settle the attempt on
+           a mid-turn message. */
+        if (!matched && terminalSeen) continue;
+        if (matched && !id) anonymousTools -= 1;
       } else if (id) {
         openTools.add(id);
       } else {

--- a/src/lib/lifecycle/liveness.test.ts
+++ b/src/lib/lifecycle/liveness.test.ts
@@ -340,6 +340,39 @@ test("a live agent deep in a tool stretch is running: freshness is the newest RE
   expect(snapshot.stalledCount).toBe(0);
 });
 
+test("a Codex turn re-hosted after a severed tool call reports turnState idle (#1589)", async () => {
+  const dir = sandbox();
+  const agentPath = path.join(dir, "session-rehosted.jsonl");
+  const rows = [
+    { type: "response_item", timestamp: new Date(NOW - 240_000).toISOString(), payload: { type: "function_call", call_id: "cut-off-by-the-restart" } },
+    { type: "event_msg", timestamp: new Date(NOW - 120_000).toISOString(), payload: { type: "task_started", turn_id: "continued-turn" } },
+    { type: "event_msg", timestamp: new Date(NOW - 31_000).toISOString(), payload: { type: "agent_message", message: "finished" } },
+    { type: "event_msg", timestamp: new Date(NOW - 30_000).toISOString(), payload: { type: "task_complete", turn_id: "continued-turn" } },
+  ];
+  fs.writeFileSync(agentPath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n", "utf8");
+
+  /* The production evidence path, read for real: the severed call used to keep
+     this turn `busy` forever, which is what `agent_activity` reported while the
+     stage sat stranded. */
+  const evidence = await readLivenessTranscriptEvidence("codex", agentPath);
+  expect(evidence).toMatchObject({ turn: "idle", lastRecordTs: NOW - 30_000 });
+
+  const registry = {
+    entries: { "codex:session-rehosted": structuredEntry(agentPath, 4243) },
+    conversations: {},
+  } as unknown as RegistryFile;
+  const snapshot = await agentLivenessSnapshot({}, sources({
+    probe: { now: () => NOW, pidAlive: () => true, processIdentity: () => "start-token-of-a-dead-host" },
+    listFiles: async () => [fileEntry({ path: agentPath, mtime: (NOW - 30_000) / 1000 })],
+    registrySnapshot: () => registry,
+    pipelines: () => [],
+    transcriptEvidence: readLivenessTranscriptEvidence,
+  }));
+
+  expect(snapshot.conversations[0]).toMatchObject({ turnState: "idle", lifecycle: "waiting", reason: "host_alive_turn_idle" });
+  expect(snapshot.stalledCount).toBe(0);
+});
+
 test("a single-conversation query does no inventory sweep and reads the tail once (#645)", async () => {
   const agentPath = "/transcripts/named-session.jsonl";
   const described: string[] = [];

--- a/src/lib/pipelines/durableEvidence.test.ts
+++ b/src/lib/pipelines/durableEvidence.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { readStableTailRecords } from "@/lib/scanner/activity";
+
 import { durableStageTurnEvidence } from "./durableEvidence";
 
 const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-durable-evidence-"));
@@ -102,6 +104,34 @@ test("a re-hosted Codex continuation settles after a tool call cut off in the pr
 
   expect(await durableStageTurnEvidence("codex", file)).toMatchObject({
     turn: "terminal",
+    message: { text: PASS_TEXT },
+  });
+});
+
+test("a Codex tail window truncated above its own function_call stays busy (#1589)", async () => {
+  /* The real shape behind the guard: a rollout whose single tool output is
+     large enough that the 128 KiB window starts inside it, so the matching
+     `function_call` is above the window and no boundary is visible. The last
+     agent message parses as a verdict, so `unknown` here would hand the engine
+     a settlement candidate over a transcript that is still mid-turn. */
+  const file = path.join(dir, "codex-truncated-tool-output.jsonl");
+  const rows = [
+    JSON.stringify({ timestamp: "2026-09-09T07:30:00.000Z", type: "response_item", payload: { type: "function_call", call_id: "oversized" } }),
+    /* Bulk that pushes the call out of the window; the read starts inside it. */
+    JSON.stringify({ timestamp: "2026-09-09T07:30:01.000Z", type: "event_msg", payload: { type: "agent_reasoning", text: "r".repeat(200_000) } }),
+    JSON.stringify({ timestamp: "2026-09-09T07:30:02.000Z", type: "event_msg", payload: { type: "agent_message", message: PASS_TEXT } }),
+    JSON.stringify({ timestamp: "2026-09-09T07:30:03.000Z", type: "response_item", payload: { type: "custom_tool_call_output", call_id: "oversized", output: "x".repeat(40_000) } }),
+    JSON.stringify({ timestamp: "2026-09-09T07:30:04.000Z", type: "event_msg", payload: { type: "token_count" } }),
+  ];
+  fs.writeFileSync(file, rows.join("\n") + "\n", "utf8");
+
+  const read = await readStableTailRecords(file);
+  expect(read).toMatchObject({ integrity: "complete", prefixTruncated: true });
+  expect(read.records.map((record) => (record.payload as { type: string }).type))
+    .toEqual(["agent_message", "custom_tool_call_output", "token_count"]);
+
+  expect(await durableStageTurnEvidence("codex", file)).toMatchObject({
+    turn: "busy",
     message: { text: PASS_TEXT },
   });
 });

--- a/src/lib/pipelines/durableEvidence.test.ts
+++ b/src/lib/pipelines/durableEvidence.test.ts
@@ -92,6 +92,20 @@ test("a Codex task_complete transcript yields terminal evidence with the final a
   expect(evidence!.message!.ts).toBe(Date.parse("2026-07-18T11:05:00.000Z"));
 });
 
+test("a re-hosted Codex continuation settles after a tool call cut off in the prior turn (#1589)", async () => {
+  const file = writeTranscript("codex-rehosted-continuation.jsonl", [
+    { timestamp: "2026-09-09T05:36:42.000Z", type: "response_item", payload: { type: "function_call", call_id: "old-tool" } },
+    { timestamp: "2026-09-09T05:38:44.000Z", type: "event_msg", payload: { type: "task_started", turn_id: "continued-turn" } },
+    { timestamp: "2026-09-09T05:40:17.000Z", type: "event_msg", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-09-09T05:40:18.000Z", type: "event_msg", payload: { type: "task_complete", turn_id: "continued-turn", last_agent_message: PASS_TEXT } },
+  ]);
+
+  expect(await durableStageTurnEvidence("codex", file)).toMatchObject({
+    turn: "terminal",
+    message: { text: PASS_TEXT },
+  });
+});
+
 test("a Codex turn with an open tool call is busy", async () => {
   const file = writeTranscript("codex-busy.jsonl", [
     { timestamp: "2026-07-18T11:00:00.000Z", payload: { type: "task_started" } },

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -6209,6 +6209,92 @@ function readFixtures(h: ReturnType<typeof harness>, fixtures: Record<string, st
   };
 }
 
+/** The #1589 production tail, in the order the incident wrote it: a
+    `function_call` the deploy cut off mid-flight, the standing continuation
+    prompt startup delivered, and the re-hosted turn that finished with a
+    fenced verdict. */
+function severedToolTranscript(name: string): string {
+  return stageTranscript(name, [
+    { timestamp: "2026-09-09T05:36:42.000Z", type: "response_item", payload: { type: "function_call", call_id: "cut-off-by-the-restart" } },
+    { timestamp: "2026-09-09T05:38:44.000Z", type: "event_msg", payload: { type: "user_message", message: "Continue the interrupted turn from the transcript." } },
+    { timestamp: "2026-09-09T05:38:45.000Z", type: "event_msg", payload: { type: "task_started", turn_id: "continued-turn" } },
+    { timestamp: "2026-09-09T05:40:17.000Z", type: "event_msg", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-09-09T05:40:18.000Z", type: "event_msg", payload: { type: "task_complete", turn_id: "continued-turn" } },
+  ]);
+}
+
+/** A tail window that begins inside an oversized tool output, so the matching
+    `function_call` and every lifecycle boundary sit above it. Everything the
+    engine can see is mid-turn — including a message that parses as a verdict. */
+function truncatedMidTurnTranscript(name: string): string {
+  return stageTranscript(name, [
+    { timestamp: "2026-09-09T08:00:00.000Z", type: "response_item", payload: { type: "function_call", call_id: "oversized" } },
+    { timestamp: "2026-09-09T08:00:01.000Z", type: "event_msg", payload: { type: "agent_reasoning", text: "r".repeat(200_000) } },
+    { timestamp: "2026-09-09T08:00:02.000Z", type: "event_msg", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-09-09T08:00:03.000Z", type: "response_item", payload: { type: "custom_tool_call_output", call_id: "oversized", output: "x".repeat(40_000) } },
+    { timestamp: "2026-09-09T08:00:04.000Z", type: "event_msg", payload: { type: "token_count" } },
+  ]);
+}
+
+test("a re-hosted Codex continuation settles once and activates the next stage exactly once (#1589)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  h.setConversationActive(false);
+  /* Through the real projection over the real fixture, so the assertion fails
+     for the reason the incident had rather than for a hand-shaped map entry. */
+  readFixtures(h, { "/codex/stage-1.jsonl": severedToolTranscript("issue-1589-severed-tool") });
+
+  await tickPipelines([], h.ports);
+
+  const settled = loadPipelines()[0]!;
+  expect(settled.runs[0]!.attempts).toHaveLength(1);
+  expect(settled.runs[0]!.attempts[0]).toMatchObject({
+    state: "passed",
+    verdict: { status: "pass", confidence: 0.9 },
+  });
+  /* No recovery misses were spent, so nothing asked the operator anything. */
+  expect(settled.runs[0]!.attempts[0]!.verdictRecovery).toBeUndefined();
+  expect(settled).toMatchObject({ state: "running", stateDetail: null });
+  expect(settled.cursor).toMatchObject({ stageId: "build", state: "pending" });
+  expect(settled.lastPassedCommit).toBe(STAGE_HEAD);
+
+  await tickPipelines([], h.ports);
+
+  const advanced = loadPipelines()[0]!;
+  expect(advanced.runs[1]!.attempts).toHaveLength(1);
+  expect(h.calls.filter((call) => call.startsWith("spawn:"))).toHaveLength(2);
+
+  /* A third tick is the exactly-once check: no second settlement, no second
+     attempt on either stage, no second spawn. */
+  await tickPipelines([], h.ports);
+
+  const stable = loadPipelines()[0]!;
+  expect(stable.runs[0]!.attempts).toHaveLength(1);
+  expect(stable.runs[1]!.attempts).toHaveLength(1);
+  expect(h.calls.filter((call) => call.startsWith("spawn:"))).toHaveLength(2);
+  expect(stable).toMatchObject({ state: "running", stateDetail: null });
+});
+
+test("a truncated mid-turn window cannot settle a structured stage on its trailing message (#1589)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  h.setConversationActive(false);
+  readFixtures(h, { "/codex/stage-1.jsonl": truncatedMidTurnTranscript("issue-1589-truncated-mid-turn") });
+
+  /* The scan does have the transcript and its trailing message parses as a
+     verdict; only the busy turn projection stands between them and a
+     settlement over work that is still running. */
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  const current = loadPipelines()[0]!;
+  expect(current.runs[0]!.attempts).toHaveLength(1);
+  expect(current.runs[0]!.attempts[0]).toMatchObject({ state: "running", completedAt: null });
+  expect(current.runs[1]!.attempts).toHaveLength(0);
+  expect(current.cursor?.stageId).toBe("plan");
+  expect(h.calls.filter((call) => call.startsWith("spawn:"))).toHaveLength(1);
+});
+
 function usageLimitPorts(
   h: ReturnType<typeof harness>,
   resolution: ReturnType<typeof accountManager.resolveProjectSpawn>,

--- a/src/lib/scanner/activity.test.ts
+++ b/src/lib/scanner/activity.test.ts
@@ -129,6 +129,50 @@ describe("turnStateFromRecords (codex)", () => {
     const records = [payload("task_complete"), payload("token_count"), payload("reasoning")];
     expect(turnStateFromRecords(records, "codex")).toBe("done");
   });
+
+  test("a tool call cut off before the continuation turn no longer holds the projection open (#1589)", () => {
+    /* The incident tail: a function_call the restart severed, then the
+       re-hosted continuation's own completed turn. `agent_activity` reads
+       turnState off this same projection, so `done` here is what makes it
+       report idle instead of a stage that never settles. */
+    const pathname = path.join(sandbox, "codex-rehosted-continuation.jsonl");
+    const records = [
+      { type: "response_item", timestamp: "2026-09-09T05:36:42.000Z", payload: { type: "function_call", call_id: "cut-off-by-the-restart" } },
+      { type: "event_msg", timestamp: "2026-09-09T05:38:45.000Z", payload: { type: "task_started", turn_id: "continued-turn" } },
+      { type: "event_msg", timestamp: "2026-09-09T05:40:17.000Z", payload: { type: "agent_message", message: "finished" } },
+      { type: "event_msg", timestamp: "2026-09-09T05:40:18.000Z", payload: { type: "task_complete", turn_id: "continued-turn" } },
+    ];
+    fs.writeFileSync(pathname, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+    const aged = Date.now() / 1000 - 3_600;
+    fs.utimesSync(pathname, aged, aged);
+    const stat = fs.statSync(pathname);
+
+    expect(turnStateFromRecords(records, "codex")).toBe("done");
+    expect(activityVerdict("codex-sessions", pathname, stat.mtimeMs / 1000, stat.size)).toMatchObject({
+      state: "idle",
+      reason: "jsonl_turn_completed",
+      complete: true,
+    });
+  });
+
+  test("a truncated window whose only tool evidence is an unmatched output stays open (#1589)", () => {
+    /* The other half of the same guard: nothing in this window is a boundary,
+       so the projection must keep the turn open rather than fall through to
+       the mtime heuristics. */
+    const pathname = path.join(sandbox, "codex-truncated-tool-output.jsonl");
+    const records = [
+      { type: "response_item", timestamp: "2026-09-09T07:00:00.000Z", payload: { type: "custom_tool_call_output", call_id: "call-above-the-window", output: "x" } },
+      { type: "event_msg", timestamp: "2026-09-09T07:00:01.000Z", payload: { type: "token_count" } },
+    ];
+    fs.writeFileSync(pathname, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+    const stat = fs.statSync(pathname);
+
+    expect(turnStateFromRecords(records, "codex")).toBe("busy");
+    expect(activityVerdict("codex-sessions", pathname, stat.mtimeMs / 1000, stat.size)).toMatchObject({
+      state: "live",
+      reason: "jsonl_turn_open",
+    });
+  });
 });
 
 describe("readStableTailRecords", () => {


### PR DESCRIPTION
## Summary

- Reset the Codex tool ledger at `task_started`, `turn_started`, and `user_message` boundaries so a re-hosted continuation starts with its own evidence.
- Treat `turn_aborted` as a terminal lifecycle boundary and clear its abandoned tools.
- Ignore an unmatched tool output **only after a terminal boundary has been seen**, so a late or duplicate output cannot reopen a closed turn while a prefix-truncated window with no boundary keeps projecting `busy`.
- Add pure turn-state, durable-evidence, engine, scanner-activity, and liveness regressions for issue #1589.

## Review repair (round 2)

Three findings were raised at `bb58968cdbc281f5ca80f48bc6e771596ca23c01`. All three are addressed here.

### 1 (MEDIUM, blocker) — unmatched outputs no longer punch a hole in the mid-turn guard

`if (!matched) continue` skipped the `turnOpen = true` that every tool record used to set, so a 128 KiB tail window whose `function_call` sits above the window projected `unknown` instead of `busy`. The skip is now gated on `terminalSeen`.

Causally proven, not asserted:

| Case | at `bb58968c` | after this change |
| --- | --- | --- |
| `turnState.test.ts` — prefix-truncated window, unmatched output only | RED (`unknown`/`empty`) | green (`busy`/`lifecycle`) |
| `durableEvidence.test.ts` — tail window that starts inside an oversized output | RED | green (`turn: "busy"`) |
| `engine.test.ts` — structured stage over that window, trailing message parses as a verdict | RED: **the attempt settled `passed` and the stage advanced on mid-turn evidence** | green: attempt stays `running`, next stage has 0 attempts, 1 spawn total |
| `activity.test.ts` — same window through `activityVerdict` | RED | green (`live` / `jsonl_turn_open`) |
| existing "late and duplicate Codex tool output cannot reopen a terminal turn" | green | green (untouched) |

The engine row is the finding's own failure scenario reproduced end to end: at the reviewed head the truncated mid-turn transcript really did settle the attempt.

**Observed-scale replay.** Both projections replayed over the same 128 KiB tail window production reads (`readStableTailRecords`), across every Codex rollout under the 2026 sessions tree — 4,907 discovered, 4,906 with a complete tail read, 1 racing:

| Comparison | Result |
| --- | --- |
| base `bf60e71d` → reviewed head `bb58968c` | `busy → terminal` **62**, `busy → unknown` **1** |
| base `bf60e71d` → this head | `busy → terminal` **62**, `busy → unknown` **0** |
| reviewed head `bb58968c` → this head | `unknown → busy` **1** (exactly the regression, reverted) |

The replay emitted counts only; no transcript path or content left the script, and nothing was written to the corpus.

### 2 (LOW) — the `user_message` override is now on the record, with first-hand evidence

The behaviour is kept and the reasoning is now in the code at the boundary that implements it. `docs/design/pipeline-account-contention.md` §4.4 carved `user_message` out on the premise that "a steer mid-turn must not drop the turn's own tools"; the corpus refutes that premise. Measured directly over the August rollouts (967 files):

- a `user_message` arrives **55 times in 5 files** while a named tool call is outstanding;
- of the **506** calls outstanding at those steers, **0** were ever answered anywhere later in the same file.

So a steer abandons the in-flight call, and carrying it forward reproduces the #1589 poisoning. Replaying the design-shaped projection (clear at `task_started`/`turn_started` only, `user_message` reopens without clearing) against this head over all 4,906 readable tails gives **no change in any final-tail verdict** — the override is about keeping one rule at every turn boundary, not a behavioural divergence.

**Release-coordination item, disclosed rather than silently deferred:** §4.4 itself lives on the #1591 branch, which already carries an exact-head approval. Amending it from here would either duplicate that file or invalidate that approval, so the one-line amendment belongs to #1591 before or with its merge. Suggested replacement for the §4.4 sentence: *"`user_message` clears the ledger with the other turn boundaries: measured over the rollout corpus, a steer abandons the outstanding call rather than keeping it."* Until that lands, the authoritative record of the rule is the comment at the code, and this note.

### 3 (LOW) — #1589's acceptance bullets 3 and 4 are now covered by named tests

| #1589 acceptance | Covering test | RED at base `bf60e71d` |
| --- | --- | --- |
| pure `turnStateFromRecords` red case | `turnState.test.ts` — "issue 1589 clears a cut-off tool ledger at the next Codex turn boundary" | yes |
| `durableStageTurnEvidence` returns `turn: "terminal"` | `durableEvidence.test.ts` — "a re-hosted Codex continuation settles after a tool call cut off in the prior turn" | yes |
| settles once, spawns the next stage exactly once, no operator message | `engine.test.ts` — "a re-hosted Codex continuation settles once and activates the next stage exactly once" | yes |
| `agent_activity` reports `turnState: idle` | `liveness.test.ts` — "a Codex turn re-hosted after a severed tool call reports turnState idle" (through the real `readLivenessTranscriptEvidence`), plus `activity.test.ts` on the scan projection | yes |
| existing same-turn open-tool guard stays busy | `turnState.test.ts:31` — untouched | n/a |

The engine case runs through the real `durableStageTurnEvidence` over a fixture transcript, not the harness `durableTurns` map, so it fails for the incident's own reason. It asserts one settlement, exactly one next-stage attempt across a second tick, no second spawn on a third tick, and no verdict-recovery check spent — nothing the operator would have to answer.

No engine behaviour changed: `pipelines/engine.ts` is untouched, and only its test file gained cases.

## Gates at this head

- Focused suites, one file per invocation under an isolated `HOME`/`XDG_*`/`LLV_STATE_DIR`/`TMPDIR` and isolated provider homes: `turnState` + `durableEvidence` + `activity` + `liveness` **121 pass / 0 fail**; `engine.test.ts` **233 pass / 0 fail**; `startup.test.ts` **87 pass / 0 fail**; `flows/decisions.test.ts` **25 pass / 0 fail**.
  - Running `startup.test.ts` and `decisions.test.ts` in one `bun test` invocation reports 5 failures; each file is green alone. That is the known cross-file `mock.module` leak, reproducible at the base, and unrelated to this change.
- `bunx tsc --noEmit --pretty false --incremental false` — exit 0.
- `bun scripts/privacy-publication-gate.ts --base <merge-base> --check-commits` — PASS.

## Scope

Limited to `src/lib/accounts/migration/turnState.ts` and test files: `turnState.test.ts`, `pipelines/durableEvidence.test.ts`, `pipelines/engine.test.ts`, `scanner/activity.test.ts`, `lifecycle/liveness.test.ts`. No product source outside `turnState.ts`.

The repair commits were authored on the successor lane branch `pipeline/repair-truncated-turn-safety-pr1592-revi-30638557` and pushed to this PR's existing head branch `pipeline/fix-completed-turns-stranded-as-busy-iss-4f6eaf4d`; both point at the same commits, and the original lane's history is preserved untouched below them.

The engine contention repair in [#1591](https://github.com/Latand/live-log-viewer-next/pull/1591), the quota-verdict case in [#1459](https://github.com/Latand/live-log-viewer-next/issues/1459), and object-shaped findings in [#1469](https://github.com/Latand/live-log-viewer-next/issues/1469) remain outside this change. The open Grok work in [#1250](https://github.com/Latand/live-log-viewer-next/pull/1250) remains separate.

Fixes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
