### PR TITLE
fix(accounts): stop dead pinned receipts from blocking account removal

### DIFF
--- a/src/lib/accounts/removal.test.ts
+++ b/src/lib/accounts/removal.test.ts
@@ -302,6 +302,20 @@ test("an aged queued pin blocks every account until its durable receipt settles"
   expect(accountRemovalBlockers("claude", "other", DAYS_LATER)).toEqual(["live_sessions"]);
 });
 
+/* Production shape of issue #1595: launch receipts pinned to an account, left
+   in `starting` by pipelines that ended days ago — no pane, no admission owner,
+   no verified host — and carrying no queued pin to actuate later. A pin records
+   which account a launch would have used; it is not evidence that anything is
+   running, so it may not outlive the launch it belonged to. */
+test("dead pinned receipts block neither their own account nor any other (issue #1595)", () => {
+  const store = registry();
+  const own = beginLegacySpawnFixture(store, { engine: "codex", cwd: "/repo", accountId: "other", accountPin: true });
+  if (own.kind !== "created") throw new Error("expected a launch receipt");
+
+  expect(accountRemovalBlockers("codex", "work", DAYS_LATER)).toEqual([]);
+  expect(accountRemovalBlockers("codex", "other", DAYS_LATER)).toEqual([]);
+});
+
 test("dead history plus stale starting entries and receipts no longer block removal (issue #643)", () => {
   const store = registry();
   // Production shape: ~dozens of historical conversations whose latest generation

--- a/src/lib/accounts/removal.test.ts
+++ b/src/lib/accounts/removal.test.ts
@@ -316,6 +316,20 @@ test("dead pinned receipts block neither their own account nor any other (issue 
   expect(accountRemovalBlockers("codex", "other", DAYS_LATER)).toEqual([]);
 });
 
+/* The opposite guard of the case above. Dropping the probe-free pin claim may
+   not cost a pinned launch its blocker while that launch is still real: inside
+   the unproven-launch grace the fall-through to `receiptIsLive` must keep
+   blocking the account the pin names — and only that account. Turning the
+   fall-through into a `continue` would make removal race a live launch. */
+test("a pinned receipt still inside its launch blocks the account it names, and only that one", () => {
+  const store = registry();
+  const begun = beginLegacySpawnFixture(store, { engine: "codex", cwd: "/repo", accountId: "work", accountPin: true });
+  if (begun.kind !== "created") throw new Error("expected a launch receipt");
+
+  expect(accountRemovalBlockers("codex", "work")).toEqual(["live_sessions"]);
+  expect(accountRemovalBlockers("codex", "other")).toEqual([]);
+});
+
 test("dead history plus stale starting entries and receipts no longer block removal (issue #643)", () => {
   const store = registry();
   // Production shape: ~dozens of historical conversations whose latest generation

--- a/src/lib/agent/accountLiveness.ts
+++ b/src/lib/agent/accountLiveness.ts
@@ -234,8 +234,16 @@ export function accountHasLiveSessions(
     if (entryIsLive(entry, probe)) return true;
   }
   for (const receipt of Object.values(file.receipts)) {
-    if (receipt.engine !== engine || !owned(receipt.accountId) && receipt.accountPin !== true) continue;
-    if (receipt.accountPin === true && OPEN_RECEIPT_STATES.has(receipt.state)) return true;
+    /* A pin that is still queued for account capacity is durable in-flight work
+       with nothing to probe yet: it will actuate on the account it names, so it
+       outranks liveness until its receipt settles. A pin WITHOUT a queued spawn
+       records only which account a launch would have used — it is no evidence
+       that anything runs, and treating it as such let receipts abandoned in an
+       open state weeks ago block removal for ever, on their own account and on
+       every other account of the engine (issue #1595). */
+    const queuedPin = receipt.accountPin === true && receipt.queuedPinnedSpawn !== null;
+    if (receipt.engine !== engine || !owned(receipt.accountId) && !queuedPin) continue;
+    if (queuedPin && OPEN_RECEIPT_STATES.has(receipt.state)) return true;
     if (receiptIsLive(file, receipt, probe)) return true;
   }
   return false;


### PR DESCRIPTION
Closes #1595.

## What was broken

Removing a managed Codex account whose device sign-in had failed did nothing. `Remove` → `Confirm` closed the bar and the row stayed. `DELETE /api/accounts/codex` answered `409 account_removal_blocked` with `blockers: ["live_sessions"]`, and the panel reported "still has an active session or sign-in" — for an account with `authPresent: false`, `auth.state: "signed_out"`, `loginPending: false`, zero conversations and zero sessions.

The stale login record was not the cause, and neither was the UI: the confirmation path fires the request and the refusal notice does render. The backend refusal was real, and false.

## Mechanism

`accountHasLiveSessions` in `src/lib/agent/accountLiveness.ts` treated an account pin as a liveness claim. The branch added beside the probe in #1401 had two independent defects:

1. **It never consulted `owned()`.** The `continue` guard admits any pinned receipt of the engine whatever account it is pinned to, and the branch that follows returns `true` without checking ownership — so a receipt pinned to account B answered for account A.
2. **It never called `receiptIsLive`.** Membership in `OPEN_RECEIPT_STATES` alone counted as a live session, with no `UNPROVEN_LAUNCH_GRACE_MS` bound — so a receipt merely *in* an open state counted for ever.

Together, launch receipts abandoned in `starting` — no pane, no admission owner, no verified host — blocked removal permanently, on their own account and on every other account of that engine.

## The fix

A pin only records which account a launch would have used. It legitimately outranks liveness in exactly one case: a spawn still queued for account capacity, which has nothing to probe yet and will actuate later on the account it names. The branch is now scoped to a receipt carrying that durable `queuedPinnedSpawn`; every other pinned receipt falls through to `receiptIsLive`, exactly as before #1401.

This deliberately preserves the #1401 contract asserted by "an aged queued pin blocks every account until its durable receipt settles" — that test is untouched and still passes. No force path, no generic deletion, no change to what a genuinely live session blocks.

## Verification

**Isolated red/green** — `src/lib/accounts/removal.test.ts`, new case "dead pinned receipts block neither their own account nor any other (issue #1595)": RED at `["live_sessions"]` before the change with the file's other 25 tests passing, GREEN after.

**Replayed read-only over this machine's live registry** (a snapshot parsed in memory; no account, receipt or transcript was mutated, and nothing was deleted):

| account | before | after |
| --- | --- | --- |
| A — signed out, failed login, 0 conversations | `live_sessions` | removable |
| B — signed in, 1 live conversation | blocked | blocked |
| three further accounts with live conversations | blocked | blocked |

The 13 codex receipts doing the blocking were all pinned to accounts other than A, all `receiptIsLive() === false`, none carrying a `queuedPinnedSpawn`, the oldest 26 days old.

**Test files run individually** (all in this worktree, after `bun install`): `removal.test.ts` 26 pass, `accountLiveness.test.ts` 1 pass, `rateLimit.test.ts` 22 pass, `SwitchCard.status.render.test.tsx` 4 pass, `api/accounts/codex/route.test.ts` 10 pass, `api/accounts/claude/route.test.ts` 16 pass — 0 fail.

`bunx tsc --noEmit` exit 0. Privacy publication gate PASS against the merge base with `--check-commits`.

**One pre-existing red file, not from this branch:** `src/lib/agent/failedSpawnDelivery.test.ts` is 0 pass / 7 fail, every failure `title is required for every new spawn` thrown at spawn admission in `registry.ts`. Baselined in a throwaway worktree at the merge base `6cc462e9`: identical 0 pass / 7 fail there. Filed separately as #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
