### PR TITLE
fix(runtime): repair delivery status after a lost terminal acknowledgement

### DIFF
--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -101,6 +101,12 @@ export interface RuntimeHostClient {
     details?: { turnId?: string | null; queuePosition?: number | null; reason?: string | null },
     options?: RuntimeTransitionOptions,
   ): Promise<RuntimeOperationResult>;
+  /** Releases the retention a terminal transition took out under
+      `awaitProjection` (#1612), once its outcome is in the durable delivery
+      record. Optional because a runtime host from before it answers
+      "unsupported": the receipt then expires on the ordinary compaction
+      cadence, which is exactly the behaviour that predates this method. */
+  acknowledgeTerminalProjection?(operationIds: readonly string[]): Promise<number>;
   requestViewerDeployment(request: ViewerDeploymentRequest): Promise<ViewerDeploymentReceipt>;
   cancelViewerDeployment?(deploymentId: string): Promise<ViewerDeploymentStatus | null>;
   readViewerDeployment(deploymentId: string): Promise<ViewerDeploymentStatus | null>;
@@ -158,7 +164,11 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
       status,
       ...(details ? { details } : {}),
       ...(options.fromStatuses ? { fromStatuses: [...options.fromStatuses] } : {}),
+      ...(options.awaitProjection ? { awaitProjection: true } : {}),
     }) as Promise<RuntimeOperationResult>;
+  }
+  acknowledgeTerminalProjection(operationIds: readonly string[]): Promise<number> {
+    return this.call("operation-projection-ack", { operationIds: [...operationIds] }) as Promise<number>;
   }
   requestViewerDeployment(request: ViewerDeploymentRequest): Promise<ViewerDeploymentReceipt> { return this.call("viewer-deployment-request", request as unknown as Record<string, unknown>, this.deploymentTimeoutMs) as Promise<ViewerDeploymentReceipt>; }
   cancelViewerDeployment(deploymentId: string): Promise<ViewerDeploymentStatus | null> { return this.call("viewer-deployment-cancel", { deploymentId }) as Promise<ViewerDeploymentStatus | null>; }

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -200,6 +200,14 @@ export type RuntimeReceipt = RuntimeOperationReceipt;
 export interface RuntimeTransitionOptions {
   /** Compare-and-set fence evaluated inside the journal write transaction. */
   fromStatuses?: readonly RuntimeReceiptStatus[];
+  /** Marks a terminal transition as owed a durable projection, inside the same
+      write transaction that commits it (#1612). The caller is saying: the
+      answer to this call is what carries the outcome into the delivery record,
+      so the receipt has to outlive compaction until the projection is
+      acknowledged — the acknowledgement is the one thing that can be lost
+      while the outcome itself is already committed. A runtime host from before
+      this option ignores it and retains nothing extra. */
+  awaitProjection?: boolean;
 }
 
 export function runtimePresentationReceipt(receipt: RuntimeOperationReceipt): RuntimeOperationReceipt {
@@ -725,7 +733,7 @@ export interface RuntimeReplay {
 
 export interface RuntimeSocketRequest {
   id: string;
-  method: "runtime-host-health" | "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-delivery-action" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "viewer-deployment-cancel" | "mcp-health-probe-admission";
+  method: "runtime-host-health" | "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-delivery-action" | "operation-retry" | "effect-batch" | "operation-transition" | "operation-projection-ack" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "viewer-deployment-cancel" | "mcp-health-probe-admission";
   params?: Record<string, unknown>;
 }
 

--- a/src/lib/runtime/lostTerminalAcknowledgement.test.ts
+++ b/src/lib/runtime/lostTerminalAcknowledgement.test.ts
@@ -1,0 +1,524 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+
+/* Isolated state only: this suite drives the process-scoped delivery
+   controller, a real runtime journal and a real agent registry, none of which
+   may touch the operator's live state. */
+const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-lost-ack-"));
+const isolatedEnvironment = {
+  HOME: path.join(isolated, "home"),
+  XDG_CONFIG_HOME: path.join(isolated, "config"),
+  LLV_STATE_DIR: path.join(isolated, "state"),
+  TMPDIR: path.join(isolated, "tmp"),
+};
+/* Restored in afterAll: a bun run that carries several test files shares one
+   process, so an isolated TMPDIR this file then deletes would strand every
+   later file's mkdtemp. */
+const ambientEnvironment = Object.fromEntries(
+  Object.keys(isolatedEnvironment).map((name) => [name, process.env[name]]),
+);
+for (const [name, directory] of Object.entries(isolatedEnvironment)) {
+  fs.mkdirSync(directory, { recursive: true });
+  process.env[name] = directory;
+}
+
+const { AgentRegistry } = await import("@/lib/agent/registry");
+const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+const { RuntimeJournal } = await import("@/runtime-host/journal");
+const { createFakeDeliveryLedger, FakeEngineHost } = await import("./fixtures/fakeEngineHost");
+const { RuntimeHostUnavailableError } = await import("./client");
+const { bindStructuredDeliveryQueue } = await import("./structuredDeliveryController");
+const { kickStructuredDeliveryQueue } = await import("./structuredDeliverySignal");
+const { structuredContentDigest } = await import("./structuredContent");
+type AgentRegistry = InstanceType<typeof AgentRegistry>;
+type RuntimeJournal = InstanceType<typeof RuntimeJournal>;
+type RuntimeHostClient = import("./client").RuntimeHostClient;
+type SessionKey = import("@/lib/agent/sessionKey").SessionKey;
+
+afterAll(() => {
+  for (const [name, value] of Object.entries(ambientEnvironment)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  fs.rmSync(isolated, { recursive: true, force: true });
+});
+
+interface Faults {
+  /** Applies the delivered transition and loses only its answer — the incident. */
+  loseDeliveredAcknowledgement: boolean;
+  /** Every receipt read fails from that moment: the outcome is committed and
+      unreadable, which is the compound outage the incident ran inside. */
+  unreadableAfterLostAcknowledgement: boolean;
+  /** Live state of the read fault, flipped by the loss above and by tests. */
+  statusUnreadable: boolean;
+}
+
+interface HostGeneration {
+  /** Drops the projection-retention option, as a runtime host released before
+      it does, and answers "unsupported" for the acknowledgement itself. */
+  legacy?: boolean;
+  /** Present, but rejecting: the acknowledgement must never take a drain down. */
+  acknowledgementRejects?: boolean;
+}
+
+function runtimeClient(
+  journal: RuntimeJournal,
+  faults: Faults,
+  acknowledged: string[],
+  generation: HostGeneration = {},
+): RuntimeHostClient {
+  const client: Record<string, unknown> = {
+    snapshot: async () => journal.snapshot(),
+    events: async (after: number) => journal.replay(after),
+    waitEvents: async (after: number) => journal.replay(after),
+    append: async (event: unknown) => journal.append(event as Parameters<RuntimeJournal["append"]>[0]),
+    operation: async (event: unknown) => journal.append(event as Parameters<RuntimeJournal["append"]>[0]),
+    command: async (command: unknown) => journal.executeOperation(command as Parameters<RuntimeJournal["executeOperation"]>[0]),
+    operationStatus: async (operationId: string) => {
+      if (faults.statusUnreadable) throw new RuntimeHostUnavailableError("runtime host request timed out");
+      return journal.operationResult(operationId);
+    },
+    producerCursor: async (producerKind: string, eventKeyPrefix: string) => journal.producerCursor(producerKind, eventKeyPrefix),
+    effectBatch: async (kinds?: readonly string[], afterEventSeq?: number) => journal.effectBatch(100, kinds, afterEventSeq),
+    transitionOperation: async (
+      operationId: string,
+      status: Parameters<RuntimeJournal["transitionOperation"]>[1],
+      details: Parameters<RuntimeJournal["transitionOperation"]>[2],
+      options: Parameters<RuntimeJournal["transitionOperation"]>[3],
+    ) => {
+      const result = journal.transitionOperation(operationId, status, details, generation.legacy ? {} : options ?? {});
+      if (faults.loseDeliveredAcknowledgement && status === "delivered") {
+        faults.loseDeliveredAcknowledgement = false;
+        if (faults.unreadableAfterLostAcknowledgement) faults.statusUnreadable = true;
+        throw new RuntimeHostUnavailableError("runtime host request timed out");
+      }
+      return result;
+    },
+  };
+  if (generation.acknowledgementRejects) {
+    client.acknowledgeTerminalProjection = async () => {
+      throw new RuntimeHostUnavailableError("runtime request method is unsupported");
+    };
+  } else if (!generation.legacy) {
+    client.acknowledgeTerminalProjection = async (operationIds: readonly string[]) => {
+      acknowledged.push(...operationIds);
+      return journal.acknowledgeTerminalProjection(operationIds);
+    };
+  }
+  return client as unknown as RuntimeHostClient;
+}
+
+function seedConversation(registry: AgentRegistry, directory: string, name: string): { conversationId: `conversation_${string}`; key: SessionKey } {
+  const artifactPath = path.join(directory, `${name}.jsonl`);
+  const launchProfile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "lost-ack-fixture-account",
+    launchProfile,
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-09-09T19:49:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath);
+  const generation = conversation?.generations.at(-1);
+  if (!conversation || !generation) throw new Error("seeded conversation is missing");
+  const key: SessionKey = { engine: "codex", sessionId: generation.id };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd: directory,
+    accountId: "lost-ack-fixture-account",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:lost-ack-fixture-host",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  return { conversationId: conversation.id as `conversation_${string}`, key };
+}
+
+const ORIGINAL_TEXT = "the original message, delivered exactly once";
+
+function fixture(name: string, generation: HostGeneration = {}) {
+  const directory = fs.mkdtempSync(path.join(isolated, `${name}-`));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const faults: Faults = {
+    loseDeliveredAcknowledgement: false,
+    unreadableAfterLostAcknowledgement: false,
+    statusUnreadable: false,
+  };
+  const acknowledged: string[] = [];
+  const client = runtimeClient(journal, faults, acknowledged, generation);
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+  const { conversationId, key } = seedConversation(registry, directory, name);
+  journal.append({
+    scope: { type: "session", id: conversationId },
+    kind: "session-status",
+    payload: {
+      conversationId,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath: path.join(directory, `${name}.jsonl`),
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  const operationId = `op-${name}`;
+  const clientMessageId = `client-${name}`;
+  const contentDigest = structuredContentDigest({ text: ORIGINAL_TEXT, images: [] });
+  return {
+    directory,
+    registry,
+    journal,
+    client,
+    host,
+    ledger,
+    faults,
+    acknowledged,
+    conversationId,
+    key,
+    operationId,
+    clientMessageId,
+    contentDigest,
+    /** Reserves the operator's message and admits its runtime operation under
+        the identity the composer minted, exactly as production does. */
+    admit(): string {
+      const held = registry.holdDelivery(
+        conversationId,
+        ORIGINAL_TEXT,
+        clientMessageId,
+        "text",
+        [],
+        contentDigest,
+        { operationId, kind: "send", policy: "queue", turnId: null },
+      );
+      registry.beginDeliveryAttempt(held.id, held.generationId!);
+      journal.executeOperation({
+        kind: "send",
+        operationId,
+        idempotencyKey: clientMessageId,
+        conversationId,
+        text: ORIGINAL_TEXT,
+        contentDigest,
+        policy: "queue",
+      });
+      return held.id;
+    },
+    delivery(deliveryId: string) {
+      return registry.readOnlySnapshot().heldDeliveries[deliveryId]!;
+    },
+    async bind(): Promise<void> {
+      await bindStructuredDeliveryQueue([{ key, host }], { registry, client });
+    },
+    async release(): Promise<void> {
+      await bindStructuredDeliveryQueue([], { registry, client: null });
+      journal.close();
+    },
+  };
+}
+
+/** Drains the queue the way the controller's own retry does, tolerating a pass
+    that fails: a failing drain is part of several cases here. */
+async function drain(times = 3): Promise<void> {
+  for (let attempt = 0; attempt < times; attempt += 1) {
+    await Promise.resolve(kickStructuredDeliveryQueue()).catch(() => undefined);
+  }
+}
+
+async function settles(assertion: () => boolean, what: string, budgetMs = 2_000): Promise<void> {
+  for (let waited = 0; waited < budgetMs; waited += 10) {
+    if (assertion()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`${what} did not settle`);
+}
+
+test("a lost delivered acknowledgement settles the original reservation in the same drain, with one recipient write", async () => {
+  const subject = fixture("lost-ack");
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+    subject.faults.loseDeliveredAcknowledgement = true;
+
+    await drain();
+
+    const delivery = subject.delivery(deliveryId);
+    expect(delivery.state).toBe("delivered");
+    expect(subject.journal.operationResult(subject.operationId)?.receipt.status).toBe("delivered");
+    expect(subject.ledger.writes.length).toBe(1);
+    // The identity the operator submitted under is untouched by the repair.
+    expect(delivery.command.operationId).toBe(subject.operationId);
+    expect(delivery.clientMessageId).toBe(subject.clientMessageId);
+    expect(subject.ledger.writes[0]!.text).toBe(ORIGINAL_TEXT);
+    expect(subject.ledger.writes[0]!.contentDigest).toBe(subject.contentDigest);
+    // The retention the terminal transition took is released once, by id.
+    expect(subject.acknowledged).toEqual([subject.operationId]);
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("an intact acknowledgement settles the same way and leaves no retention behind", async () => {
+  const subject = fixture("intact-ack");
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+
+    await drain(1);
+
+    expect(subject.delivery(deliveryId).state).toBe("delivered");
+    expect(subject.ledger.writes.length).toBe(1);
+    expect(subject.acknowledged).toEqual([subject.operationId]);
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("repeated drains and a controller rebind after the repair write nothing further", async () => {
+  const subject = fixture("idempotent-repair");
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+    subject.faults.loseDeliveredAcknowledgement = true;
+    await drain();
+    const repaired = subject.delivery(deliveryId);
+    expect(repaired.state).toBe("delivered");
+
+    await drain(3);
+    await subject.bind();
+    await drain(2);
+
+    const settled = subject.delivery(deliveryId);
+    expect(settled.state).toBe("delivered");
+    expect(settled.deliveredAt).toBe(repaired.deliveredAt);
+    expect(subject.ledger.writes.length).toBe(1);
+    // Nothing re-acknowledges a receipt whose retention is already released.
+    expect(subject.acknowledged).toEqual([subject.operationId]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("compaction cannot take a terminal receipt whose projection is still owed", async () => {
+  const subject = fixture("compaction-before-projection");
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+    // The whole gap at once: the answer is lost AND the journal goes unreadable
+    // with it, so the repair establishes nothing in the pass that lost it.
+    subject.faults.loseDeliveredAcknowledgement = true;
+    subject.faults.unreadableAfterLostAcknowledgement = true;
+    await drain();
+    expect(subject.delivery(deliveryId).state).toBe("delivery-uncertain");
+
+    // Retention pressure arrives before the repair does.
+    subject.journal.append({
+      scope: { type: "session", id: subject.conversationId },
+      kind: "session-status",
+      payload: { conversationId: subject.conversationId, host: "hosted", turn: "idle" },
+    });
+    subject.journal.compact(1);
+    expect(subject.journal.operationResult(subject.operationId)?.receipt.status).toBe("delivered");
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([subject.operationId]);
+
+    subject.faults.statusUnreadable = false;
+    await settles(
+      () => subject.delivery(deliveryId).state === "delivered",
+      "the retained receipt's projection",
+    );
+    expect(subject.ledger.writes.length).toBe(1);
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("compaction after the projection is acknowledged releases the receipt as it always did", async () => {
+  const subject = fixture("compaction-after-projection");
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+    subject.faults.loseDeliveredAcknowledgement = true;
+    await drain();
+    expect(subject.delivery(deliveryId).state).toBe("delivered");
+
+    subject.journal.append({
+      scope: { type: "session", id: subject.conversationId },
+      kind: "session-status",
+      payload: { conversationId: subject.conversationId, host: "hosted", turn: "idle" },
+    });
+    subject.journal.compact(1);
+
+    expect(subject.journal.operationResult(subject.operationId)).toBeNull();
+    expect(subject.delivery(deliveryId).state).toBe("delivered");
+    expect(subject.ledger.writes.length).toBe(1);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("an unreadable journal leaves the fate unknown and moves nothing", async () => {
+  const subject = fixture("unreadable-journal");
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+    subject.faults.loseDeliveredAcknowledgement = true;
+    subject.faults.unreadableAfterLostAcknowledgement = true;
+
+    await drain();
+
+    const delivery = subject.delivery(deliveryId);
+    expect(delivery.state).toBe("delivery-uncertain");
+    expect(delivery.deliveredAt).toBeNull();
+    // The reservation keeps the payload it would need to be acted on again.
+    expect(delivery.text).toBe(ORIGINAL_TEXT);
+    expect(subject.ledger.writes.length).toBe(1);
+    expect(subject.acknowledged).toEqual([]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("a terminal receipt naming another conversation settles no reservation", async () => {
+  const subject = fixture("target-mismatch");
+  try {
+    const other = seedConversation(subject.registry, subject.directory, "target-mismatch-other");
+    subject.journal.append({
+      scope: { type: "session", id: other.conversationId },
+      kind: "session-status",
+      payload: {
+        conversationId: other.conversationId,
+        sessionKey: other.key,
+        hostKind: "codex-app-server",
+        host: "hosted",
+        turn: "idle",
+        provenance: "structured",
+        capabilities: { steer: true, structuredAttention: true },
+      },
+    });
+    /* One operation id, two targets: the reservation is held against this
+       conversation while the runtime operation belongs to the other one. */
+    const held = subject.registry.holdDelivery(
+      subject.conversationId,
+      ORIGINAL_TEXT,
+      subject.clientMessageId,
+      "text",
+      [],
+      subject.contentDigest,
+      { operationId: subject.operationId, kind: "send", policy: "queue", turnId: null },
+    );
+    subject.registry.beginDeliveryAttempt(held.id, held.generationId!);
+    subject.journal.executeOperation({
+      kind: "send",
+      operationId: subject.operationId,
+      idempotencyKey: subject.clientMessageId,
+      conversationId: other.conversationId,
+      text: "a different message on a different target",
+      contentDigest: structuredContentDigest({ text: "a different message on a different target", images: [] }),
+      policy: "queue",
+    });
+    subject.registry.recordDeliveryOutcome(held.id, "delivery-uncertain", "delivery result is uncertain");
+    subject.journal.transitionOperation(subject.operationId, "delivered", {}, { awaitProjection: true });
+
+    await subject.bind();
+    await drain();
+
+    expect(subject.delivery(held.id).state).toBe("delivery-uncertain");
+    expect(subject.acknowledged).toEqual([]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("a runtime host without projection retention behaves exactly as it does today", async () => {
+  const subject = fixture("legacy-host", { legacy: true });
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+    subject.faults.loseDeliveredAcknowledgement = true;
+
+    await drain();
+
+    // The drain-time repair needs no protocol addition at all.
+    expect(subject.delivery(deliveryId).state).toBe("delivered");
+    expect(subject.ledger.writes.length).toBe(1);
+    // Nothing was retained, so compaction behaves as it did before this repair.
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([]);
+    subject.journal.append({
+      scope: { type: "session", id: subject.conversationId },
+      kind: "session-status",
+      payload: { conversationId: subject.conversationId, host: "hosted", turn: "idle" },
+    });
+    subject.journal.compact(1);
+    expect(subject.journal.operationResult(subject.operationId)).toBeNull();
+  } finally {
+    await subject.release();
+  }
+});
+
+test("an acknowledgement the runtime host refuses never fails the delivery it belongs to", async () => {
+  const subject = fixture("acknowledgement-refused", { acknowledgementRejects: true });
+  try {
+    await subject.bind();
+    const deliveryId = subject.admit();
+
+    await drain(1);
+
+    expect(subject.delivery(deliveryId).state).toBe("delivered");
+    expect(subject.ledger.writes.length).toBe(1);
+    // The receipt simply stays retained, which is the safe direction.
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([subject.operationId]);
+  } finally {
+    await subject.release();
+  }
+});
+
+test("a lost acknowledgement for an operation no reservation owns settles nothing and stops asking", async () => {
+  const subject = fixture("no-reservation");
+  try {
+    await subject.bind();
+    /* A runtime operation with no held delivery behind it — the shape a send
+       admitted outside the composer leaves. */
+    subject.journal.executeOperation({
+      kind: "send",
+      operationId: subject.operationId,
+      idempotencyKey: subject.clientMessageId,
+      conversationId: subject.conversationId,
+      text: ORIGINAL_TEXT,
+      contentDigest: subject.contentDigest,
+      policy: "queue",
+    });
+    subject.faults.loseDeliveredAcknowledgement = true;
+
+    await drain();
+
+    expect(subject.journal.operationResult(subject.operationId)?.receipt.status).toBe("delivered");
+    expect(subject.ledger.writes.length).toBe(1);
+    expect(Object.keys(subject.registry.readOnlySnapshot().heldDeliveries)).toEqual([]);
+    // Established, so the receipt is released rather than retained for ever.
+    expect(subject.acknowledged).toEqual([subject.operationId]);
+    expect(subject.journal.unprojectedTerminalOperationIds()).toEqual([]);
+  } finally {
+    await subject.release();
+  }
+});

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -8,7 +8,7 @@ import { BRANCH_SHARED_HOST_ERROR, branchSharesRootHost } from "@/lib/conversati
 import { captureProcessIdentity } from "@/lib/processIdentity";
 
 import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
-import { runtimeSettingsCapability, type RuntimeEventInput, type RuntimeSession } from "./contracts";
+import { runtimeSettingsCapability, type RuntimeEventInput, type RuntimeOperationReceipt, type RuntimeSession } from "./contracts";
 import { readEvidence } from "./evidence";
 import type { EngineHost, HostState } from "./engineHost";
 import { StructuredDeliveryQueue } from "./structuredDeliveryQueue";
@@ -59,6 +59,8 @@ interface HostRegistration {
 const DELIVERY_DRAIN_COALESCE_MS = 25;
 const DELIVERY_DRAIN_MAX_BACKOFF_MS = 1_000;
 const TERMINAL_RECONCILIATION_PAGE_SIZE = 16;
+/** One socket frame's worth of acknowledgements (#1612). */
+const TERMINAL_ACKNOWLEDGEMENT_BATCH_SIZE = 128;
 const TERMINAL_RECONCILIATION_SETTLEMENT_BATCH_SIZE = 256;
 
 /* Next standalone can evaluate instrumentation and route handlers in separate
@@ -231,6 +233,152 @@ async function yieldControllerTurn(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
+interface TerminalDeliveryOutcome {
+  conversationId: `conversation_${string}`;
+  operationId: string;
+  state: "delivered" | "failed";
+  error: string | null;
+  disposition: NonNullable<Parameters<AgentRegistry["recordDeliveryOutcomeForOperation"]>[4]>;
+  /** The durable operation the journal answered for — the retry leaf, where a
+      retry created one. Its retention is what the acknowledgement releases. */
+  receiptOperationId: string;
+}
+
+/**
+ * The one reading of a runtime receipt as a durable delivery outcome.
+ *
+ * Every repair here goes through it — the startup sweep and the drain-time
+ * repair of a lost acknowledgement — so "what does this receipt settle, and
+ * against which reservation" has one answer rather than two that can drift.
+ * It proves nothing on its own: an open status, an absent receipt, a receipt
+ * naming a different conversation all return null, and the caller leaves the
+ * record exactly as it found it.
+ */
+function terminalDeliveryOutcome(
+  registry: AgentRegistry,
+  result: { operationId: string; receipt: { status: RuntimeOperationReceipt["status"]; reason?: string | null; conversationId: string; presentationOperationId?: string } },
+  /** The reservation this receipt is being read for. `conversationId` is the
+      target it must agree with, and null where the caller came from the receipt
+      rather than from a reservation — there the registry's own (conversation,
+      operation) keying is what refuses a row under another target. */
+  expected: { conversationId: `conversation_${string}` | null; operationId: string },
+): TerminalDeliveryOutcome | null {
+  /* The same classifier the receipt query reads the journal through: what a
+     status PROVES about a send is one question with one answer, and
+     `uncertain` — the send was handed to the engine and never answered for —
+     is the one whose disposition stops a later receipt from calling a resend
+     safe (#1131). */
+  const verdict = journalVerdict(result.receipt.status, result.receipt.reason);
+  if (!verdict) return null;
+  const receiptConversationId = result.receipt.conversationId;
+  if (!receiptConversationId.startsWith("conversation_")) return null;
+  const conversationId = receiptConversationId as `conversation_${string}`;
+  if (expected.conversationId
+    && registry.canonicalConversationId(conversationId) !== registry.canonicalConversationId(expected.conversationId)) {
+    console.error("[structured delivery] terminal receipt conversation mismatch", {
+      operationId: expected.operationId,
+      deliveryConversationId: expected.conversationId,
+      receiptConversationId,
+    });
+    return null;
+  }
+  return {
+    conversationId,
+    /* The identity the reservation was made under, never the retry leaf the
+       journal answered from: the delivery record is keyed on what the operator
+       submitted. */
+    operationId: result.receipt.presentationOperationId ?? expected.operationId,
+    state: verdict.state,
+    /* The journal's own words where it has them, and the settlement's
+       where the status IS the reason. */
+    error: verdict.disposition === "unverified" ? verdict.reason : result.receipt.reason ?? null,
+    disposition: verdict.disposition,
+    receiptOperationId: result.operationId,
+  };
+}
+
+/**
+ * Releases the journal's retention of receipts whose outcome now lives in the
+ * durable delivery record (#1612).
+ *
+ * Failure is the safe direction and is therefore swallowed: the receipt stays
+ * retained, which costs one row and repairs itself at the cap, whereas a throw
+ * here would abort a drain over evidence that has already been consumed. A
+ * runtime host from before this method answers "unsupported", which is the same
+ * no-op — the retention it never took needs no release.
+ */
+async function acknowledgeTerminalProjection(
+  client: RuntimeHostClient,
+  operationIds: readonly string[],
+): Promise<void> {
+  if (operationIds.length === 0 || typeof client.acknowledgeTerminalProjection !== "function") return;
+  try {
+    for (let offset = 0; offset < operationIds.length; offset += TERMINAL_ACKNOWLEDGEMENT_BATCH_SIZE) {
+      await client.acknowledgeTerminalProjection(operationIds.slice(offset, offset + TERMINAL_ACKNOWLEDGEMENT_BATCH_SIZE));
+    }
+  } catch (error) {
+    console.error("[structured delivery] terminal projection acknowledgement failed", {
+      operationIds: operationIds.length,
+      error,
+    });
+  }
+}
+
+/**
+ * Carries the outcome of ONE operation whose transition acknowledgement was
+ * lost into its durable delivery record (#1612).
+ *
+ * It re-reads the journal rather than trusting the transition the caller
+ * believed it wrote: the whole failure is that the caller does not know what
+ * landed. An unreadable status, a receipt that is not terminal, a receipt that
+ * names another conversation, and a reservation the registry no longer has all
+ * leave the record alone — and only the first of those is a reason to ask for
+ * another pass, because the others are answers rather than outages.
+ *
+ * Returns whether the fate was established, which is a different question from
+ * whether a reservation moved: an operation with no reservation left to settle
+ * is established and acknowledged, because nothing will ever project it.
+ */
+async function projectLostTerminalAcknowledgement(
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+  operationId: string,
+): Promise<boolean> {
+  let result: Awaited<ReturnType<RuntimeHostClient["operationStatus"]>>;
+  try {
+    result = await client.operationStatus(operationId, { currentRetryLeaf: true });
+  } catch (error) {
+    console.error("[structured delivery] lost terminal acknowledgement could not be read", { operationId, error });
+    return false;
+  }
+  if (!result) {
+    /* The receipt is gone. Under this repair's own retention it cannot be gone
+       while a projection is owed, so this is a receipt that was already
+       projected, or one released past the retention cap. Absence proves
+       nothing about execution and settles nothing (#1612). */
+    return true;
+  }
+  const outcome = terminalDeliveryOutcome(registry, result, { conversationId: null, operationId });
+  if (!outcome) return true;
+  try {
+    registry.recordDeliveryOutcomeForOperation(
+      outcome.conversationId,
+      outcome.operationId,
+      outcome.state,
+      outcome.error,
+      outcome.disposition,
+    );
+  } catch (error) {
+    console.error("[structured delivery] lost terminal acknowledgement could not be projected", {
+      operationId,
+      error,
+    });
+    return false;
+  }
+  await acknowledgeTerminalProjection(client, [outcome.receiptOperationId]);
+  return true;
+}
+
 async function reconcileTerminalDeliveries(
   registry: AgentRegistry,
   client: RuntimeHostClient,
@@ -239,9 +387,13 @@ async function reconcileTerminalDeliveries(
   const unsettledDeliveries = Object.values(registry.readOnlySnapshot().heldDeliveries)
     .filter((delivery) => delivery.state === "delivery-uncertain" || delivery.state === "failed");
   const pendingOutcomes: Parameters<AgentRegistry["recordDeliveryOutcomesForOperations"]>[0][number][] = [];
-  const flushOutcomes = () => {
+  const pendingAcknowledgements: string[] = [];
+  const flushOutcomes = async () => {
     if (pendingOutcomes.length === 0) return;
     registry.recordDeliveryOutcomesForOperations(pendingOutcomes.splice(0));
+    /* Only after the settlement is durable: the journal's retention is what
+       stands in for it until then (#1612). */
+    await acknowledgeTerminalProjection(client, pendingAcknowledgements.splice(0));
   };
   for (let offset = 0; offset < unsettledDeliveries.length && isCurrent(); offset += TERMINAL_RECONCILIATION_PAGE_SIZE) {
     const page = unsettledDeliveries.slice(offset, offset + TERMINAL_RECONCILIATION_PAGE_SIZE);
@@ -249,34 +401,13 @@ async function reconcileTerminalDeliveries(
       try {
         const result = await client.operationStatus(delivery.command.operationId, { currentRetryLeaf: true });
         if (!result) return null;
-        /* The same classifier the receipt query reads the journal through:
-           what a status PROVES about a send is one question with one answer,
-           and `uncertain` — the send was handed to the engine and never
-           answered for — is the one whose disposition stops a later receipt
-           from calling a resend safe (#1131). */
-        const verdict = journalVerdict(result.receipt.status, result.receipt.reason);
-        if (!verdict) return null;
-        const receiptConversationId = result.receipt.conversationId;
-        if (!receiptConversationId.startsWith("conversation_")
-          || registry.canonicalConversationId(receiptConversationId as `conversation_${string}`)
-            !== registry.canonicalConversationId(delivery.conversationId)) {
-          console.error("[structured delivery] terminal receipt conversation mismatch", {
-            operationId: delivery.command.operationId,
-            deliveryConversationId: delivery.conversationId,
-            receiptConversationId,
-          });
-          return null;
-        }
-        if (delivery.state === "failed" && verdict.state === "failed") return null;
-        return {
-          conversationId: receiptConversationId as `conversation_${string}`,
-          operationId: result.receipt.presentationOperationId ?? delivery.command.operationId,
-          state: verdict.state,
-          /* The journal's own words where it has them, and the settlement's
-             where the status IS the reason. */
-          error: verdict.disposition === "unverified" ? verdict.reason : result.receipt.reason ?? null,
-          disposition: verdict.disposition,
-        };
+        const outcome = terminalDeliveryOutcome(registry, result, {
+          conversationId: delivery.conversationId,
+          operationId: delivery.command.operationId,
+        });
+        if (!outcome) return null;
+        if (delivery.state === "failed" && outcome.state === "failed") return null;
+        return outcome;
       } catch (error) {
         /* Scoped to this one delivery on purpose (#1131): a status that could
            not be read contributes no outcome, so the row keeps the state it
@@ -291,11 +422,12 @@ async function reconcileTerminalDeliveries(
       }
     }))).filter((outcome): outcome is NonNullable<typeof outcome> => outcome !== null);
     if (!isCurrent()) return;
-    pendingOutcomes.push(...outcomes);
-    if (pendingOutcomes.length >= TERMINAL_RECONCILIATION_SETTLEMENT_BATCH_SIZE) flushOutcomes();
+    pendingOutcomes.push(...outcomes.map(({ receiptOperationId, ...outcome }) => outcome));
+    pendingAcknowledgements.push(...outcomes.map((outcome) => outcome.receiptOperationId));
+    if (pendingOutcomes.length >= TERMINAL_RECONCILIATION_SETTLEMENT_BATCH_SIZE) await flushOutcomes();
     await yieldControllerTurn();
   }
-  if (isCurrent()) flushOutcomes();
+  if (isCurrent()) await flushOutcomes();
 }
 
 type RegistrySessionProjection = Pick<RuntimeSession,
@@ -488,8 +620,27 @@ export async function bindStructuredDeliveryQueue(
          evidence a `delivering` row is compared against before it is called
          abandoned, so a send another live executor is actuating is left to it. */
       hostClaim: structuredHostClaim(registry),
+      /* The repair for a lost terminal acknowledgement (#1612). Reading the
+         journal is what settles it, so a socket that cannot answer settles
+         nothing and says so — the queue keeps the operation and asks again on
+         its next pass. */
+      projectTerminal: async (operationId) => {
+        if (stopped || state.activeQueue !== queue) return false;
+        return projectLostTerminalAcknowledgement(registry, client, operationId);
+      },
       transition: async (operationId, status, details) => {
-        const result = await client.transitionOperation(operationId, status, details);
+        const terminal = status === "delivered" || status === "failed" || status === "uncertain";
+        /* Terminal transitions take out the journal's retention as they commit
+           (#1612): the registry write below rides on this call's ANSWER, and an
+           answer is the one part of it that can be lost while the outcome is
+           already durable. The receipt then has to outlive compaction until
+           this Viewer says the outcome reached the delivery record. */
+        const result = await client.transitionOperation(
+          operationId,
+          status,
+          details,
+          terminal ? { awaitProjection: true } : {},
+        );
         /* The three states a held delivery can settle into. `uncertain` — a
            send an executor actuated and could not answer for — settles the
            reservation HERE, at the moment the queue writes it, rather than
@@ -499,7 +650,7 @@ export async function bindStructuredDeliveryQueue(
            projection is keyed on `heldDeliveries`, which only a composer
            message ever creates, so a compact operation has no row here to
            settle (#862). */
-        if (status !== "delivered" && status !== "failed" && status !== "uncertain") return;
+        if (!terminal) return;
         const conversationId = result.receipt.conversationId;
         if (!conversationId?.startsWith("conversation_")) return;
         registry.recordDeliveryOutcomeForOperation(
@@ -513,6 +664,7 @@ export async function bindStructuredDeliveryQueue(
              own, so it carries none. */
           status === "uncertain" ? "unverified" : undefined,
         );
+        await acknowledgeTerminalProjection(client, [result.operationId]);
         if (status === "delivered" && operationId.startsWith("spawn_message_")) {
           const launchId = operationId.slice("spawn_message_".length);
           const receipt = registry.readOnlySnapshot().receipts[launchId];

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -60,6 +60,22 @@ export interface StructuredDeliveryQueuePort {
       claim, or a read that throws: no evidence either way, which leaves the row
       with the executor that holds it rather than ending its send. */
   hostClaim?(conversationId: string): string | null | Promise<string | null>;
+  /** Carries the outcome of a transition whose ACKNOWLEDGEMENT was lost into
+      the durable delivery record (#1612).
+   *
+   * `transition` writes the journal and the delivery record in that order, so a
+   * transport failure between them commits the outcome and drops the projection
+   * — and the completing transition clears the effect in the same transaction,
+   * which means no later drain pass can rediscover it. This queue holds the one
+   * moment where that is still known, so it hands the operation back rather than
+   * dropping it. The implementation reads the journal's own answer instead of
+   * trusting what this call meant to write, and settles nothing it cannot read;
+   * it must never throw and never actuate the message again.
+   *
+   * Answers whether the fate was ESTABLISHED — settled, or read and shown to
+   * settle nothing. False means only that the journal could not be read, which
+   * is what brings the operation back on the next pass. */
+  projectTerminal?(operationId: string): Promise<boolean>;
 }
 
 export type StructuredHostResolver = (conversationId: string) => EngineHost | null;
@@ -71,6 +87,10 @@ const THREAD_READ_ATTEMPTS = 2;
 /** Controls carry no message reservation to settle them outside the journal,
     so the queue itself gives every accepted control a terminal ceiling. */
 export const CONTROL_SETTLEMENT_WINDOW_MS = 2 * 60_000;
+/** How many terminal projections may be owed at once before the oldest is
+    given up (#1612). The Viewer's side of the same bound the runtime journal
+    keeps on the receipts themselves. */
+const UNPROJECTED_TERMINAL_LIMIT = 128;
 const TERMINAL_DELIVERY_STATUSES = new Set([
   "turn-started",
   "steered",
@@ -487,6 +507,14 @@ export class StructuredDeliveryQueue {
       arrived. The effect stays pending in the journal meanwhile, so every later
       drain pass must find it here and leave it alone (#862). */
   private readonly activeCompactions = new Map<string, Promise<void>>();
+  /** Operations the journal ended and whose projection is still owed, because
+      the pass that lost the acknowledgement could not read the receipt either
+      (#1612). Nothing else remembers them: the completing transition cleared
+      their effects, so they can never come back through `effects()`. Bounded,
+      and drained at the head of every later pass — the drain is the clock, so
+      the repair needs no timer of its own and stops as soon as the journal can
+      answer. */
+  private readonly unprojectedTerminals = new Set<string>();
   /** The conversations those compactions belong to. Reads block on this rather
       than on a whole-group barrier, so an unfinished compaction holds messages
       without holding kill, interrupt, or answer. */
@@ -551,6 +579,7 @@ export class StructuredDeliveryQueue {
   }
 
   private async drainPass(): Promise<void> {
+    await this.projectOwedTerminals();
     const rawEffects: StructuredDeliveryEffect[] = [];
     let afterEventSeq = 0;
     while (true) {
@@ -1114,9 +1143,63 @@ export class StructuredDeliveryQueue {
     } catch (error) {
       const durable = await this.readStatus(operationId);
       if (durable.readable && durable.value && TERMINAL_DELIVERY_STATUSES.has(durable.value.status)) {
+        /* The journal ended this operation and only the answer was lost, so the
+           delivery record's projection — which rides on that answer — never
+           happened. Nothing else will come back for it: the effect is cleared
+           and this pass is the last one that sees the operation at all (#1612).
+           Awaited, because the evidence is readable right now and the repair is
+           two reads away. */
+        await this.projectLostTerminalAcknowledgement(operationId);
         return false;
       }
+      /* Unreadable: whether the transition applied at all is unknown, and an
+         unknown is not settled here. The repair is asked for anyway — it reads
+         the journal itself and settles only what it can prove — and this pass
+         still fails exactly as before. Not awaited: this path is a broken
+         socket, and every read behind it would spend its whole timeout before
+         the failure below could be reported. */
+      void this.projectLostTerminalAcknowledgement(operationId);
       throw error;
+    }
+  }
+
+  /** Never throws: a repair that could not be made leaves the record exactly as
+      it was, and the operation is kept for the next pass rather than dropped. */
+  private async projectLostTerminalAcknowledgement(operationId: string): Promise<void> {
+    let established = false;
+    try {
+      established = await this.port.projectTerminal?.(operationId) ?? true;
+    } catch (error) {
+      console.error("[structured delivery] terminal projection after a lost acknowledgement failed", {
+        operationId,
+        error: failureReason(error),
+      });
+    }
+    if (established) {
+      this.unprojectedTerminals.delete(operationId);
+      return;
+    }
+    /* The cap releases the OLDEST owed projection, which has had every pass
+       since it was recorded to be established and is the one the journal's own
+       bounded retention gives up on first. */
+    if (!this.unprojectedTerminals.has(operationId) && this.unprojectedTerminals.size >= UNPROJECTED_TERMINAL_LIMIT) {
+      const oldest = this.unprojectedTerminals.values().next();
+      if (!oldest.done) {
+        this.unprojectedTerminals.delete(oldest.value);
+        console.error("[structured delivery] owed terminal projection released at the retry cap", { operationId: oldest.value });
+      }
+    }
+    this.unprojectedTerminals.add(operationId);
+    /* Nothing else will wake this: the effect is gone, so without a scheduled
+       pass a quiet queue would wait for the next message to repair the last. */
+    this.retrySoon();
+  }
+
+  /** The owed projections, retried once per pass and in the order they were
+      recorded. Reported unreadable again, they simply stay owed. */
+  private async projectOwedTerminals(): Promise<void> {
+    for (const operationId of [...this.unprojectedTerminals]) {
+      await this.projectLostTerminalAcknowledgement(operationId);
     }
   }
 

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -179,6 +179,10 @@ export class RuntimeHost {
         }
         const details = request.params?.details;
         const fromStatuses = request.params?.fromStatuses;
+        const awaitProjection = request.params?.awaitProjection;
+        if (awaitProjection !== undefined && typeof awaitProjection !== "boolean") {
+          throw new Error("runtime operation projection retention flag is invalid");
+        }
         if (fromStatuses !== undefined && (!Array.isArray(fromStatuses)
           || fromStatuses.some((candidate) => typeof candidate !== "string"
             || !RUNTIME_RECEIPT_STATUSES.includes(candidate as RuntimeReceiptStatus)))) {
@@ -188,8 +192,18 @@ export class RuntimeHost {
           String(request.params?.operationId ?? ""),
           status as Exclude<RuntimeReceiptStatus, "pending">,
           details && typeof details === "object" ? details as { turnId?: string | null; queuePosition?: number | null; reason?: string | null } : {},
-          fromStatuses ? { fromStatuses: fromStatuses as RuntimeReceiptStatus[] } : {},
+          {
+            ...(fromStatuses ? { fromStatuses: fromStatuses as RuntimeReceiptStatus[] } : {}),
+            ...(awaitProjection === true ? { awaitProjection: true } : {}),
+          },
         );
+      } else if (request.method === "operation-projection-ack") {
+        if (!this.structuredHosts) throw new Error("structured hosts are disabled");
+        const operationIds = request.params?.operationIds;
+        if (!Array.isArray(operationIds) || operationIds.some((operationId) => typeof operationId !== "string" || !operationId)) {
+          throw new Error("runtime projection acknowledgement ids are invalid");
+        }
+        result = this.journal.acknowledgeTerminalProjection(operationIds as string[]);
       } else if (request.method === "viewer-deployment-request") {
         if (!this.deployments) throw new Error("viewer deployments are disabled");
         result = await this.deployments.requestViewerDeployment({

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -64,6 +64,20 @@ export const RUNTIME_SNAPSHOT_STALE_EDGE_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000
     every effect drain remains proportional to work that can still run. */
 export const RUNTIME_PENDING_EFFECT_STALE_MS = 60 * 60 * 1_000;
 
+/** How many terminal receipts may be held past the compaction anchor while
+    their projection is unacknowledged (#1612).
+ *
+ * A terminal receipt whose acknowledgement was lost is the ONLY remaining proof
+ * that its message was delivered, so compaction must not take it while the
+ * durable delivery record still needs it. That obligation cannot be unbounded:
+ * a Viewer that never acknowledges — one that crashed, one released before this
+ * protocol existed — would otherwise pin the operations table for ever. The
+ * cap is the bound, applied to the OLDEST retained receipts first, because the
+ * newest are the ones a live repair can still consume. Sized far above any
+ * realistic outstanding set: production carries single digits of unprojected
+ * terminal receipts at a time, and each row is a receipt, not a transcript. */
+export const RUNTIME_UNPROJECTED_RECEIPT_RETENTION_LIMIT = 512;
+
 export type RuntimeRegistryConversationRetentionState = "current" | "dead" | "superseded";
 
 type EventRow = {
@@ -344,6 +358,7 @@ export class RuntimeJournal {
     `);
     this.migrateOperationIdempotencyScope();
     this.migrateOperationOrphanedSince();
+    this.migrateOperationProjectionPending();
     this.migrateLegacyEvents();
     this.migrateEntityUpdatedAt();
     for (const row of this.db.query<EventRow, []>("SELECT * FROM events WHERE producer_key IS NOT NULL").all()) {
@@ -676,7 +691,14 @@ export class RuntimeJournal {
       const committed = { ...next, revision: event.revision };
       this.upsertEntity("operation", operationId, event.revision, committed, event.seq);
       if (completing) this.appendCompletionConsequences(command, committed, operationId);
-      this.db.query("UPDATE operations SET receipt_json = ?, event_seq = ? WHERE operation_id = ?").run(stableJson(committed), event.seq, operationId);
+      /* The retention obligation is taken in the same transaction that commits
+         the outcome (#1612), because the failure it exists for is the answer to
+         THIS call never reaching its caller: a marker written afterwards, from
+         the caller, is lost by exactly the event it is meant to survive.
+         COALESCE, so a later transition can never silently release an
+         obligation an earlier one took. */
+      this.db.query("UPDATE operations SET receipt_json = ?, event_seq = ?, projection_pending = COALESCE(?, projection_pending) WHERE operation_id = ?")
+        .run(stableJson(committed), event.seq, completing && options.awaitProjection === true ? this.now() : null, operationId);
       if (completing) this.db.query("UPDATE outbox SET state = 'completed', payload_json = '{}' WHERE id = ?").run(`effect:${operationId}`);
       if (killBoundary) {
         this.db.query(`
@@ -1346,7 +1368,40 @@ export class RuntimeJournal {
     });
   }
 
-  compact(maxEvents = this.maxEvents): void {
+  /** Releases the retention taken by {@link transitionOperation} under
+      `awaitProjection`, for receipts whose outcome now lives in the durable
+      delivery record (#1612).
+   *
+   * Idempotent and self-limiting: an id with no obligation, an id compacted
+   * away, and an id acknowledged twice are all the same no-op, so a caller that
+   * cannot tell whether its previous acknowledgement arrived may simply send it
+   * again. It moves nothing else — not the receipt, not its status, not its
+   * time — so nothing about the delivery evidence depends on who called it. */
+  acknowledgeTerminalProjection(operationIds: readonly string[]): number {
+    this.assertHealthy();
+    if (operationIds.length === 0) return 0;
+    if (operationIds.length > RUNTIME_UNPROJECTED_RECEIPT_RETENTION_LIMIT) {
+      throw new Error("runtime projection acknowledgement batch is too large");
+    }
+    if (operationIds.some((operationId) => typeof operationId !== "string" || !operationId)) {
+      throw new Error("runtime projection acknowledgement id is invalid");
+    }
+    return this.db.query(
+      `UPDATE operations SET projection_pending = NULL
+       WHERE projection_pending IS NOT NULL AND operation_id IN (${operationIds.map(() => "?").join(", ")})`,
+    ).run(...operationIds).changes;
+  }
+
+  /** The receipts compaction is holding for an unacknowledged projection, newest
+      first — the exact set the cap below is applied to. */
+  unprojectedTerminalOperationIds(limit = RUNTIME_UNPROJECTED_RECEIPT_RETENTION_LIMIT): string[] {
+    this.assertHealthy();
+    return this.db.query<{ operation_id: string }, [number]>(
+      "SELECT operation_id FROM operations WHERE projection_pending IS NOT NULL ORDER BY event_seq DESC LIMIT ?",
+    ).all(Math.max(0, limit)).map((row) => row.operation_id);
+  }
+
+  compact(maxEvents = this.maxEvents, unprojectedReceiptLimit = RUNTIME_UNPROJECTED_RECEIPT_RETENTION_LIMIT): void {
     this.assertHealthy();
     const count = Number(this.db.query<{ count: number }, []>("SELECT COUNT(*) AS count FROM events").get()?.count ?? 0);
     if (count <= maxEvents) return;
@@ -1358,7 +1413,29 @@ export class RuntimeJournal {
       this.db.query("DELETE FROM events WHERE seq <= ?").run(anchor.seq);
       this.db.exec("DELETE FROM consumer_checkpoints WHERE NOT EXISTS (SELECT 1 FROM events WHERE events.event_id = consumer_checkpoints.event_id)");
       this.db.query("DELETE FROM outbox WHERE state = 'completed' AND event_seq <= ?").run(anchor.seq);
-      this.db.query("DELETE FROM operations WHERE event_seq <= ? AND operation_id NOT IN (SELECT substr(id, 8) FROM outbox WHERE state = 'pending' AND id LIKE 'effect:%')").run(anchor.seq);
+      /* Two reasons an operation outlives the anchor: an effect still owed
+         execution, and a terminal receipt still owed a projection (#1612). The
+         second is capped, and the cap keeps the NEWEST obligations, so a
+         Viewer that stopped acknowledging cannot pin the table indefinitely
+         while a live repair keeps the receipts it can still consume. */
+      const released = Number(this.db.query<{ count: number }, [number, number]>(
+        `SELECT COUNT(*) AS count FROM operations
+         WHERE event_seq <= ? AND projection_pending IS NOT NULL
+           AND operation_id NOT IN (
+             SELECT operation_id FROM operations WHERE projection_pending IS NOT NULL ORDER BY event_seq DESC LIMIT ?
+           )`,
+      ).get(anchor.seq, Math.max(0, unprojectedReceiptLimit))?.count ?? 0);
+      this.db.query(
+        `DELETE FROM operations
+         WHERE event_seq <= ?
+           AND operation_id NOT IN (SELECT substr(id, 8) FROM outbox WHERE state = 'pending' AND id LIKE 'effect:%')
+           AND operation_id NOT IN (
+             SELECT operation_id FROM operations WHERE projection_pending IS NOT NULL ORDER BY event_seq DESC LIMIT ?
+           )`,
+      ).run(anchor.seq, Math.max(0, unprojectedReceiptLimit));
+      if (released > 0) {
+        console.error(`[runtime journal] compaction released ${released} unacknowledged terminal receipt(s) over the ${unprojectedReceiptLimit} retention cap`);
+      }
       this.db.exec("DELETE FROM delivery_operation_actions WHERE operation_id NOT IN (SELECT operation_id FROM operations)");
       this.db.query("DELETE FROM entities WHERE kind = 'operation' AND checkpoint_seq <= ?").run(anchor.seq);
       this.metaSet("anchor_seq", String(anchor.seq));
@@ -2411,6 +2488,14 @@ export class RuntimeJournal {
   private migrateOperationOrphanedSince(): void {
     const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(operations)").all().map((row) => row.name));
     if (!columns.has("orphaned_since")) this.db.exec("ALTER TABLE operations ADD COLUMN orphaned_since INTEGER");
+  }
+
+  /** #1612. Null on every existing row, which reads as "owed nothing": a
+      journal written before this column keeps exactly its previous retention,
+      and only transitions that ask for projection retention set it. */
+  private migrateOperationProjectionPending(): void {
+    const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(operations)").all().map((row) => row.name));
+    if (!columns.has("projection_pending")) this.db.exec("ALTER TABLE operations ADD COLUMN projection_pending INTEGER");
   }
 
   private migrateLegacyEvents(): void {

--- a/src/runtime-host/terminalProjectionRetention.test.ts
+++ b/src/runtime-host/terminalProjectionRetention.test.ts
@@ -1,0 +1,262 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+
+import { runtimeScope } from "@/lib/runtime/contracts";
+
+import { RuntimeHost } from "./host";
+import { RUNTIME_UNPROJECTED_RECEIPT_RETENTION_LIMIT, RuntimeJournal } from "./journal";
+
+/* Isolated files only: every case here writes a journal of its own under the
+   process temp directory and never reads the operator's runtime state. */
+function sandbox(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `llv-projection-${name}-`));
+}
+
+function journalWithHostedSession(name: string, conversationId = "conv-projection"): RuntimeJournal {
+  const journal = new RuntimeJournal(path.join(sandbox(name), "events.sqlite"), { structuredHosts: true });
+  journal.append({
+    scope: runtimeScope("session", conversationId),
+    kind: "session-status",
+    payload: {
+      conversationId,
+      sessionKey: { engine: "codex", sessionId: "thread-projection" },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  return journal;
+}
+
+/** Admits one send and ends it, the way the delivery queue does: `awaitProjection`
+    is what the queue asks for on a terminal transition it must project. */
+function deliveredSend(
+  journal: RuntimeJournal,
+  operationId: string,
+  options: { awaitProjection?: boolean; conversationId?: string } = {},
+): void {
+  const conversationId = options.conversationId ?? "conv-projection";
+  journal.executeOperation({
+    kind: "send",
+    operationId,
+    idempotencyKey: operationId,
+    conversationId,
+    text: `message for ${operationId}`,
+    policy: "queue",
+  });
+  journal.transitionOperation(
+    operationId,
+    "delivered",
+    {},
+    options.awaitProjection ? { awaitProjection: true } : {},
+  );
+}
+
+/** Pushes the compaction anchor past everything written so far. */
+function compactPastEverything(journal: RuntimeJournal, conversationId = "conv-projection", retentionLimit?: number): void {
+  journal.append({
+    scope: runtimeScope("session", conversationId),
+    kind: "session-status",
+    payload: { conversationId, host: "hosted", turn: "idle" },
+  });
+  if (retentionLimit === undefined) journal.compact(1);
+  else journal.compact(1, retentionLimit);
+}
+
+test("a terminal receipt whose projection is owed survives compaction", () => {
+  const journal = journalWithHostedSession("retained");
+  deliveredSend(journal, "op-retained", { awaitProjection: true });
+
+  compactPastEverything(journal);
+
+  expect(journal.operationResult("op-retained")?.receipt.status).toBe("delivered");
+  expect(journal.unprojectedTerminalOperationIds()).toEqual(["op-retained"]);
+  journal.close();
+});
+
+test("a terminal transition that asks for nothing retains nothing", () => {
+  const journal = journalWithHostedSession("unretained");
+  deliveredSend(journal, "op-unretained");
+
+  compactPastEverything(journal);
+
+  expect(journal.operationResult("op-unretained")).toBeNull();
+  expect(journal.unprojectedTerminalOperationIds()).toEqual([]);
+  journal.close();
+});
+
+test("acknowledgement releases the receipt, and the next compaction takes it", () => {
+  const journal = journalWithHostedSession("acknowledged");
+  deliveredSend(journal, "op-acknowledged", { awaitProjection: true });
+
+  expect(journal.acknowledgeTerminalProjection(["op-acknowledged"])).toBe(1);
+  expect(journal.unprojectedTerminalOperationIds()).toEqual([]);
+  compactPastEverything(journal);
+
+  expect(journal.operationResult("op-acknowledged")).toBeNull();
+  journal.close();
+});
+
+test("acknowledgement moves the receipt itself in no way", () => {
+  const journal = journalWithHostedSession("untouched");
+  deliveredSend(journal, "op-untouched", { awaitProjection: true });
+  const before = journal.operationResult("op-untouched")!.receipt;
+
+  journal.acknowledgeTerminalProjection(["op-untouched"]);
+
+  expect(journal.operationResult("op-untouched")!.receipt).toEqual(before);
+  journal.close();
+});
+
+test("acknowledgement is idempotent, and an id it has never seen is a no-op", () => {
+  const journal = journalWithHostedSession("idempotent");
+  deliveredSend(journal, "op-idempotent", { awaitProjection: true });
+
+  expect(journal.acknowledgeTerminalProjection(["op-idempotent"])).toBe(1);
+  expect(journal.acknowledgeTerminalProjection(["op-idempotent"])).toBe(0);
+  expect(journal.acknowledgeTerminalProjection(["op-never-admitted"])).toBe(0);
+  expect(journal.acknowledgeTerminalProjection([])).toBe(0);
+  expect(() => journal.acknowledgeTerminalProjection([""])).toThrow("runtime projection acknowledgement id is invalid");
+  expect(() => journal.acknowledgeTerminalProjection(
+    Array.from({ length: RUNTIME_UNPROJECTED_RECEIPT_RETENTION_LIMIT + 1 }, (_, index) => `op-${index}`),
+  )).toThrow("runtime projection acknowledgement batch is too large");
+  journal.close();
+});
+
+test("retention pressure keeps the newest owed receipts and releases the oldest", () => {
+  const journal = journalWithHostedSession("pressure");
+  for (const operationId of ["op-oldest", "op-middle", "op-newest"]) {
+    deliveredSend(journal, operationId, { awaitProjection: true });
+  }
+
+  compactPastEverything(journal, "conv-projection", 2);
+
+  expect(journal.unprojectedTerminalOperationIds()).toEqual(["op-newest", "op-middle"]);
+  expect(journal.operationResult("op-oldest")).toBeNull();
+  expect(journal.operationResult("op-middle")?.receipt.status).toBe("delivered");
+  expect(journal.operationResult("op-newest")?.receipt.status).toBe("delivered");
+  journal.close();
+});
+
+test("an unacknowledged receipt is retained however far the anchor moves", () => {
+  const journal = journalWithHostedSession("repeated");
+  deliveredSend(journal, "op-repeated", { awaitProjection: true });
+
+  for (let pass = 0; pass < 3; pass += 1) compactPastEverything(journal);
+
+  expect(journal.operationResult("op-repeated")?.receipt.status).toBe("delivered");
+  journal.close();
+});
+
+test("a journal written before this column migrates on open and keeps its receipts", () => {
+  const filename = path.join(sandbox("migration"), "events.sqlite");
+  const before = new RuntimeJournal(filename, { structuredHosts: true });
+  before.close();
+  /* The shape a runtime host released before this repair leaves behind. */
+  const legacy = new Database(filename);
+  legacy.exec("ALTER TABLE operations DROP COLUMN projection_pending");
+  legacy.close();
+
+  const journal = new RuntimeJournal(filename, { structuredHosts: true });
+  journal.append({
+    scope: runtimeScope("session", "conv-projection"),
+    kind: "session-status",
+    payload: {
+      conversationId: "conv-projection",
+      sessionKey: { engine: "codex", sessionId: "thread-projection" },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  deliveredSend(journal, "op-migrated", { awaitProjection: true });
+  compactPastEverything(journal);
+
+  expect(journal.operationResult("op-migrated")?.receipt.status).toBe("delivered");
+  expect(journal.unprojectedTerminalOperationIds()).toEqual(["op-migrated"]);
+  journal.close();
+});
+
+/* The same obligation over the socket, where a Viewer and a runtime host of
+   different releases actually meet. */
+
+function hostFor(journal: RuntimeJournal): RuntimeHost {
+  return new RuntimeHost(journal, undefined, undefined, true);
+}
+
+test("the transition RPC carries the retention obligation, and the acknowledgement RPC releases it", async () => {
+  const journal = journalWithHostedSession("rpc");
+  const host = hostFor(journal);
+  journal.executeOperation({
+    kind: "send",
+    operationId: "op-rpc",
+    idempotencyKey: "op-rpc",
+    conversationId: "conv-projection",
+    text: "message for op-rpc",
+    policy: "queue",
+  });
+
+  const transitioned = await host.handle({
+    id: "request-transition",
+    method: "operation-transition",
+    params: { operationId: "op-rpc", status: "delivered", awaitProjection: true },
+  });
+  expect(transitioned.ok).toBe(true);
+  expect(journal.unprojectedTerminalOperationIds()).toEqual(["op-rpc"]);
+
+  const acknowledged = await host.handle({
+    id: "request-ack",
+    method: "operation-projection-ack",
+    params: { operationIds: ["op-rpc"] },
+  });
+  expect(acknowledged).toMatchObject({ ok: true, result: 1 });
+  expect(journal.unprojectedTerminalOperationIds()).toEqual([]);
+  journal.close();
+});
+
+test("the RPC refuses a malformed retention flag and malformed acknowledgement ids", async () => {
+  const journal = journalWithHostedSession("rpc-invalid");
+  const host = hostFor(journal);
+  journal.executeOperation({
+    kind: "send",
+    operationId: "op-rpc-invalid",
+    idempotencyKey: "op-rpc-invalid",
+    conversationId: "conv-projection",
+    text: "message for op-rpc-invalid",
+    policy: "queue",
+  });
+
+  expect(await host.handle({
+    id: "request-flag",
+    method: "operation-transition",
+    params: { operationId: "op-rpc-invalid", status: "delivered", awaitProjection: "yes" },
+  })).toMatchObject({ ok: false, error: "runtime operation projection retention flag is invalid" });
+  expect(journal.operationResult("op-rpc-invalid")?.receipt.status).toBe("queued");
+
+  expect(await host.handle({
+    id: "request-ids",
+    method: "operation-projection-ack",
+    params: { operationIds: "op-rpc-invalid" },
+  })).toMatchObject({ ok: false, error: "runtime projection acknowledgement ids are invalid" });
+  journal.close();
+});
+
+test("a runtime host with structured delivery disabled refuses the acknowledgement outright", async () => {
+  const journal = journalWithHostedSession("rpc-disabled");
+  const host = new RuntimeHost(journal, undefined, undefined, false);
+
+  expect(await host.handle({
+    id: "request-disabled",
+    method: "operation-projection-ack",
+    params: { operationIds: ["op-anything"] },
+  })).toMatchObject({ ok: false, error: "structured hosts are disabled" });
+  journal.close();
+});


### PR DESCRIPTION
Closes #1612.

A message the recipient had already received stayed `delivery-uncertain` in the durable delivery record until the Viewer was restarted, and journal compaction could delete the only proof before that happened. Two real operator messages were answered by their recipients while their reservations still read uncertain.

## What was wrong

The controller's transition port writes the runtime journal and the delivery record in that order, so a transport failure between them commits the outcome and drops the projection. The completing transition clears the outbox row in the same transaction, so no later drain pass can rediscover the operation, and the only repair — the startup sweep — ran at controller bind alone. Compaction then deleted the receipt on the ordinary event-count cadence, with no regard for whether it had ever been projected.

## What this changes

- **Drain-time repair.** The queue hands an operation whose terminal acknowledgement was lost back to the controller, which re-reads the journal's own answer — never what the failed call meant to write — and settles the reservation from it. One recipient write, original operation id / client message id / content digest untouched, no replay.
- **Ongoing recovery, bounded.** An operation whose receipt could not be read at that moment stays owed and is retried at the head of every later drain pass, under a cap that releases the oldest. The drain is the clock, so the repair needs no timer of its own and stops as soon as the journal can answer.
- **Retention until acknowledgement.** A terminal transition can ask the journal to retain its receipt until the projection is acknowledged, inside the same write transaction that commits it — a marker written afterwards would be lost by exactly the event it exists to survive. Compaction honours that up to a cap applied oldest-first, reporting anything it releases; the acknowledgement clears it and the next compaction takes the receipt as it always did.
- One shared reading of a receipt now serves both the startup sweep and the drain-time repair, so "what does this receipt settle, and against which reservation" has a single answer.

Nothing here issues a send, raises a deadline, or writes a receipt. An unreadable journal, a receipt naming another conversation, and an absent receipt after compaction all leave the record unknown.

## Backwards compatibility (Viewer and runtime host are released separately)

Both protocol additions degrade in each skew direction, and both directions are tested:

- **New Viewer, old runtime host:** the retention flag is an unknown parameter the old transition handler ignores, and the acknowledgement method answers "unsupported", which the Viewer swallows. The drain-time repair needs no protocol addition at all, so it still works; retention behaves exactly as it does today.
- **Old Viewer, new runtime host:** nothing ever asks for retention, so nothing is retained.
- A journal file written before the new column migrates on open, with every existing row reading "owed nothing".

## Verification

Named tests only, all under an isolated `HOME` / `XDG_CONFIG_HOME` / `LLV_STATE_DIR` / `TMPDIR`, run on the pinned Bun 1.4.0.

- `src/lib/runtime/lostTerminalAcknowledgement.test.ts` — 10 pass. Lost acknowledgement, acknowledgement intact, repeated drains + rebind, compaction before projection, compaction after acknowledgement, unreadable journal, mismatched target, legacy host, refused acknowledgement, operation with no reservation.
- `src/runtime-host/terminalProjectionRetention.test.ts` — 11 pass. Retention, no retention when unasked, release, receipt left untouched, idempotent/invalid/oversize acknowledgement, retention pressure, repeated compaction, legacy-file migration, and the same obligation over the socket RPC.
- Red paths proven for each mechanism separately: removing the drain-time repair fails 5 cases; making compaction ignore the obligation fails 5; making the controller stop asking for retention fails 2.
- Adjacent suites by path, all green: `structuredDeliveryQueue`, `structuredDeliveryController`, `structuredDeliveryRebind`, `structuredDelivery.integration`, `structuredDeliveryLegacyVerdict.integration`, `structuredCompactDelivery`, `client`, `http`, `sendSettlement`, `journal`, `journalCompact`, `journalRetention`, `journalVacuum`, `journalSnapshotBounds`, `receiptSweep`, `socket`.
- `startup.test.ts` (1 fail) and `structuredSpawn.integration.test.ts` (2 fails, #1607) fail identically at the merge base — verified in a merge-base worktree, one file per invocation.
- `bunx tsc --noEmit --incremental false` → exit 0. `privacy-publication-gate --base <merge-base> --check-commits` → PASS.

## Scope

Delivery controller, delivery queue, runtime journal, its RPC surface, and the two new test files. `registry.ts`, `sendSettlement.ts` and `admittedMessageText.ts` are untouched — they belong to other lanes. #1576 (payload-confirmation collision) and #1609 (recovery whitespace normalization) are separate causes and are deliberately not addressed here.

Runtime-protocol note for release: this adds one optional transition parameter and one new socket method. It needs no live host change to be safe — an unpatched host simply retains nothing — but the full repair only holds once the runtime host is running this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
