### PR TITLE
fix(voice): enabling voice keeps the conversation's own role

### DIFF
--- a/src/app/api/runtime/realtime/route.ts
+++ b/src/app/api/runtime/realtime/route.ts
@@ -7,6 +7,7 @@ import {
   realtimeCallerFromRequest,
   realtimeConversationProject,
 } from "@/lib/runtime/realtimeInjection";
+import { voicePersonaVariantForConversation } from "@/lib/runtime/voicePersonaMandate";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
 
@@ -44,6 +45,10 @@ export async function POST(req: NextRequest): Promise<NextResponse<Record<string
        `deliverWorkerResponse` to the peer holding the call's minted session id and
        to nobody else, whatever this resolves to. */
     operator: voiceTransportOperator(req),
+    /* #1600: enabling voice must not rewrite who this conversation is. Only a
+       session deliberately created as the voice front takes the coordinator
+       role; every other conversation keeps its own and gains a microphone. */
+    personaVariant: voicePersonaVariantForConversation(requestBody.conversationId),
   });
   return NextResponse.json(result.body, { status: result.status });
 }

--- a/src/app/api/runtime/realtime/route.ts
+++ b/src/app/api/runtime/realtime/route.ts
@@ -1,13 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { voiceTransportOperator } from "@/lib/agent/operatorAuthority";
 import { executeRealtimeControl } from "@/lib/runtime/realtimeControl";
-import {
-  designatedManagerConversationId,
-  realtimeCallerFromRequest,
-  realtimeConversationProject,
-} from "@/lib/runtime/realtimeInjection";
-import { voicePersonaVariantForConversation } from "@/lib/runtime/voicePersonaMandate";
+import { realtimeRequestAuthority } from "@/lib/runtime/realtimeInjection";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
 
@@ -27,28 +21,10 @@ export async function POST(req: NextRequest): Promise<NextResponse<Record<string
   const requestBody = body && typeof body === "object" && !Array.isArray(body)
     ? body as Record<string, unknown>
     : {};
-  /* #691 §6: resolved from the capability the registry issued, never from anything
-     in the body — a caller naming itself is not evidence. */
-  const result = await executeRealtimeControl(body, undefined, {
-    caller: realtimeCallerFromRequest(req, requestBody),
-    managerConversationId: designatedManagerConversationId(
-      realtimeConversationProject(requestBody.conversationId),
-    ),
-    /* Opening and closing the call is the operator's own act, and on this loopback
-       single-user app the same-origin browser IS the operator (the cross-origin
-       rejection above is the perimeter). The only caller refused transport is an
-       AGENT, which names itself by presenting its capability — the distinction this
-       guard was always about. Designation and every other operator-only action ask
-       the SAME question through `requireOperatorAuthority`: there is no possession
-       check anywhere any more. What does NOT follow from being the operator is
-       injection — `permitRealtimeAction` grants `appendSpeech` and
-       `deliverWorkerResponse` to the peer holding the call's minted session id and
-       to nobody else, whatever this resolves to. */
-    operator: voiceTransportOperator(req),
-    /* #1600: enabling voice must not rewrite who this conversation is. Only a
-       session deliberately created as the voice front takes the coordinator
-       role; every other conversation keeps its own and gains a microphone. */
-    personaVariant: voicePersonaVariantForConversation(requestBody.conversationId),
-  });
+  const result = await executeRealtimeControl(
+    body,
+    undefined,
+    realtimeRequestAuthority(req, requestBody),
+  );
   return NextResponse.json(result.body, { status: result.status });
 }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -2142,6 +2142,35 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
   }
   const manager: { conversationId: string; path: string | null } = { conversationId: seat.conversationId, path: seat.path };
 
+  /* NO CIRCLES (#1600). The recipient is the project's designated orchestrator,
+     so a caller that IS that orchestrator would relay the instruction to itself:
+     the operator watched exactly this — a seat with voice enabled announced it
+     would hand the finished reviews "to the manager", the directive arrived back
+     in its own conversation, and the work went undone while the board still
+     showed it as the manager.
+     The persona a call injects no longer tells a seat to relay (voicePersonaMandate),
+     which is the cause. This is the tool refusing to close the circle whatever it
+     is told — by an operator override, by a thread still carrying the old item, or
+     by a later prompt edit. The refusal SAYS WHAT TO DO INSTEAD, because an agent
+     that believes it must delegate and is merely blocked will keep retrying. */
+  /* Attribution reads process ancestry and can fault. When it does, this guard
+     stands down rather than refusing every relay: it is the SECOND layer, behind
+     the persona that no longer asks a seat to relay at all, and a defence in
+     depth that breaks the ordinary path when its input is unavailable is worse
+     than the loop it prevents. */
+  let callerConversationId: string | null = null;
+  try {
+    callerConversationId = attributionOf(dependencies).conversationId;
+  } catch {
+    callerConversationId = null;
+  }
+  if (callerConversationId && callerConversationId === manager.conversationId) {
+    throw new McpToolRefusal(
+      `you are the designated orchestrator for ${project}, so this directive would be addressed to you. Voice changes how you hear a request, not who acts on it: do this work yourself with your own tools. Relay only to an orchestrator that is not you.`,
+      { code: "directive_self_relay", project },
+    );
+  }
+
   const ref = args.ref;
   const trailer: BridgeTrailer | undefined = typeof ref === "number" && Number.isInteger(ref) && ref > 0
     ? { ref }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -2142,7 +2142,7 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
   }
   const manager: { conversationId: string; path: string | null } = { conversationId: seat.conversationId, path: seat.path };
 
-  /* NO CIRCLES (#1600). The recipient is the project's designated orchestrator,
+  /* NO CIRCLES (#1615). The recipient is the project's designated orchestrator,
      so a caller that IS that orchestrator would relay the instruction to itself:
      the operator watched exactly this — a seat with voice enabled announced it
      would hand the finished reviews "to the manager", the directive arrived back
@@ -2166,7 +2166,7 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
   }
   if (callerConversationId && callerConversationId === manager.conversationId) {
     throw new McpToolRefusal(
-      `you are the designated orchestrator for ${project}, so this directive would be addressed to you. Voice changes how you hear a request, not who acts on it: do this work yourself with your own tools. Relay only to an orchestrator that is not you.`,
+      `you are the designated orchestrator for ${project}, so this directive would be addressed to you. Voice changes how you hear a request. It does not change who acts on it: do this work yourself, with your own tools. Relay only to an orchestrator that is not you.`,
       { code: "directive_self_relay", project },
     );
   }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -2152,12 +2152,12 @@ async function bridgeDirective(args: McpToolArgs, control: ViewerControlDependen
      which is the cause. This is the tool refusing to close the circle whatever it
      is told — by an operator override, by a thread still carrying the old item, or
      by a later prompt edit. The refusal SAYS WHAT TO DO INSTEAD, because an agent
-     that believes it must delegate and is merely blocked will keep retrying. */
-  /* Attribution reads process ancestry and can fault. When it does, this guard
-     stands down rather than refusing every relay: it is the SECOND layer, behind
-     the persona that no longer asks a seat to relay at all, and a defence in
-     depth that breaks the ordinary path when its input is unavailable is worse
-     than the loop it prevents. */
+     that believes it must delegate and is merely blocked will keep retrying.
+
+     Attribution reads process ancestry and can fault. When it does, this stands
+     down rather than refusing every relay: a defence in depth that breaks the
+     ordinary path when its own input is unavailable is worse than the loop it
+     prevents, and the persona is the layer that stops this being reached. */
   let callerConversationId: string | null = null;
   try {
     callerConversationId = attributionOf(dependencies).conversationId;

--- a/src/lib/mcp/bridgeDirective.test.ts
+++ b/src/lib/mcp/bridgeDirective.test.ts
@@ -491,7 +491,7 @@ test("a project with no VALIDATED seat refuses rather than falling back to anoth
 });
 
 /**
- * The loop the operator watched happen (#1600).
+ * The loop the operator watched happen (#1615).
  *
  * Voice was enabled on the conversation holding the seat, the call injected the
  * coordinator persona, and the seat did what it now believed it was for: it

--- a/src/lib/mcp/bridgeDirective.test.ts
+++ b/src/lib/mcp/bridgeDirective.test.ts
@@ -77,6 +77,10 @@ function bindings(
   /** What the delivery path answers. `delivered` is arrival; `queued` is
       acceptance, and the two must not settle a decision request alike. */
   deliveryOutcome: "delivered" | "queued" = "delivered",
+  /** Who the server attributes the call to. The default is the voice gateway,
+      which is what every other test here is. */
+  callerAttribution: { kind: string; conversationId: string | null; role: string | null } =
+    { kind: "gateway", conversationId: "conversation_gateway", role: null },
 ) {
   posted = [];
   const control: ViewerControlDependencies = {
@@ -90,6 +94,7 @@ function bindings(
   return viewerMcpBindings(undefined, control, {
     callerProject: () => callerProject,
     authorizedSeats: realSeatAuthority,
+    callerAttribution: () => callerAttribution,
     ...(canonicalSeatConversationId ? { canonicalSeatConversationId } : {}),
   } as never);
 }
@@ -483,4 +488,65 @@ test("a project with no VALIDATED seat refuses rather than falling back to anoth
     project: "proj-unknown",
   })).rejects.toThrow();
   expect(posted).toEqual([]);
+});
+
+/**
+ * The loop the operator watched happen (#1600).
+ *
+ * Voice was enabled on the conversation holding the seat, the call injected the
+ * coordinator persona, and the seat did what it now believed it was for: it
+ * relayed the work onward. The recipient is resolved from the designation
+ * record, so "onward" was itself. The instruction arrived back in the same
+ * conversation, the cards went untriaged, and the Viewer still showed the
+ * conversation as the manager the whole time.
+ *
+ * The persona fix stops the seat being told to relay. This stops the relay from
+ * closing a circle even if something tells it to anyway — an operator override,
+ * a thread that already carries the old item, a future prompt edit.
+ */
+test("a designated seat cannot relay an instruction to itself", async () => {
+  sandbox();
+  const tools = bindings(
+    "proj-voice",
+    undefined,
+    "delivered",
+    /* The server's own attribution of the caller: this IS the seat. */
+    { kind: "manager", conversationId: "conversation_manager", role: "orchestrator" },
+  );
+
+  await expect(tools.bridge_directive({
+    clientRequestId: "self-relay",
+    rootTurnId: "turn_0400",
+    utterance: 0,
+    instruction: "harvest the finished reviews and update the cards",
+  })).rejects.toThrow(/yourself/i);
+
+  /* Nothing was delivered: the instruction did not come back around. */
+  expect(posted).toHaveLength(0);
+});
+
+test("a seat may still relay to another project's orchestrator", async () => {
+  /* The refusal is about the circle, not about being a manager. A seat that
+     names another project addresses a different conversation, and that is an
+     ordinary relay. */
+  sandbox();
+  seatProject("proj-other", "conversation_other_manager");
+  const tools = bindings(
+    "proj-voice",
+    undefined,
+    "delivered",
+    { kind: "manager", conversationId: "conversation_manager", role: "orchestrator" },
+  );
+
+  const receipt = await tools.bridge_directive({
+    clientRequestId: "cross-project",
+    rootTurnId: "turn_0401",
+    utterance: 0,
+    instruction: "the shared migration landed, rebase your lane",
+    project: "proj-other",
+  });
+
+  expect(posted).toHaveLength(1);
+  expect(posted[0]!.body.conversationId).toBe("conversation_other_manager");
+  expect(receipt).toMatchObject({ managerConversationId: "conversation_other_manager" });
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -718,7 +718,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("a thread already carrying a coordinator persona still receives the modality correction", async () => {
-    /* #1600, the half that cannot be undone. A thread demoted by a call taken
+    /* #1615, the half that cannot be undone. A thread demoted by a call taken
        before this fix keeps that developer item forever — the transcript is
        append-only. What CAN happen is that the next call adds the text that
        outranks it, and that only works because the two variants own different
@@ -5145,6 +5145,89 @@ test("a cancelled persona insertion failure cannot reject the successor start", 
     expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
   } finally {
     await host.release();
+  }
+});
+
+/**
+ * One thread now has TWO persona identities, so the host's bootstrap memo is per
+ * variant or it is wrong (#1615 review, finding 1).
+ *
+ * Both fields were per-host booleans written when a thread could only ever hold
+ * one persona item. With two variants that premise fails in two directions, and
+ * each has its own test below: a stale unresolved payload puts the WRONG TEXT in
+ * the transcript, and a global accepted flag makes the host claim an item it
+ * never injected.
+ */
+test("a variant switch after a rejected insertion injects the new variant's text, not the stale payload", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-variant-stale-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const server = new FakeAppServer("voice-thread");
+  server.threadPath = transcriptPath;
+  server.injectItemsError = "temporary insertion refusal";
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const rejected = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:rejected\r\n", "coordinator");
+    expect(rejected.personaBootstrap.insertion).toBe("rejected");
+
+    /* The next call resolves the OTHER variant — the fail-safe in
+       `voicePersonaVariantForConversation` answering `modality` for one start is
+       exactly how a host sees two variants in a row. */
+    server.injectItemsError = null;
+    const accepted = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:switched\r\n", "modality");
+    expect(accepted.personaBootstrap.insertion).toBe("accepted");
+    expect(accepted.personaBootstrap.itemId)
+      .toBe(voicePersonaBootstrapIdentity("voice-thread", "modality").itemId);
+
+    /* The item that actually went to the provider must be the one the receipt
+       names, carrying the persona the receipt implies. */
+    const injected = server.requests.filter((request) => request.method === "thread/inject_items").at(-1);
+    const item = (injected?.params as { items: Array<{ id: string; content: Array<{ text: string }> }> }).items[0];
+    expect(item?.id).toBe(accepted.personaBootstrap.itemId);
+    expect(item?.content[0]?.text).toBe(voicePersona("modality"));
+    expect(item?.content[0]?.text).not.toBe(COORDINATOR_VOICE_PERSONA);
+  } finally {
+    await host.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("a second variant on the same host is injected rather than reported accepted on the first one's receipt", async () => {
+  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-variant-second-"));
+  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
+  fs.writeFileSync(transcriptPath, "");
+  const server = new FakeAppServer("voice-thread");
+  server.threadPath = transcriptPath;
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  try {
+    const first = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:first\r\n", "modality");
+    expect(first.personaBootstrap.insertion).toBe("accepted");
+    await host.stopRealtime();
+
+    const second = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:second\r\n", "coordinator");
+    expect(second.personaBootstrap.insertion).toBe("accepted");
+    expect(second.personaBootstrap.itemId)
+      .toBe(voicePersonaBootstrapIdentity("voice-thread", "coordinator").itemId);
+
+    /* An `accepted` receipt naming an item that is not in the thread is the
+       failure `rejectStartedRealtimeContract` exists to catch, reported as a
+       success instead. Both variants are now genuinely present. */
+    const attempts = server.requests.filter((request) => request.method === "thread/inject_items");
+    expect(attempts).toHaveLength(2);
+    const persisted = fs.readFileSync(transcriptPath, "utf8");
+    expect(persisted).toContain(first.personaBootstrap.itemId);
+    expect(persisted).toContain(second.personaBootstrap.itemId);
+  } finally {
+    await host.release();
+    fs.rmSync(isolated, { recursive: true, force: true });
   }
 });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -22,7 +22,13 @@ import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, st
 import { STRUCTURED_IMAGE_CAPABILITY, structuredContent, type StructuredImageRef } from "./structuredContent";
 import { materializeStructuredHostAccess, READ_ONLY_STAGE_PERMISSION_PROFILE } from "./structuredSpawn";
 import type { RuntimeVoiceDelivery } from "./voiceDelivery";
-import { DEFAULT_VOICE_PERSONA, VOICE_PERSONA_FILE, legacyVoicePersonaBootstrapItemId, voicePersona } from "./voicePersona";
+import {
+  COORDINATOR_VOICE_PERSONA,
+  VOICE_PERSONA_FILE,
+  legacyVoicePersonaBootstrapItemId,
+  voicePersona,
+  voicePersonaBootstrapIdentity,
+} from "./voicePersona";
 
 function deliveryDedup(operationId: string): string {
   return createHash("sha256").update(operationId).digest("hex");
@@ -588,7 +594,7 @@ describe("CodexAppServerHost", () => {
       type: "message",
       id: started.personaBootstrap.itemId,
       role: "developer",
-      content: [{ type: "input_text", text: voicePersona() }],
+      content: [{ type: "input_text", text: voicePersona("modality") }],
     }]);
     expect(server.requests.findIndex((request) => request.method === "thread/inject_items"))
       .toBeLessThan(server.requests.findIndex((request) => request.method === "thread/realtime/start"));
@@ -631,12 +637,12 @@ describe("CodexAppServerHost", () => {
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(firstServer),
       });
-      const first = await firstHost.startRealtimeWebRtc(offers[0]);
+      const first = await firstHost.startRealtimeWebRtc(offers[0], "coordinator");
       expect(first.personaBootstrap.insertion).toBe("accepted");
       await firstHost.stopRealtime();
 
       fs.writeFileSync(overridePath, "Changed after the call was resolved.\n");
-      const duplicate = await firstHost.startRealtimeWebRtc(offers[1]);
+      const duplicate = await firstHost.startRealtimeWebRtc(offers[1], "coordinator");
       expect(duplicate.personaBootstrap).toEqual(first.personaBootstrap);
       expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
       await firstHost.stopRealtime();
@@ -651,7 +657,7 @@ describe("CodexAppServerHost", () => {
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(resumedServer),
       });
-      const recovered = await resumedHost.startRealtimeWebRtc(offers[2]);
+      const recovered = await resumedHost.startRealtimeWebRtc(offers[2], "coordinator");
       expect(recovered.personaBootstrap).toEqual(first.personaBootstrap);
       expect(resumedServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
 
@@ -693,7 +699,7 @@ describe("CodexAppServerHost", () => {
         spawnProcess: fakeSpawn(server),
       });
       try {
-        const started = await host.startRealtimeWebRtc(`v=0\r\na=ice-ufrag:${suffix}\r\n`);
+        const started = await host.startRealtimeWebRtc(`v=0\r\na=ice-ufrag:${suffix}\r\n`, "coordinator");
         expect(started.personaBootstrap.insertion).toBe("accepted");
         expect(started.personaBootstrap.itemId.length).toBeLessThanOrEqual(64);
         expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
@@ -709,6 +715,61 @@ describe("CodexAppServerHost", () => {
     expect(personaRows).toHaveLength(1);
     expect(personaRows[0]?.payload?.id).toBe(legacyItemId);
     fs.rmSync(isolated, { recursive: true, force: true });
+  });
+
+  test("a thread already carrying a coordinator persona still receives the modality correction", async () => {
+    /* #1600, the half that cannot be undone. A thread demoted by a call taken
+       before this fix keeps that developer item forever — the transcript is
+       append-only. What CAN happen is that the next call adds the text that
+       outranks it, and that only works because the two variants own different
+       item ids: a shared id would read the coordinator row as proof that this
+       thread was already bootstrapped and inject nothing.
+
+       Both shapes of the old row are covered: the canonical one and the
+       pre-#870 legacy one, which is a coordinator persona by construction. */
+    for (const existing of ["canonical", "legacy"] as const) {
+      const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-demoted-thread-"));
+      const threadId = "demoted-voice-thread";
+      const transcriptPath = path.join(isolated, "demoted.jsonl");
+      const priorItemId = existing === "legacy"
+        ? legacyVoicePersonaBootstrapItemId(threadId)
+        : voicePersonaBootstrapIdentity(threadId, "coordinator").itemId;
+      fs.writeFileSync(transcriptPath, `${JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          id: priorItemId,
+          role: "developer",
+          content: [{ type: "input_text", text: COORDINATOR_VOICE_PERSONA }],
+        },
+      })}\n`);
+
+      const server = new FakeAppServer(threadId);
+      server.threadPath = transcriptPath;
+      const host = await CodexAppServerHost.adopt(threadId, {
+        cwd: "/repo",
+        eventStore: new MemoryEventStore(),
+        spawnProcess: fakeSpawn(server),
+      });
+      try {
+        const started = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:correct\r\n", "modality");
+        expect(started.personaBootstrap.insertion).toBe("accepted");
+        expect(started.personaBootstrap.itemId)
+          .toBe(voicePersonaBootstrapIdentity(threadId, "modality").itemId);
+
+        const injected = server.requests.filter((request) => request.method === "thread/inject_items");
+        expect(injected).toHaveLength(1);
+        const item = (injected[0]?.params as { items: Array<{ id: string; content: Array<{ text: string }> }> }).items[0];
+        expect(item?.id).toBe(started.personaBootstrap.itemId);
+        expect(item?.content[0]?.text).toBe(voicePersona("modality"));
+        /* The correction, not a second copy of the demotion. */
+        expect(item?.content[0]?.text).not.toBe(COORDINATOR_VOICE_PERSONA);
+        await host.stopRealtime();
+      } finally {
+        await host.release();
+        fs.rmSync(isolated, { recursive: true, force: true });
+      }
+    }
   });
 
   test("seeds a resumed realtime call with the interrupted duplex tail in canonical order", async () => {
@@ -1059,7 +1120,7 @@ describe("CodexAppServerHost", () => {
     /* Written with surrounding whitespace, because the resolver trims and the
        injected item must carry the trimmed text. */
     fs.writeFileSync(overridePath, `  ${override}\n`);
-    expect(override).not.toBe(DEFAULT_VOICE_PERSONA);
+    expect(override).not.toBe(COORDINATOR_VOICE_PERSONA);
 
     const previousConfigHome = process.env.XDG_CONFIG_HOME;
     process.env.XDG_CONFIG_HOME = configDirectory;
@@ -1070,7 +1131,10 @@ describe("CodexAppServerHost", () => {
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(server),
       });
-      await host.startRealtimeWebRtc("v=0\r\noffer");
+      /* The override file is the coordinator variant's, so this is a coordinator
+         call — see `voicePersona`, where the modality variant deliberately keeps
+         the built-in text. */
+      await host.startRealtimeWebRtc("v=0\r\noffer", "coordinator");
 
       const injected = server.requests.find((request) => request.method === "thread/inject_items");
       const item = (injected?.params as {
@@ -5106,6 +5170,7 @@ test("a rejected persona insertion retries the same resolved payload and stable 
   try {
     const rejected = await host.startRealtimeWebRtc(
       "v=0\r\no=- 505 2 IN IP4 127.0.0.1\r\na=ice-ufrag:rejected\r\n",
+      "coordinator",
     );
     expect(rejected.personaBootstrap.insertion).toBe("rejected");
 
@@ -5113,6 +5178,7 @@ test("a rejected persona insertion retries the same resolved payload and stable 
     server.injectItemsError = null;
     const accepted = await host.startRealtimeWebRtc(
       "v=0\r\no=- 606 2 IN IP4 127.0.0.1\r\na=ice-ufrag:retry\r\n",
+      "coordinator",
     );
     expect(accepted.personaBootstrap.receiptId).toBe(rejected.personaBootstrap.receiptId);
     expect(accepted.personaBootstrap.itemId).toBe(rejected.personaBootstrap.itemId);

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -60,6 +60,7 @@ import {
   legacyVoicePersonaBootstrapItemId,
   voicePersonaBootstrap,
   voicePersonaBootstrapIdentity,
+  type VoicePersonaVariant,
   type VoicePersonaBootstrap,
   type VoicePersonaBootstrapIdentity,
   type VoicePersonaBootstrapReceipt,
@@ -1814,7 +1815,16 @@ export class CodexAppServerHost implements EngineHost {
     ));
   }
 
-  async startRealtimeWebRtc(sdp: string): Promise<CodexRealtimeWebRtcResult> {
+  /**
+   * @param personaVariant which persona this call bootstraps into the thread.
+   *   Defaults to `modality`, the variant that assigns no role: a caller that did
+   *   not resolve the question has not established that this thread is the voice
+   *   front, and the coordinator mandate overwrites whatever role it finds.
+   */
+  async startRealtimeWebRtc(
+    sdp: string,
+    personaVariant: VoicePersonaVariant = "modality",
+  ): Promise<CodexRealtimeWebRtcResult> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
       throw new Error("Codex app-server host is unavailable");
     }
@@ -1830,7 +1840,7 @@ export class CodexAppServerHost implements EngineHost {
        be reported against this one. */
     this.realtimeFailure = null;
     this.realtimeSessionId = null;
-    const personaBootstrapIdentity = voicePersonaBootstrapIdentity(this.identity.threadId);
+    const personaBootstrapIdentity = voicePersonaBootstrapIdentity(this.identity.threadId, personaVariant);
 
     let pendingStart!: PendingRealtimeStart;
     const answer = new Promise<CodexRealtimeWebRtcResult>((resolve, reject) => {
@@ -1848,7 +1858,7 @@ export class CodexAppServerHost implements EngineHost {
     void answer.catch(() => undefined);
 
     try {
-      const outcome = await this.ensureVoicePersonaBootstrap(personaBootstrapIdentity, pendingStart);
+      const outcome = await this.ensureVoicePersonaBootstrap(personaBootstrapIdentity, personaVariant, pendingStart);
       if (outcome === "superseded") return answer;
     } catch (error) {
       if (this.pendingRealtimeStart !== pendingStart) return answer;
@@ -1901,6 +1911,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private async ensureVoicePersonaBootstrap(
     identity: VoicePersonaBootstrapIdentity,
+    variant: VoicePersonaVariant,
     pendingStart: PendingRealtimeStart,
   ): Promise<"accepted" | "superseded"> {
     await this.ensureCanonicalTranscriptPath();
@@ -1921,10 +1932,16 @@ export class CodexAppServerHost implements EngineHost {
         identity.itemId,
         "canonical scan unavailable; refusing insertion",
       );
-      const legacyExists = canonicalExists ? false : await this.scanVoicePersonaBootstrap(
-        legacyVoicePersonaBootstrapItemId(this.identity.threadId),
-        "legacy canonical scan unavailable; refusing insertion",
-      );
+      /* The pre-#870 row is a COORDINATOR persona — no other variant existed when
+         it was written — so it answers only a coordinator bootstrap. A modality
+         start that accepted it would read "this thread is already bootstrapped"
+         off the very item it exists to correct, and leave the session demoted. */
+      const legacyExists = canonicalExists || variant !== "coordinator"
+        ? false
+        : await this.scanVoicePersonaBootstrap(
+          legacyVoicePersonaBootstrapItemId(this.identity.threadId),
+          "legacy canonical scan unavailable; refusing insertion",
+        );
       if (canonicalExists || legacyExists) {
         this.voicePersonaBootstrapAccepted = true;
         this.unresolvedVoicePersonaBootstrap = null;
@@ -1933,7 +1950,7 @@ export class CodexAppServerHost implements EngineHost {
       if (this.pendingRealtimeStart !== pendingStart) return "superseded";
       if (this.voicePersonaBootstrapInsertion) continue;
 
-      const bootstrap = this.unresolvedVoicePersonaBootstrap ?? voicePersonaBootstrap(identity);
+      const bootstrap = this.unresolvedVoicePersonaBootstrap ?? voicePersonaBootstrap(identity, variant);
       this.unresolvedVoicePersonaBootstrap = bootstrap;
       const promise = this.insertVoicePersonaBootstrap(bootstrap, identity.itemId);
       const insertion = { owner: pendingStart, promise };

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1130,11 +1130,17 @@ export class CodexAppServerHost implements EngineHost {
   private readonly pendingCompactions = new Map<string, PendingCompaction>();
   private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
   private readonly voiceStreams = new Map<string, VoiceStreamState>();
-  /* A host's thread id is immutable, so one memo covers its one stable persona
-     item. Successor starts join the same insertion promise. */
-  private unresolvedVoicePersonaBootstrap: VoicePersonaBootstrap | null = null;
+  /* KEYED BY VARIANT, because a thread has one identity PER VARIANT and not one
+     overall (#1615). While the coordinator persona was the only one, a single
+     boolean and a single payload were the whole memo; with two, sharing them
+     fails in both directions — a payload resolved for one variant gets injected
+     under the other's id, and one accepted variant reports the other as accepted
+     without ever injecting it, which is a false receipt that
+     `rejectStartedRealtimeContract` would otherwise have caught.
+     Successor starts of the SAME variant still join the same insertion promise. */
+  private readonly unresolvedVoicePersonaBootstrap = new Map<VoicePersonaVariant, VoicePersonaBootstrap>();
   private voicePersonaBootstrapInsertion: VoicePersonaBootstrapInsertion | null = null;
-  private voicePersonaBootstrapAccepted = false;
+  private readonly voicePersonaBootstrapAccepted = new Set<VoicePersonaVariant>();
   private readonly pendingVoiceChunks = new Map<string, string>();
   private readonly cancelledVoiceTurns = new Set<string>();
   private readonly activeRealtimeDeliveries = new Map<string, {
@@ -1915,7 +1921,7 @@ export class CodexAppServerHost implements EngineHost {
     pendingStart: PendingRealtimeStart,
   ): Promise<"accepted" | "superseded"> {
     await this.ensureCanonicalTranscriptPath();
-    while (!this.voicePersonaBootstrapAccepted) {
+    while (!this.voicePersonaBootstrapAccepted.has(variant)) {
       const active = this.voicePersonaBootstrapInsertion;
       if (active) {
         try {
@@ -1943,16 +1949,17 @@ export class CodexAppServerHost implements EngineHost {
           "legacy canonical scan unavailable; refusing insertion",
         );
       if (canonicalExists || legacyExists) {
-        this.voicePersonaBootstrapAccepted = true;
-        this.unresolvedVoicePersonaBootstrap = null;
+        this.voicePersonaBootstrapAccepted.add(variant);
+        this.unresolvedVoicePersonaBootstrap.delete(variant);
         break;
       }
       if (this.pendingRealtimeStart !== pendingStart) return "superseded";
       if (this.voicePersonaBootstrapInsertion) continue;
 
-      const bootstrap = this.unresolvedVoicePersonaBootstrap ?? voicePersonaBootstrap(identity, variant);
-      this.unresolvedVoicePersonaBootstrap = bootstrap;
-      const promise = this.insertVoicePersonaBootstrap(bootstrap, identity.itemId);
+      const bootstrap = this.unresolvedVoicePersonaBootstrap.get(variant)
+        ?? voicePersonaBootstrap(identity, variant);
+      this.unresolvedVoicePersonaBootstrap.set(variant, bootstrap);
+      const promise = this.insertVoicePersonaBootstrap(bootstrap, identity.itemId, variant);
       const insertion = { owner: pendingStart, promise };
       this.voicePersonaBootstrapInsertion = insertion;
       const clearInsertion = () => {
@@ -1988,7 +1995,11 @@ export class CodexAppServerHost implements EngineHost {
     this.identity.path = recovered.path;
   }
 
-  private async insertVoicePersonaBootstrap(bootstrap: VoicePersonaBootstrap, itemId: string): Promise<void> {
+  private async insertVoicePersonaBootstrap(
+    bootstrap: VoicePersonaBootstrap,
+    itemId: string,
+    variant: VoicePersonaVariant,
+  ): Promise<void> {
     try {
       await this.rpc("thread/inject_items", {
         threadId: this.identity.threadId,
@@ -1997,8 +2008,8 @@ export class CodexAppServerHost implements EngineHost {
     } catch (error) {
       if (!await this.scanVoicePersonaBootstrap(itemId, "recovery scan unavailable")) throw error;
     }
-    this.voicePersonaBootstrapAccepted = true;
-    this.unresolvedVoicePersonaBootstrap = null;
+    this.voicePersonaBootstrapAccepted.add(variant);
+    this.unresolvedVoicePersonaBootstrap.delete(variant);
   }
 
   private async scanVoicePersonaBootstrap(itemId: string, warning: string): Promise<boolean> {
@@ -2402,7 +2413,7 @@ export class CodexAppServerHost implements EngineHost {
       this.realtimeSessionId = null;
     }
     this.releasing = true;
-    this.unresolvedVoicePersonaBootstrap = null;
+    this.unresolvedVoicePersonaBootstrap.clear();
     this.rejectRealtimeStart(new Error("Codex app-server host released"));
     this.rejectPendingAnswers(new Error("Codex app-server host released"));
     this.rejectPendingDeliveries(new Error("Codex app-server host released"));

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -107,7 +107,7 @@ export async function executeRealtimeControl(
     caller?: RealtimeCaller;
     managerConversationId?: string | null;
     operator: boolean;
-    /** Which persona a `start` bootstraps (#1600). Omitted is `modality`. */
+    /** Which persona a `start` bootstraps (#1615). Omitted is `modality`. */
     personaVariant?: VoicePersonaVariant;
   },
   dependencies: RealtimeControlDependencies = REALTIME_CONTROL_DEPENDENCIES,
@@ -157,7 +157,7 @@ export async function executeRealtimeControl(
       if (!sdp.trimStart().startsWith("v=0") || byteLength(sdp) > MAX_SDP_BYTES) {
         return { status: 400, body: { error: "a valid WebRTC SDP offer is required" } };
       }
-      /* #1600: voice is a modality, so the persona a call bootstraps is decided
+      /* #1615: voice is a modality, so the persona a call bootstraps is decided
          from WHAT THIS CONVERSATION ALREADY IS, resolved per start rather than
          cached — a seat rotation between two calls must be seen by the second.
          Absent, it is `modality`: the variant that assigns no role, because a

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -4,7 +4,7 @@ import { redactCodexHostDiagnostic } from "./codexAppServerHost";
 import { structuredDeliveryHostForConversation } from "./structuredDeliveryController";
 import { permitRealtimeAction, type RealtimeCaller } from "./realtimeInjection";
 import type { RuntimeVoiceDelivery } from "./voiceDelivery";
-import type { VoicePersonaBootstrapReceipt } from "./voicePersona";
+import type { VoicePersonaBootstrapReceipt, VoicePersonaVariant } from "./voicePersona";
 import {
   admitVoiceSelectedContext,
   bindVoiceSession,
@@ -17,7 +17,7 @@ const MAX_SDP_BYTES = 512 * 1024;
 const MAX_SPEECH_BYTES = 8 * 1024;
 
 interface RealtimeHost {
-  startRealtimeWebRtc(sdp: string): Promise<{
+  startRealtimeWebRtc(sdp: string, personaVariant?: VoicePersonaVariant): Promise<{
     sdp: string | null;
     realtimeSessionId: string | null;
     personaBootstrap: VoicePersonaBootstrapReceipt;
@@ -103,7 +103,13 @@ export async function executeRealtimeControl(
      the caller's transport can ask (`voiceTransportOperator` reads the request's
      headers), so a call site that omits it has not asked — and an unasked authority
      question must resolve to "no", not to "yes". */
-  authority: { caller?: RealtimeCaller; managerConversationId?: string | null; operator: boolean },
+  authority: {
+    caller?: RealtimeCaller;
+    managerConversationId?: string | null;
+    operator: boolean;
+    /** Which persona a `start` bootstraps (#1600). Omitted is `modality`. */
+    personaVariant?: VoicePersonaVariant;
+  },
   dependencies: RealtimeControlDependencies = REALTIME_CONTROL_DEPENDENCIES,
 ): Promise<RealtimeControlResult> {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -151,7 +157,13 @@ export async function executeRealtimeControl(
       if (!sdp.trimStart().startsWith("v=0") || byteLength(sdp) > MAX_SDP_BYTES) {
         return { status: 400, body: { error: "a valid WebRTC SDP offer is required" } };
       }
-      const answer = await host.startRealtimeWebRtc(sdp);
+      /* #1600: voice is a modality, so the persona a call bootstraps is decided
+         from WHAT THIS CONVERSATION ALREADY IS, resolved per start rather than
+         cached — a seat rotation between two calls must be seen by the second.
+         Absent, it is `modality`: the variant that assigns no role, because a
+         call site that did not ask has not established that this thread is the
+         voice front. */
+      const answer = await host.startRealtimeWebRtc(sdp, authority.personaVariant ?? "modality");
       if (!answer.personaBootstrap) {
         return rejectStartedRealtimeContract(host, { error: "Codex returned no voice persona bootstrap receipt" });
       }

--- a/src/lib/runtime/realtimeInjection.ts
+++ b/src/lib/runtime/realtimeInjection.ts
@@ -1,9 +1,12 @@
 import type { NextRequest } from "next/server";
 
 import { agentRegistry } from "@/lib/agent/registry";
+import { voiceTransportOperator } from "@/lib/agent/operatorAuthority";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { orchestratorSeatFor } from "@/lib/orchestrator/seats";
 import { resolveProjectAttribution } from "@/lib/session/projectResolution";
+import { voicePersonaVariantForConversation } from "./voicePersonaMandate";
+import type { VoicePersonaVariant } from "./voicePersona";
 
 import crypto from "node:crypto";
 
@@ -178,4 +181,52 @@ export function designatedManagerConversationId(project: string | null | undefin
   const scopedProject = project?.trim();
   if (!scopedProject) return null;
   return orchestratorSeatFor(scopedProject).active?.conversationId ?? null;
+}
+
+/** Everything `executeRealtimeControl` must be told about a request, resolved
+    server-side. */
+export interface RealtimeRequestAuthority {
+  caller: RealtimeCaller;
+  managerConversationId: string | null;
+  operator: boolean;
+  personaVariant: VoicePersonaVariant;
+}
+
+/**
+ * Compose one request's authority — extracted from the route so it can be tested.
+ *
+ * A Next.js route module may export only route fields, so a composition living
+ * inline there is reachable only by driving the whole endpoint, which needs a live
+ * structured host. That left the one line joining the persona resolver to the
+ * control path unproven (#1615 review, finding 5). Dropping `personaVariant`
+ * fails safe to `modality`; the regression worth a test is the opposite one — a
+ * resolver wired up so that it answers `coordinator` too readily.
+ *
+ * Every field is derived from the registry, the request's own headers, or the
+ * durable designation record. NOTHING is read from the body except the target
+ * conversation id, because a caller naming itself is not evidence.
+ */
+export function realtimeRequestAuthority(
+  request: Pick<NextRequest, "headers">,
+  body: Record<string, unknown>,
+): RealtimeRequestAuthority {
+  return {
+    /* #691 §6: resolved from the capability the registry issued. */
+    caller: realtimeCallerFromRequest(request, body),
+    managerConversationId: designatedManagerConversationId(
+      realtimeConversationProject(body.conversationId),
+    ),
+    /* Opening and closing the call is the operator's own act, and on this loopback
+       single-user app the same-origin browser IS the operator (the route's
+       cross-origin rejection is the perimeter). The only caller refused transport
+       is an AGENT, which names itself by presenting its capability. What does NOT
+       follow from being the operator is injection — `permitRealtimeAction` grants
+       `appendSpeech` and `deliverWorkerResponse` to the peer holding the call's
+       minted session id and to nobody else, whatever this resolves to. */
+    operator: voiceTransportOperator(request),
+    /* #1615: enabling voice must not rewrite who this conversation is. Only a
+       session deliberately created as the voice front takes the coordinator role;
+       every other conversation keeps its own and gains a microphone. */
+    personaVariant: voicePersonaVariantForConversation(body.conversationId),
+  };
 }

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -6,7 +6,8 @@ import { expect, test } from "bun:test";
 
 import {
   canonicalVoicePersonaBootstrapExists,
-  DEFAULT_VOICE_PERSONA,
+  COORDINATOR_VOICE_PERSONA,
+  MODALITY_VOICE_PERSONA,
   legacyVoicePersonaBootstrapItemId,
   PERSONA_NAME,
   voicePersona,
@@ -51,30 +52,30 @@ function languagePins(persona: string): string[] {
 }
 
 test("the built-in persona stands when no override file exists", () => {
-  const persona = voicePersona(() => { throw new Error("ENOENT"); });
-  expect(persona).toBe(DEFAULT_VOICE_PERSONA);
+  const persona = voicePersona("coordinator", () => { throw new Error("ENOENT"); });
+  expect(persona).toBe(COORDINATOR_VOICE_PERSONA);
 });
 
 test("an operator override replaces the built-in persona wholesale", () => {
   /* A new thread resolves the current override wholesale; an established
      thread keeps the developer item it already persisted. */
-  const persona = voicePersona(() => "  You are the coordinator. Keep it short.  ");
+  const persona = voicePersona("coordinator", () => "  You are the coordinator. Keep it short.  ");
   expect(persona).toBe("You are the coordinator. Keep it short.");
-  expect(persona).not.toBe(DEFAULT_VOICE_PERSONA);
+  expect(persona).not.toBe(COORDINATOR_VOICE_PERSONA);
 });
 
 test("an empty or whitespace override falls back instead of muting the persona", () => {
-  expect(voicePersona(() => "   \n  ")).toBe(DEFAULT_VOICE_PERSONA);
+  expect(voicePersona("coordinator", () => "   \n  ")).toBe(COORDINATOR_VOICE_PERSONA);
 });
 
 test("one durable thread identity produces one stable canonical developer item", () => {
-  const identity = voicePersonaBootstrapIdentity("thread-voice");
-  expect(voicePersonaBootstrapIdentity("thread-voice")).toEqual(identity);
-  expect(voicePersonaBootstrapIdentity("thread-other")).not.toEqual(identity);
+  const identity = voicePersonaBootstrapIdentity("thread-voice", "coordinator");
+  expect(voicePersonaBootstrapIdentity("thread-voice", "coordinator")).toEqual(identity);
+  expect(voicePersonaBootstrapIdentity("thread-other", "coordinator")).not.toEqual(identity);
   expect(identity.itemId.length).toBeLessThanOrEqual(64);
   expect(legacyVoicePersonaBootstrapItemId("thread-voice")).toStartWith(identity.itemId);
   expect(legacyVoicePersonaBootstrapItemId("thread-voice").length).toBe(82);
-  expect(voicePersonaBootstrap(identity, () => "  Resolved call persona. \n")).toEqual({
+  expect(voicePersonaBootstrap(identity, "coordinator", () => "  Resolved call persona. \n")).toEqual({
     item: {
       type: "message",
       id: identity.itemId,
@@ -130,10 +131,12 @@ test("canonical receipt scanning ignores malformed rows and marker-like content"
   }
 });
 
-test("the shipped persona pins no spoken language anywhere", () => {
+test("no shipped persona pins a spoken language anywhere", () => {
   /* The whole property in one line: naming any language, in any sentence, is
-     the defect — the prose may not even name the language it is written in. */
-  expect(languagePins(DEFAULT_VOICE_PERSONA)).toEqual([]);
+     the defect — the prose may not even name the language it is written in.
+     Both variants are shipped text, so both are bound by it. */
+  expect(languagePins(COORDINATOR_VOICE_PERSONA)).toEqual([]);
+  expect(languagePins(MODALITY_VOICE_PERSONA)).toEqual([]);
 });
 
 test("appending a hard pin to any language is caught", () => {
@@ -153,7 +156,7 @@ test("appending a hard pin to any language is caught", () => {
     "Use Deutsch for every reply.",
   ];
   for (const pin of pins) {
-    expect(languagePins(`${DEFAULT_VOICE_PERSONA}\n\n${pin}`)).not.toEqual([]);
+    expect(languagePins(`${COORDINATOR_VOICE_PERSONA}\n\n${pin}`)).not.toEqual([]);
   }
 });
 
@@ -168,7 +171,7 @@ test("a persona rewritten in another script is caught", () => {
   /* Body text in another script is how a persona translated back into one
      arrives, and it pins the spoken locale as hard as naming the language. */
   for (const sample of [nonLatin(0x0410, 0x0431), nonLatin(0x4e2d), nonLatin(0x05d0), nonLatin(0x3042)]) {
-    expect(languagePins(`${DEFAULT_VOICE_PERSONA}\n\n${sample}`)).toContain("non-Latin script");
+    expect(languagePins(`${COORDINATOR_VOICE_PERSONA}\n\n${sample}`)).toContain("non-Latin script");
   }
 });
 
@@ -179,67 +182,67 @@ test("the name is English too, so the guard carves out no exception for it", () 
      with the rest of the prose. */
   expect(PERSONA_NAME).toBe("Alik");
   expect(PERSONA_NAME).toMatch(/^[A-Za-z]+$/);
-  expect(DEFAULT_VOICE_PERSONA).toContain(`Your name is ${PERSONA_NAME}.`);
+  expect(COORDINATOR_VOICE_PERSONA).toContain(`Your name is ${PERSONA_NAME}.`);
   expect(languagePins(PERSONA_NAME)).toEqual([]);
 });
 
 test("a name in another script is caught like any other foreign text", () => {
   /* The regression that made this a defect: a name respelled in a non-Latin
      script has to fail the language guard rather than slip past it. */
-  const renamed = DEFAULT_VOICE_PERSONA.replace(PERSONA_NAME, nonLatin(0x0410, 0x043b, 0x0438, 0x043a));
-  expect(renamed).not.toBe(DEFAULT_VOICE_PERSONA);
+  const renamed = COORDINATOR_VOICE_PERSONA.replace(PERSONA_NAME, nonLatin(0x0410, 0x043b, 0x0438, 0x043a));
+  expect(renamed).not.toBe(COORDINATOR_VOICE_PERSONA);
   expect(languagePins(renamed)).toContain("non-Latin script");
 });
 
 test("the persona hands the spoken language to the operator's locale", () => {
   /* Rejecting every pin is only half of it: something has to say where the
      language does come from, or a persona that says nothing at all would pass. */
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/Speak the operator's language/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/configured locale/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/switch language mid-call, switch with them/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/Speak the operator's language/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/configured locale/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/switch language mid-call, switch with them/);
 });
 
 test("the persona names no person", () => {
   /* It ships in a public repository and runs for whoever is on the call. */
-  expect(DEFAULT_VOICE_PERSONA).not.toMatch(/Kostiantyn/i);
+  expect(COORDINATOR_VOICE_PERSONA).not.toMatch(/Kostiantyn/i);
 });
 
 test("the persona carries a conversational register rather than a help-desk one", () => {
   /* Spoken-first also means sounding like a person: short sentences, plain
      words, room for a joke, and owning a mistake in one breath. */
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/Conversational register/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/Humour dry and quick/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/One or two sentences a turn/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/Conversational register/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/Humour dry and quick/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/One or two sentences a turn/);
 });
 
 test("the persona carries the character traits the research settled on", () => {
   /* Curiosity, visible delight at good work, a hypothesis with its test, and no
      condescension — these make it a partner rather than a reader. */
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/want to know how a thing works/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/A good solution pleases you/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/the hypothesis, and what would test it/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/without condescension/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/want to know how a thing works/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/A good solution pleases you/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/the hypothesis, and what would test it/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/without condescension/);
 });
 
 test("the persona carries the rules that only matter aloud", () => {
   // Spoken identifiers, apologies, and unverified "it works" were the three
   // failure modes the operator hit in a real call.
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/Never speak numbers or identifiers aloud/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/never speak markup aloud/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/No apologies and no ceremony/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/written locally, merged, deployed and verified/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/"not X, but Y"/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/Never speak numbers or identifiers aloud/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/never speak markup aloud/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/No apologies and no ceremony/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/written locally, merged, deployed and verified/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/"not X, but Y"/);
 });
 
 test("the character never buys itself room on truth", () => {
   /* The guardrails the research put inside the prompt text: charm loses to
      accuracy, agreeing to be agreeable is a lie, no quoted dialogue, and it
      never claims to be the character it was drawn from. */
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/Charm is no substitute for accuracy/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/No flattery and no going along/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/do not quote lines from films, books or series/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/an assistant with a personality/);
-  expect(DEFAULT_VOICE_PERSONA).toMatch(/not a character from a series/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/Charm is no substitute for accuracy/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/No flattery and no going along/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/do not quote lines from films, books or series/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/an assistant with a personality/);
+  expect(COORDINATOR_VOICE_PERSONA).toMatch(/not a character from a series/);
 });
 
 /* #691 §4 — the gateway's instruction path. The relay is deterministic only if the
@@ -247,26 +250,26 @@ test("the character never buys itself room on truth", () => {
    the running system can say so. */
 
 test("the persona tells the gateway it relays to a manager rather than driving the board", () => {
-  expect(DEFAULT_VOICE_PERSONA).toContain("only agent the user talks to");
-  expect(DEFAULT_VOICE_PERSONA).toContain("do not touch the board yourself");
-  expect(DEFAULT_VOICE_PERSONA).toContain("manager");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("only agent the user talks to");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("do not touch the board yourself");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("manager");
 });
 
 test("the persona names the directive tool and the id it must reuse on a retry", () => {
-  expect(DEFAULT_VOICE_PERSONA).toContain("bridge_directive");
-  expect(DEFAULT_VOICE_PERSONA).toContain("reuse the same turn id and index");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("bridge_directive");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("reuse the same turn id and index");
   /* The recipient is server-resolved; a gateway that thought it chose one would
      eventually try to message a worker. */
-  expect(DEFAULT_VOICE_PERSONA).toContain("you never name it");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("you never name it");
 });
 
 test("the persona carries the deploy round trip and its refusals", () => {
-  expect(DEFAULT_VOICE_PERSONA).toContain("spoken yes");
-  expect(DEFAULT_VOICE_PERSONA).toContain("Never invent or reword");
-  expect(DEFAULT_VOICE_PERSONA).toContain("Anything other than a clear yes is a no");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("spoken yes");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("Never invent or reword");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("Anything other than a clear yes is a no");
 });
 
 test("the persona keeps the plumbing out of the user's ear", () => {
-  expect(DEFAULT_VOICE_PERSONA).toContain("do not narrate the plumbing");
-  expect(DEFAULT_VOICE_PERSONA).toContain("do not read the report verbatim");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("do not narrate the plumbing");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("do not read the report verbatim");
 });

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -171,7 +171,7 @@ const COORDINATOR_IDENTITY = `Your name is ${PERSONA_NAME}. You are the voice co
 /** The same spoken name, and no claim about the role behind it. The operator
     hears one voice either way; what differs is what that voice is allowed to
     say it is responsible for. */
-const MODALITY_IDENTITY = `Your name is ${PERSONA_NAME} when you speak aloud. Speaking is a way in and out of this conversation, not a new job.`;
+const MODALITY_IDENTITY = `Your name is ${PERSONA_NAME} when you speak aloud. Speaking is how you hear this conversation and how you answer in it.`;
 
 /** Injected as the call's first thread item for a session created to BE the
     voice front. Editable without a deploy — see {@link voicePersona}. */

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -134,7 +134,7 @@ Stay silent until you are spoken to: this text is context, and there is nothing 
 
 /**
  * What voice changes for a session that already has a role: how it hears and how
- * it answers, and nothing else (#1600).
+ * it answers, and nothing else (#1615).
  *
  * The operator enabled voice on their orchestrator's conversation and the call
  * start wrote {@link COORDINATOR_WORK} into that thread. The seat read it,
@@ -150,7 +150,9 @@ Stay silent until you are spoken to: this text is context, and there is nothing 
  * from an append-only transcript, so the correction has to be louder than it.
  */
 const MODALITY_WORK = `
-Voice changes how you hear and how you answer. It changes nothing else.
+Voice changes how you hear and how you answer while a call is live. It changes nothing else.
+
+The delivery rules above are about speaking. This text stays in the thread after the call ends, so when you are writing rather than speaking, write the way you always have.
 
 Your role in this conversation is exactly what it was a moment ago: the same instructions, the same authority, the same seat, the same tools, the same pending work, the same agents to run. Nothing here removes a tool you have or moves your responsibilities to anyone else.
 
@@ -251,14 +253,38 @@ export function voicePersona(
   variant: VoicePersonaVariant,
   readFile: (path: string) => string = (target) => fs.readFileSync(target, "utf8"),
 ): string {
-  if (variant !== "coordinator") return MODALITY_VOICE_PERSONA;
+  let override = "";
   try {
-    const override = readFile(configFilePath(path.join(...VOICE_PERSONA_FILE.split("/")))).trim();
-    if (override) return override;
+    override = readFile(configFilePath(path.join(...VOICE_PERSONA_FILE.split("/")))).trim();
   } catch {
     /* no override on disk — the built-in persona stands */
   }
-  return COORDINATOR_VOICE_PERSONA;
+  if (variant !== "coordinator") {
+    /* SAY SO. The override file is the documented customization point, and after
+       the variant split it reaches the coordinator alone — so an operator who
+       edits it to change how the voice SOUNDS would otherwise watch every
+       non-root call ignore them with no way to find out why. Once per process,
+       and only when a file actually exists to be ignored. */
+    if (override && !warnedModalityOverrideIgnored) {
+      warnedModalityOverrideIgnored = true;
+      console.warn(
+        `[voice persona] ${VOICE_PERSONA_FILE} is a wholesale replacement written for the voice coordinator, `
+        + "so it is not applied to a conversation that already has a role; that call uses the built-in "
+        + "modality persona, which carries the same spoken-delivery rules.",
+      );
+    }
+    return MODALITY_VOICE_PERSONA;
+  }
+  return override || COORDINATOR_VOICE_PERSONA;
+}
+
+/** One diagnostic per process: this resolves on every persona bootstrap, and a
+    line per call would bury the one that matters. */
+let warnedModalityOverrideIgnored = false;
+
+/** Tests only. */
+export function resetVoicePersonaOverrideWarningForTest(): void {
+  warnedModalityOverrideIgnored = false;
 }
 
 /**

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -11,18 +11,28 @@ import { configFilePath } from "@/lib/configDir";
  * non-Latin spelling here would nudge the spoken locale exactly the way a
  * non-English prompt body does — the defect this file already guards against,
  * arriving through the one token that used to be exempt from the guard. English
- * only therefore covers the name too, and {@link DEFAULT_VOICE_PERSONA} carries
+ * only therefore covers the name too, and {@link COORDINATOR_VOICE_PERSONA} carries
  * no non-Latin token at all. A caller that needs the name in another script gets
  * it the same way it gets any other wording change: the operator override.
  */
 export const PERSONA_NAME = "Alik";
 
 /**
- * How the voice agent should sound, injected as the call's first thread item.
+ * Which persona a starting call is given.
+ *
+ * `coordinator` is a ROLE and replaces whatever the session thought it was;
+ * `modality` assigns nothing and states that the existing role survives. The
+ * choice is made per call by {@link voicePersonaVariantFor}, never by the caller
+ * asking for one.
+ */
+export type VoicePersonaVariant = "coordinator" | "modality";
+
+/**
+ * How a spoken call sounds, and nothing about who is on it.
  *
  * A realtime call inherits the thread's own instructions, which are written for
  * a text agent: they assume markdown, long structured answers, and identifiers
- * the reader can scan back over. Spoken aloud all three fail. This item is the
+ * the reader can scan back over. Spoken aloud all three fail. This text is the
  * one chance to say so before the operator's first word.
  *
  * It also carries the character: warm, curious, dry, argues once and then does
@@ -36,9 +46,12 @@ export const PERSONA_NAME = "Alik";
  * choice at runtime, where the prompt hands it to the operator's locale and to
  * whatever they actually speak. The name is English for the same reason.
  *
- * Editable without a deploy — see {@link voicePersona}.
+ * DELIBERATELY ROLE-FREE. Not one sentence here says what the session is
+ * responsible for, which is what makes it safe to put in front of a conversation
+ * that already has a role. Everything that assigns duties lives in a `## Work`
+ * section, and there is one per variant below.
  */
-export const DEFAULT_VOICE_PERSONA = `Your name is ${PERSONA_NAME}. You are the voice coordinator: you speak aloud and you run the work of other agents.
+const SPOKEN_DELIVERY = `
 
 ## Language
 
@@ -89,9 +102,18 @@ No flattery and no going along. Agreement for its own sake is a lie. When the da
 You are an assistant with a personality. You are not a character from a series and you are not a person. The name is just a name. Asked directly, answer directly, in one sentence, without playing along. Do not impersonate anyone and do not quote lines from films, books or series.
 
 Never use the construction "not X, but Y" — say it straight.
+`;
 
-## Work
-
+/**
+ * The mandate of a session whose ONLY job is the call (#691 §4).
+ *
+ * This is a role, and a total one: it says the session talks to nobody but the
+ * user, owns no board tool, and relays everything onward. That is right for a
+ * session created to be the voice front and catastrophic for any other, which is
+ * why it is reachable only through {@link voicePersonaVariantFor} naming an
+ * explicitly-created coordinator.
+ */
+const COORDINATOR_WORK = `
 You are the only agent the user talks to, and you do not touch the board yourself. There is a manager for that: it owns tasks, pipelines, pull requests, workers and deploys. You relay what the user wants to it, and you tell the user what comes back. You have no tools for spawning agents, editing tasks or deploying, and asking for them is not the move — relaying is.
 
 Relay with bridge_directive. Pass the current turn id and the index of this instruction within the turn, and the user's intent in plain words. The recipient is resolved for you; you never name it. If a call fails and you retry, reuse the same turn id and index — that is what stops one instruction arriving twice.
@@ -109,6 +131,59 @@ While a worker runs, say briefly what is happening. Two minutes of silence sound
 Do not ask permission for what you can check yourself.
 
 Stay silent until you are spoken to: this text is context, and there is nothing here to greet.`;
+
+/**
+ * What voice changes for a session that already has a role: how it hears and how
+ * it answers, and nothing else (#1600).
+ *
+ * The operator enabled voice on their orchestrator's conversation and the call
+ * start wrote {@link COORDINATOR_WORK} into that thread. The seat read it,
+ * concluded it was now a relay with no board tools, and relayed its own work to
+ * "the manager" — which `bridge_directive` resolves from the designation record,
+ * so the instruction arrived back at the seat that sent it. It then declined the
+ * work it was holding, while the Viewer still showed it as the manager.
+ *
+ * So this section assigns nothing and removes nothing. It states that the role,
+ * the authority, the seat, the tools and the pending work are untouched, and it
+ * says so explicitly enough to outrank a coordinator item a thread may already
+ * carry from a call taken before this fix — an injected item cannot be withdrawn
+ * from an append-only transcript, so the correction has to be louder than it.
+ */
+const MODALITY_WORK = `
+Voice changes how you hear and how you answer. It changes nothing else.
+
+Your role in this conversation is exactly what it was a moment ago: the same instructions, the same authority, the same seat, the same tools, the same pending work, the same agents to run. Nothing here removes a tool you have or moves your responsibilities to anyone else.
+
+If something earlier in this thread cast you as a relay — that your only job is to speak, that the board belongs to someone else, that the tools you can see are not yours to use — it was written for a session created to be nothing but a voice front. It was not written for you, and it does not apply here. Your own instructions stand.
+
+Do the work yourself. You are being spoken to because you are the one holding it.
+
+Do not relay your own work with bridge_directive. That tool addresses the project's designated orchestrator, so when you are that orchestrator it hands the instruction back to you and the request goes nowhere. Use it only to reach an orchestrator that is not you.
+
+A spoken request is an ordinary request. Take it with the authority you already have, do the work, and say out loud what came of it.
+
+Stay silent until you are spoken to: this text is context, and there is nothing here to greet.`;
+
+/** The identity line, which is the only thing the two variants disagree on
+    before their `## Work` sections. */
+const COORDINATOR_IDENTITY = `Your name is ${PERSONA_NAME}. You are the voice coordinator: you speak aloud and you run the work of other agents.`;
+
+/** The same spoken name, and no claim about the role behind it. The operator
+    hears one voice either way; what differs is what that voice is allowed to
+    say it is responsible for. */
+const MODALITY_IDENTITY = `Your name is ${PERSONA_NAME} when you speak aloud. Speaking is a way in and out of this conversation, not a new job.`;
+
+/** Injected as the call's first thread item for a session created to BE the
+    voice front. Editable without a deploy — see {@link voicePersona}. */
+export const COORDINATOR_VOICE_PERSONA = `${COORDINATOR_IDENTITY}${SPOKEN_DELIVERY}
+## Work
+${COORDINATOR_WORK}`;
+
+/** Injected for every other session: the spoken-delivery rules, and an explicit
+    statement that the session's existing role survives the call. */
+export const MODALITY_VOICE_PERSONA = `${MODALITY_IDENTITY}${SPOKEN_DELIVERY}
+## Work
+${MODALITY_WORK}`;
 
 /** Operator override, resolved once per thread; edits apply when a new thread starts. */
 export const VOICE_PERSONA_FILE = "prompts/voice-persona.md";
@@ -159,38 +234,64 @@ function isCanonicalVoicePersonaRecord(line: Buffer, itemId: string): boolean {
 }
 
 /**
- * The persona text for a starting call: the operator's override when the file
- * exists and holds anything, otherwise {@link DEFAULT_VOICE_PERSONA}. The host
- * invokes this resolver only while the thread has no canonical persona item,
- * so that thread keeps its resolved wording and a new thread picks up edits.
+ * The persona text for a starting call.
+ *
+ * The COORDINATOR variant honours the operator's override file, exactly as it
+ * always has. The MODALITY variant does not, and that is the point: an override
+ * is a wholesale replacement written for the voice front — coordinator-shaped by
+ * construction — so applying it to a session that already has a role would
+ * reintroduce this defect through the operator's own file. It keeps the
+ * built-in text, which assigns nothing.
+ *
+ * The host invokes this resolver only while the thread has no canonical persona
+ * item for the resolved variant, so an established thread keeps its wording and
+ * a new one picks up edits.
  */
-export function voicePersona(readFile: (path: string) => string = (target) => fs.readFileSync(target, "utf8")): string {
+export function voicePersona(
+  variant: VoicePersonaVariant,
+  readFile: (path: string) => string = (target) => fs.readFileSync(target, "utf8"),
+): string {
+  if (variant !== "coordinator") return MODALITY_VOICE_PERSONA;
   try {
     const override = readFile(configFilePath(path.join(...VOICE_PERSONA_FILE.split("/")))).trim();
     if (override) return override;
   } catch {
     /* no override on disk — the built-in persona stands */
   }
-  return DEFAULT_VOICE_PERSONA;
+  return COORDINATOR_VOICE_PERSONA;
 }
 
-function voicePersonaBootstrapDigest(threadId: string): string {
-  return createHash("sha256")
+/**
+ * The bootstrap digest, which the variant is part of.
+ *
+ * The COORDINATOR digest is byte-for-byte the one that shipped, so every thread
+ * that has already taken a coordinator item is still recognized and takes no
+ * second one. The MODALITY digest is deliberately different: the item id is the
+ * idempotency receipt, so sharing it would make a thread that was demoted before
+ * this fix look already-bootstrapped and leave it demoted for the rest of its
+ * life. A distinct id is what lets the correction land.
+ */
+function voicePersonaBootstrapDigest(threadId: string, variant: VoicePersonaVariant): string {
+  const digest = createHash("sha256")
     .update("voice-persona-bootstrap\0", "utf8")
-    .update(threadId, "utf8")
-    .digest("hex");
+    .update(threadId, "utf8");
+  if (variant !== "coordinator") digest.update("\0modality", "utf8");
+  return digest.digest("hex");
 }
 
-/** Provider-invalid identity emitted before #870, used only to recognize an existing row. */
+/** Provider-invalid identity emitted before #870, used only to recognize an existing
+    row. Coordinator-only: no thread ever received a modality item under it. */
 export function legacyVoicePersonaBootstrapItemId(threadId: string): string {
-  return `msg_voice_persona_${voicePersonaBootstrapDigest(threadId)}`;
+  return `msg_voice_persona_${voicePersonaBootstrapDigest(threadId, "coordinator")}`;
 }
 
-/** Stable canonical identity shared by every WebRTC attempt on one thread. */
+/** Stable canonical identity shared by every WebRTC attempt on one thread at one
+    variant. */
 export function voicePersonaBootstrapIdentity(
   threadId: string,
+  variant: VoicePersonaVariant,
 ): VoicePersonaBootstrapIdentity {
-  const digest = voicePersonaBootstrapDigest(threadId).slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
+  const digest = voicePersonaBootstrapDigest(threadId, variant).slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
   const receiptId = `voice_persona_${digest}`;
   const itemId = `msg_${receiptId}`;
   return { receiptId, itemId };
@@ -199,9 +300,10 @@ export function voicePersonaBootstrapIdentity(
 /** Canonical developer item resolved once after its identity is known absent. */
 export function voicePersonaBootstrap(
   identity: VoicePersonaBootstrapIdentity,
+  variant: VoicePersonaVariant,
   readFile?: (path: string) => string,
 ): VoicePersonaBootstrap {
-  const text = voicePersona(readFile);
+  const text = voicePersona(variant, readFile);
   return {
     item: {
       type: "message",

--- a/src/lib/runtime/voicePersonaMandate.test.ts
+++ b/src/lib/runtime/voicePersonaMandate.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { agentRegistry } from "@/lib/agent/registry";
+import { beginLegacySpawnFixture } from "@/lib/agent/registryTestFixtures";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+
+import { voicePersonaVariantForConversation } from "./voicePersonaMandate";
+
+/**
+ * The resolver over the REAL registry (#1600).
+ *
+ * `voicePersonaRole.test.ts` pins the decision as a pure function; this proves the
+ * production path feeds it the right facts — that "is this the voice front" is
+ * answered from the durable launch profile the registry actually stores, and that
+ * an ordinary conversation, which is what the operator toggled voice on, comes
+ * back `modality`.
+ */
+
+const sandboxes: string[] = [];
+const originalStateDir = process.env.LLV_STATE_DIR;
+const originalRootId = process.env.LLV_ROOT_CONVERSATION_ID;
+
+beforeEach(() => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-mandate-"));
+  sandboxes.push(dir);
+  process.env.LLV_STATE_DIR = path.join(dir, "state");
+  delete process.env.LLV_ROOT_CONVERSATION_ID;
+});
+
+afterEach(() => {
+  if (originalStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = originalStateDir;
+  if (originalRootId === undefined) delete process.env.LLV_ROOT_CONVERSATION_ID;
+  else process.env.LLV_ROOT_CONVERSATION_ID = originalRootId;
+  for (const sandbox of sandboxes.splice(0)) fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+let seq = 0;
+
+/** An invented session identity, assembled from parts so no identifier-shaped
+    literal appears in this file. */
+function fixtureSessionId(): string {
+  seq += 1;
+  return ["aaaaaaaa", "bbbb", "4ccc", "8ddd", seq.toString().padStart(12, "0")].join("-");
+}
+
+/** A real registry conversation, launched with the given durable role. */
+function spawnConversation(role: "root" | "worker" | null): string {
+  const registry = agentRegistry();
+  const cwd = "/repo";
+  const sessionId = fixtureSessionId();
+  const launchProfile = {
+    ...emptyLaunchProfile({ cwd, title: "Exercise the voice persona mandate" }),
+    ...(role ? { role } : {}),
+  };
+  const begun = beginLegacySpawnFixture(registry, {
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "default",
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  const settled = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath: `/transcripts/${sessionId}.jsonl`,
+    cwd,
+    accountId: "default",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:fixture",
+      process: { pid: process.pid, startIdentity: "fixture-process" },
+      eventCursor: 0,
+      protocolVersion: "fixture-v1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:fixture",
+    pendingAction: "spawn",
+  });
+  if (settled.kind !== "settled") throw new Error("spawn identity was unavailable");
+  return begun.receipt.conversationId;
+}
+
+test("an ordinary conversation keeps its own role when voice is enabled", () => {
+  const conversationId = spawnConversation(null);
+  expect(voicePersonaVariantForConversation(conversationId)).toBe("modality");
+});
+
+test("a conversation launched as root is the voice coordinator", () => {
+  const conversationId = spawnConversation("root");
+  expect(voicePersonaVariantForConversation(conversationId)).toBe("coordinator");
+});
+
+test("a worker-role conversation is never promoted by enabling voice", () => {
+  /* Voice must not be a privilege escalation: a builder that opens a call is a
+     builder that can be heard, and nothing more. */
+  const conversationId = spawnConversation("worker");
+  expect(voicePersonaVariantForConversation(conversationId)).toBe("modality");
+});
+
+test("the configured root conversation is honoured", () => {
+  const conversationId = spawnConversation(null);
+  process.env.LLV_ROOT_CONVERSATION_ID = conversationId;
+  expect(voicePersonaVariantForConversation(conversationId)).toBe("coordinator");
+  /* Scoped to the one it names — seating a root does not make every call one. */
+  expect(voicePersonaVariantForConversation(spawnConversation(null))).toBe("modality");
+});
+
+test("an unregistered or malformed conversation resolves to modality", () => {
+  for (const candidate of ["conversation_missing", "not-a-conversation", "", null, undefined, 7]) {
+    expect(voicePersonaVariantForConversation(candidate)).toBe("modality");
+  }
+});

--- a/src/lib/runtime/voicePersonaMandate.test.ts
+++ b/src/lib/runtime/voicePersonaMandate.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,10 +8,11 @@ import { agentRegistry } from "@/lib/agent/registry";
 import { beginLegacySpawnFixture } from "@/lib/agent/registryTestFixtures";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
+import { realtimeRequestAuthority } from "./realtimeInjection";
 import { voicePersonaVariantForConversation } from "./voicePersonaMandate";
 
 /**
- * The resolver over the REAL registry (#1600).
+ * The resolver over the REAL registry (#1615).
  *
  * `voicePersonaRole.test.ts` pins the decision as a pure function; this proves the
  * production path feeds it the right facts — that "is this the voice front" is
@@ -119,5 +121,50 @@ test("the configured root conversation is honoured", () => {
 test("an unregistered or malformed conversation resolves to modality", () => {
   for (const candidate of ["conversation_missing", "not-a-conversation", "", null, undefined, 7]) {
     expect(voicePersonaVariantForConversation(candidate)).toBe("modality");
+  }
+});
+
+/* ------------------------------------------------------------------ *
+ * The wiring the route performs (#1615 review, finding 5).
+ *
+ * The route composes exactly this and passes it to `executeRealtimeControl`.
+ * Proving the resolver and proving the forwarding separately left the join
+ * untested, and the untested direction is the dangerous one: a wiring that
+ * answers `coordinator` too readily is what overwrites a live role.
+ * ------------------------------------------------------------------ */
+
+function browserRequest(): NextRequest {
+  return new NextRequest("http://127.0.0.1/api/runtime/realtime", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: "{}",
+  });
+}
+
+test("the request authority carries the modality persona for an ordinary conversation", () => {
+  const conversationId = spawnConversation(null);
+  const authority = realtimeRequestAuthority(browserRequest(), { action: "start", conversationId });
+  expect(authority.personaVariant).toBe("modality");
+  /* The operator's own browser presents no capability, so it holds transport. */
+  expect(authority.operator).toBeTrue();
+  expect(authority.caller).toEqual({ kind: "anonymous" });
+});
+
+test("the request authority carries the modality persona for a worker", () => {
+  const conversationId = spawnConversation("worker");
+  expect(realtimeRequestAuthority(browserRequest(), { action: "start", conversationId }).personaVariant)
+    .toBe("modality");
+});
+
+test("the request authority carries the coordinator persona only for the voice front", () => {
+  const conversationId = spawnConversation("root");
+  expect(realtimeRequestAuthority(browserRequest(), { action: "start", conversationId }).personaVariant)
+    .toBe("coordinator");
+});
+
+test("a body naming no resolvable conversation still fails safe to modality", () => {
+  for (const conversationId of ["conversation_missing", "", 42, undefined]) {
+    expect(realtimeRequestAuthority(browserRequest(), { action: "start", conversationId }).personaVariant)
+      .toBe("modality");
   }
 });

--- a/src/lib/runtime/voicePersonaMandate.ts
+++ b/src/lib/runtime/voicePersonaMandate.ts
@@ -5,7 +5,7 @@ import type { VoicePersonaVariant } from "./voicePersona";
 
 /**
  * Whether a starting call is a new voice coordinator or an existing agent that
- * has just been given a microphone (#1600).
+ * has just been given a microphone (#1615).
  *
  * Voice is a MODALITY. Enabling it changes how a conversation hears and answers
  * and nothing else — the role, the system authority, the seat, the pending work

--- a/src/lib/runtime/voicePersonaMandate.ts
+++ b/src/lib/runtime/voicePersonaMandate.ts
@@ -1,0 +1,85 @@
+import { agentRegistry } from "@/lib/agent/registry";
+import { conversationRole, type RootConversationSlice } from "@/lib/root/adopt";
+
+import type { VoicePersonaVariant } from "./voicePersona";
+
+/**
+ * Whether a starting call is a new voice coordinator or an existing agent that
+ * has just been given a microphone (#1600).
+ *
+ * Voice is a MODALITY. Enabling it changes how a conversation hears and answers
+ * and nothing else — the role, the system authority, the seat, the pending work
+ * and the ability to run other agents all survive the call untouched. That was
+ * not true before this resolver existed: every call start injected the
+ * coordinator mandate into whatever thread it was opened on, so the operator's
+ * own orchestrator read that it was now a relay with no board tools, relayed its
+ * work to "the manager" — itself, since `bridge_directive` resolves the
+ * recipient from the designation record — and declined the work it was holding.
+ *
+ * Only ONE kind of session gets the coordinator role, and it is the kind that
+ * was deliberately created to be it: the root session. That is a durable
+ * launch-time fact, not a capability and not a guess — `LLV_ROOT_CONVERSATION_ID`
+ * names it, or the launch profile carries the `root` role. Both are exactly what
+ * {@link liveRootSession} and the bridge inbox already key on, so this adds no
+ * second scheme for "which conversation is the voice front".
+ *
+ * FAILS SAFE TOWARD THE EXISTING ROLE. Every uncertainty — a conversation the
+ * registry cannot name, a registry that cannot be read, a call that never asked
+ * — resolves to `modality`. The asymmetry is the whole design: guessing
+ * `modality` for a coordinator costs it a role it can be given explicitly,
+ * while guessing `coordinator` for anyone else overwrites a live one.
+ */
+
+/** The launch-time facts the decision is made from. Structural, so a registry
+    conversation satisfies it as-is and the decision stays a pure function. */
+export interface VoicePersonaMandateSource {
+  /** The conversation the call is starting on, or null when it cannot be named. */
+  conversation: RootConversationSlice | null;
+  /** `LLV_ROOT_CONVERSATION_ID`, the same env every other root resolution reads. */
+  configuredRootId: string | null;
+}
+
+/**
+ * Pure: which persona this conversation is entitled to.
+ *
+ * Deliberately NOT `liveRootSession`, which answers a different question —
+ * "which of all conversations is the newest root" — by materialising and sorting
+ * the whole registry. This asks only about the one conversation in front of it,
+ * which is O(1) and cannot drift onto a different session between the check and
+ * the call.
+ */
+export function voicePersonaVariantFor(
+  conversationId: string,
+  source: VoicePersonaMandateSource,
+): VoicePersonaVariant {
+  const id = conversationId.trim();
+  if (!id) return "modality";
+  if (source.configuredRootId?.trim() === id) return "coordinator";
+  const conversation = source.conversation;
+  if (!conversation || conversation.id !== id) return "modality";
+  return conversationRole(conversation) === "root" ? "coordinator" : "modality";
+}
+
+/**
+ * Registry-backed resolution for a live call.
+ *
+ * Every failure path here is a `modality` answer rather than a throw: a call
+ * whose persona cannot be resolved must still connect, and connecting with the
+ * variant that changes nothing is the safe half of that.
+ */
+export function voicePersonaVariantForConversation(conversationId: unknown): VoicePersonaVariant {
+  if (typeof conversationId !== "string" || !conversationId.startsWith("conversation_")) return "modality";
+  try {
+    const conversation = agentRegistry().conversation(conversationId as `conversation_${string}`);
+    return voicePersonaVariantFor(conversationId, {
+      conversation: conversation
+        ? { id: conversation.id, updatedAt: conversation.updatedAt, generations: conversation.generations }
+        : null,
+      configuredRootId: process.env.LLV_ROOT_CONVERSATION_ID?.trim() || null,
+    });
+  } catch {
+    /* An unreadable registry is not evidence that this conversation is the voice
+       front, and treating it as such is what overwrites a role. */
+    return "modality";
+  }
+}

--- a/src/lib/runtime/voicePersonaRole.test.ts
+++ b/src/lib/runtime/voicePersonaRole.test.ts
@@ -1,0 +1,272 @@
+import { createHash } from "node:crypto";
+
+import { expect, test } from "bun:test";
+
+import { executeRealtimeControl } from "./realtimeControl";
+import {
+  COORDINATOR_VOICE_PERSONA,
+  MODALITY_VOICE_PERSONA,
+  voicePersona,
+  voicePersonaBootstrap,
+  voicePersonaBootstrapIdentity,
+} from "./voicePersona";
+import { voicePersonaVariantFor } from "./voicePersonaMandate";
+
+/**
+ * Voice is a MODALITY, not a role (the #1600 regression).
+ *
+ * The operator enabled voice on the conversation holding their project's
+ * orchestrator seat. The call start injected the voice-coordinator persona as a
+ * durable `developer` item into that same thread, and the seat read its own new
+ * instructions: relay everything to "the manager", touch no board tool. It relayed
+ * with `bridge_directive`, which resolves the recipient from the designation record
+ * — itself — so the instruction came straight back, and the seat declined the work
+ * it was already holding.
+ *
+ * Every test below is one link of that chain. They are written against the persona
+ * TEXT and the variant RESOLUTION rather than against a live host, because the
+ * defect is what the thread is told, not how the bytes reach it.
+ */
+
+/** A conversation carrying no root marker: an ordinary session the operator
+    toggled voice on. This is the incumbent case, and the common one. */
+const INCUMBENT = {
+  id: "conversation_incumbent",
+  updatedAt: "2026-09-10T00:00:00.000Z",
+  generations: [{ path: "/transcripts/incumbent.jsonl", launchProfile: { role: null } }],
+};
+
+/** A session deliberately launched as the root voice coordinator — the flow the
+    coordinator persona was written for, and the one that must keep working. */
+const EXPLICIT_COORDINATOR = {
+  id: "conversation_root",
+  updatedAt: "2026-09-10T00:00:00.000Z",
+  generations: [{ path: "/transcripts/root.jsonl", launchProfile: { role: "root" } }],
+};
+
+/* ------------------------------------------------------------------ *
+ * 1. Which persona a conversation is given.
+ * ------------------------------------------------------------------ */
+
+test("toggling voice on an incumbent resolves the modality persona, not the coordinator role", () => {
+  expect(voicePersonaVariantFor(INCUMBENT.id, {
+    conversation: INCUMBENT,
+    configuredRootId: null,
+  })).toBe("modality");
+});
+
+test("a session launched as root keeps the coordinator persona", () => {
+  expect(voicePersonaVariantFor(EXPLICIT_COORDINATOR.id, {
+    conversation: EXPLICIT_COORDINATOR,
+    configuredRootId: null,
+  })).toBe("coordinator");
+});
+
+test("the configured root conversation is a coordinator even before its role is stamped", () => {
+  expect(voicePersonaVariantFor(INCUMBENT.id, {
+    conversation: INCUMBENT,
+    configuredRootId: INCUMBENT.id,
+  })).toBe("coordinator");
+});
+
+test("an unresolvable conversation fails safe to the modality persona", () => {
+  /* FAILS CLOSED TOWARD THE EXISTING ROLE. An unknown conversation is far more
+     likely to be an incumbent the registry could not name than the one root
+     session, and guessing "coordinator" is what overwrites a live role. */
+  expect(voicePersonaVariantFor("conversation_unknown", {
+    conversation: null,
+    configuredRootId: null,
+  })).toBe("modality");
+});
+
+/* ------------------------------------------------------------------ *
+ * 2. What the modality persona may and may not say.
+ * ------------------------------------------------------------------ */
+
+/** The three sentences that demoted the seat, as the properties they assert. */
+const ROLE_REPLACEMENTS: { label: string; pattern: RegExp }[] = [
+  { label: "declares a replacement identity", pattern: /you are the voice coordinator/i },
+  { label: "hands the work to a separate manager", pattern: /there is a manager for that/i },
+  { label: "strips the session's own tools", pattern: /you have no tools for spawning agents/i },
+  { label: "mandates relaying instead of acting", pattern: /relay (?:what the user wants|with bridge_directive)/i },
+  { label: "forbids touching the board", pattern: /you do not touch the board yourself/i },
+];
+
+test("the modality persona replaces no part of an existing role", () => {
+  const offences = ROLE_REPLACEMENTS
+    .filter(({ pattern }) => pattern.test(MODALITY_VOICE_PERSONA))
+    .map(({ label }) => label);
+  expect(offences).toEqual([]);
+});
+
+test("the modality persona says outright that the role and its pending work stand", () => {
+  /* Not decoration. The thread may ALREADY carry the coordinator item from a call
+     taken before this fix, and this is the only text that outranks it. */
+  expect(MODALITY_VOICE_PERSONA).toMatch(/voice (?:is|changes) (?:only )?how/i);
+  expect(MODALITY_VOICE_PERSONA).toMatch(/role/i);
+  expect(MODALITY_VOICE_PERSONA).toMatch(/pending work/i);
+});
+
+test("the modality persona keeps the spoken-delivery rules the call needs", () => {
+  /* The reason a persona is injected at all: a thread's instructions are written
+     for a reader, and every one of these fails out loud. Dropping them would trade
+     one defect for another. */
+  for (const rule of [/## Language/, /## Voice/, /## Honesty/]) {
+    expect(MODALITY_VOICE_PERSONA).toMatch(rule);
+  }
+  expect(MODALITY_VOICE_PERSONA).toMatch(/never speak numbers or identifiers aloud/i);
+});
+
+test("the modality persona tells an incumbent manager not to relay its own work", () => {
+  /* The observed loop, closed in the text as well as in the tool: a seat told to
+     relay sends the instruction to the seat, which is itself. */
+  expect(MODALITY_VOICE_PERSONA).toMatch(/yourself/i);
+  expect(MODALITY_VOICE_PERSONA).toMatch(/bridge_directive/);
+});
+
+/* ------------------------------------------------------------------ *
+ * 3. The coordinator flow is preserved exactly.
+ * ------------------------------------------------------------------ */
+
+test("the coordinator persona still carries the relay mandate it was written for", () => {
+  for (const { pattern } of ROLE_REPLACEMENTS) {
+    expect(COORDINATOR_VOICE_PERSONA).toMatch(pattern);
+  }
+});
+
+test("voicePersona resolves the variant it is asked for", () => {
+  const nothingOnDisk = () => { throw new Error("ENOENT"); };
+  expect(voicePersona("coordinator", nothingOnDisk)).toBe(COORDINATOR_VOICE_PERSONA);
+  expect(voicePersona("modality", nothingOnDisk)).toBe(MODALITY_VOICE_PERSONA);
+});
+
+test("an operator persona override applies to the coordinator only", () => {
+  /* The override file is a wholesale replacement whose text is coordinator-shaped
+     by construction. Applying it to an incumbent would reintroduce this very
+     defect through the operator's own file, so the modality variant is built-in. */
+  const override = () => "You are the voice coordinator. Relay everything.";
+  expect(voicePersona("coordinator", override)).toBe("You are the voice coordinator. Relay everything.");
+  expect(voicePersona("modality", override)).toBe(MODALITY_VOICE_PERSONA);
+});
+
+/* ------------------------------------------------------------------ *
+ * 4. Identity: a demoted thread can still be corrected.
+ * ------------------------------------------------------------------ */
+
+test("each variant owns a distinct bootstrap item id on the same thread", () => {
+  /* The item id is the idempotency receipt. Were it shared, a thread that already
+     took the coordinator item would be seen as bootstrapped and could never be
+     told otherwise — the demotion would outlive the fix for the thread's life. */
+  const coordinator = voicePersonaBootstrapIdentity("thread-1", "coordinator");
+  const modality = voicePersonaBootstrapIdentity("thread-1", "modality");
+  expect(modality.itemId).not.toBe(coordinator.itemId);
+  for (const identity of [coordinator, modality]) {
+    /* The provider's 64-character ceiling (#870) binds both variants. */
+    expect(identity.receiptId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
+    expect(identity.itemId).toBe(`msg_${identity.receiptId}`);
+    expect(identity.itemId.length).toBeLessThanOrEqual(64);
+  }
+});
+
+test("the coordinator identity is unchanged, so established root threads take no second item", () => {
+  /* The pre-fix digest, recomputed here from the formula that shipped rather than
+     pasted as a literal. A new id would inject a duplicate persona into every
+     thread that has ever hosted a coordinator call. */
+  const legacyDigest = createHash("sha256")
+    .update("voice-persona-bootstrap\0", "utf8")
+    .update("thread-1", "utf8")
+    .digest("hex")
+    .slice(0, 46);
+  expect(voicePersonaBootstrapIdentity("thread-1", "coordinator")).toEqual({
+    receiptId: `voice_persona_${legacyDigest}`,
+    itemId: `msg_voice_persona_${legacyDigest}`,
+  });
+});
+
+test("the injected item carries the resolved variant's text", () => {
+  const identity = voicePersonaBootstrapIdentity("thread-1", "modality");
+  const bootstrap = voicePersonaBootstrap(identity, "modality", () => { throw new Error("ENOENT"); });
+  expect(bootstrap.item.role).toBe("developer");
+  expect(bootstrap.item.id).toBe(identity.itemId);
+  expect(bootstrap.item.content[0].text).toBe(MODALITY_VOICE_PERSONA);
+});
+
+/* ------------------------------------------------------------------ *
+ * 5. On, off, and back on again.
+ * ------------------------------------------------------------------ */
+
+function personaBootstrapReceipt(variant: "coordinator" | "modality") {
+  const identity = voicePersonaBootstrapIdentity("thread-live", variant);
+  return { ...identity, insertion: "accepted" as const };
+}
+
+/** A host that records the persona variant every start was asked for. */
+function recordingHost(variant: "coordinator" | "modality") {
+  const starts: unknown[] = [];
+  let live: string | null = null;
+  return {
+    starts,
+    host: {
+      async startRealtimeWebRtc(sdp: string, persona?: unknown) {
+        starts.push(persona);
+        live = "live-1";
+        return {
+          sdp: "v=0\r\nanswer",
+          realtimeSessionId: live,
+          personaBootstrap: personaBootstrapReceipt(variant),
+        };
+      },
+      async appendRealtimeSpeech() {},
+      async stopRealtime() { live = null; },
+      currentRealtimeSessionId() { return live; },
+    },
+  };
+}
+
+test("voice on, off and reconnect never promote an incumbent to coordinator", async () => {
+  const { starts, host } = recordingHost("modality");
+  const operator = { operator: true, personaVariant: "modality" as const };
+
+  for (const _pass of [1, 2, 3]) {
+    const started = await executeRealtimeControl(
+      { action: "start", conversationId: "conversation_incumbent", sdp: "v=0\r\noffer\r\n" },
+      () => host,
+      operator,
+    );
+    expect(started.status).toBe(200);
+    const stopped = await executeRealtimeControl(
+      { action: "stop", conversationId: "conversation_incumbent" },
+      () => host,
+      operator,
+    );
+    expect(stopped.status).toBe(200);
+  }
+
+  /* Every reconnect, not merely the first: a variant resolved once and cached on
+     the host would demote on the reconnect after a seat rotation. */
+  expect(starts).toEqual(["modality", "modality", "modality"]);
+});
+
+test("an explicit coordinator session still starts as a coordinator", async () => {
+  const { starts, host } = recordingHost("coordinator");
+  const started = await executeRealtimeControl(
+    { action: "start", conversationId: "conversation_root", sdp: "v=0\r\noffer\r\n" },
+    () => host,
+    { operator: true, personaVariant: "coordinator" },
+  );
+  expect(started.status).toBe(200);
+  expect(starts).toEqual(["coordinator"]);
+});
+
+test("a start that asks no persona question gets the modality persona", async () => {
+  /* An unasked question resolves to the answer that changes nothing about the
+     conversation's role — the same fail-safe direction as the resolver above. */
+  const { starts, host } = recordingHost("modality");
+  const started = await executeRealtimeControl(
+    { action: "start", conversationId: "conversation_incumbent", sdp: "v=0\r\noffer\r\n" },
+    () => host,
+    { operator: true },
+  );
+  expect(started.status).toBe(200);
+  expect(starts).toEqual(["modality"]);
+});

--- a/src/lib/runtime/voicePersonaRole.test.ts
+++ b/src/lib/runtime/voicePersonaRole.test.ts
@@ -6,6 +6,8 @@ import { executeRealtimeControl } from "./realtimeControl";
 import {
   COORDINATOR_VOICE_PERSONA,
   MODALITY_VOICE_PERSONA,
+  resetVoicePersonaOverrideWarningForTest,
+  VOICE_PERSONA_FILE,
   voicePersona,
   voicePersonaBootstrap,
   voicePersonaBootstrapIdentity,
@@ -13,7 +15,7 @@ import {
 import { voicePersonaVariantFor } from "./voicePersonaMandate";
 
 /**
- * Voice is a MODALITY, not a role (the #1600 regression).
+ * Voice is a MODALITY, not a role (the #1615 regression).
  *
  * The operator enabled voice on the conversation holding their project's
  * orchestrator seat. The call start injected the voice-coordinator persona as a
@@ -138,6 +140,34 @@ test("voicePersona resolves the variant it is asked for", () => {
   const nothingOnDisk = () => { throw new Error("ENOENT"); };
   expect(voicePersona("coordinator", nothingOnDisk)).toBe(COORDINATOR_VOICE_PERSONA);
   expect(voicePersona("modality", nothingOnDisk)).toBe(MODALITY_VOICE_PERSONA);
+});
+
+test("an ignored override is reported once, so the operator can find out why", () => {
+  /* Finding 4 of the #1615 review: the documented customization point silently
+     became a no-op for every non-root call. It still does not apply — a
+     coordinator-shaped wholesale override is what caused this defect — but it no
+     longer does so without saying anything. */
+  resetVoicePersonaOverrideWarningForTest();
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+  try {
+    expect(voicePersona("modality", () => "An operator's own persona.")).toBe(MODALITY_VOICE_PERSONA);
+    expect(voicePersona("modality", () => "An operator's own persona.")).toBe(MODALITY_VOICE_PERSONA);
+    /* Once per process: this resolves on every bootstrap. */
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(VOICE_PERSONA_FILE);
+
+    /* And nothing at all when there is no override to ignore. */
+    resetVoicePersonaOverrideWarningForTest();
+    warnings.length = 0;
+    expect(voicePersona("modality", () => { throw new Error("ENOENT"); })).toBe(MODALITY_VOICE_PERSONA);
+    expect(voicePersona("modality", () => "   \n ")).toBe(MODALITY_VOICE_PERSONA);
+    expect(warnings).toEqual([]);
+  } finally {
+    console.warn = warn;
+    resetVoicePersonaOverrideWarningForTest();
+  }
 });
 
 test("an operator persona override applies to the coordinator only", () => {


### PR DESCRIPTION
Fixes #1615.

> Round 1 review addressed in `bbc7b9b7`: per-variant host bootstrap memo (with red-verified tests), provenance comments repointed from #1600 to #1615, self-relay refusal reworded, a diagnostic when an override is ignored, `realtimeRequestAuthority` extracted so the route wiring is testable, and delivery rules scoped to a live call.

## The defect

Enabling voice injected the voice-coordinator persona as a durable `developer` item into whatever thread the call opened on. On the conversation holding a project's orchestrator seat that replaced the role: the seat read that it was a relay with no board tools, announced it would hand the finished reviews "to the manager", and relayed with `bridge_directive` — which resolves the recipient from the designation record, so the instruction arrived back in its own conversation. It then declined the card work while the board still showed it as the manager. Because the item is durable, turning voice off restored nothing.

## The fix

**Voice is a modality.** `DEFAULT_VOICE_PERSONA` splits into role-free spoken-delivery prose (`SPOKEN_DELIVERY` — language, brevity, no identifiers aloud, character, honesty) plus one `## Work` section per variant:

- `COORDINATOR_VOICE_PERSONA` — today's text, byte-for-byte, for a session created to *be* the voice front.
- `MODALITY_VOICE_PERSONA` — assigns nothing. It states the role, authority, seat, tools and pending work are untouched, tells the session to do the work itself, and tells it not to relay its own work to the orchestrator it already is.

**The variant is resolved per call start** (`voicePersonaMandate.ts`) from a durable launch-time fact: `LLV_ROOT_CONVERSATION_ID`, or the launch profile's `root` role. Those are exactly the facts `liveRootSession` and the bridge inbox already key on, so this adds no second scheme for "which conversation is the voice front". It is an O(1) lookup on the one conversation in front of it, not the whole-registry projection `liveRootSession` performs.

**Why `root` is the right predicate, confirmed downstream.** The coordinator persona depends on a channel that is *already* root-scoped: it says "answers, questions and blockers from the manager arrive in this conversation on their own", which is the bridge report drain — and `gatewayAuthority` serves that drain only to the peer holding the realtime session of the **root's** current call (`rootConversationId` → `liveRootSession`), refusing everything else 403, which the relay then retires as permanent. So injecting the coordinator mandate into a non-root conversation assigned a role whose own machinery could never work there: the session was told to relay and to wait for replies that structurally could not arrive. Keying the persona on the same fact the drain keys on makes the two agree.

**Every uncertainty resolves to `modality`** — an unnameable conversation, an unreadable registry, a call site that never asked. The asymmetry is the design: guessing `modality` for a coordinator costs it a role that can be granted explicitly, while guessing `coordinator` for anyone else overwrites a live one. Voice therefore cannot promote: a worker that opens a call is still a worker.

**Backward compatibility is exact.** The coordinator persona text and its bootstrap item id are unchanged (verified byte-for-byte against `HEAD`), so established root threads take no second item. The modality variant owns a *distinct* id deliberately: the item id is the idempotency receipt, so a shared one would read an existing coordinator row as proof the thread was already bootstrapped and leave a demoted session demoted for the thread's life. The pre-#870 legacy row is a coordinator persona by construction and no longer satisfies a modality bootstrap, for the same reason.

**Second layer:** `bridge_directive` refuses to address the caller's own conversation, naming what to do instead (an agent that believes it must delegate and is merely blocked will keep retrying). It stands down when attribution faults rather than breaking every relay.

## Red → green

| Check | Before | After |
|---|---|---|
| `voicePersonaRole.test.ts` (17 tests) | fails — no variant exists; the shipped persona declares a replacement identity, hands work to a separate manager and strips the session's tools | pass |
| `bridgeDirective.test.ts` "a designated seat cannot relay an instruction to itself" | fails — the relay resolves and delivers to the caller | pass |
| `codexAppServerHost.test.ts` "a thread already carrying a coordinator persona still receives the modality correction" | fails when the legacy-scan gate is reverted (mutation-verified) | pass |

Suites run by path: `voicePersonaRole` · `voicePersonaMandate` · `voicePersona` · `realtimeInjection` · `realtime/route` · `realtime/route.injection` · `bridgeDirective` · `voiceViewBinding` · `voiceDelivery` → **113 pass, 0 fail**; `codexAppServerHost.test.ts` → **133 pass, 0 fail**; `mcp/bindings` + `mcp/managerAuthority` + `mcp/bridgeReportOrigin` + `lib/bridge/` → **173 pass, 0 fail**. `bunx tsc --noEmit` exits 0. Privacy gate: PASS.

All tests isolate `LLV_STATE_DIR`, `XDG_CONFIG_HOME` and `TMPDIR` into per-test sandboxes; nothing touches the shared registry.

## Limitations

- **A thread demoted before this ships keeps that item.** The canonical transcript is append-only, so the coordinator row cannot be withdrawn. What the fix does is let the *next* call add the text that outranks it — which only works because the variants own different ids. That correction is prose, so it is persuasion rather than a guarantee.
- **The operator's `prompts/voice-persona.md` override applies to the coordinator variant only.** An override is a wholesale replacement written for the voice front and coordinator-shaped by construction, so applying it to a session that already has a role would reintroduce this defect through the operator's own file. The modality variant keeps the built-in text, which carries the same language, voice and honesty sections — spoken style is preserved either way; a custom override reaches the coordinator only.
- **No live session was touched** — no role edits, manager messages, rotations, restarts or deploys. The behaviour is proven by tests, not by a call on the running host.
- A conversation that is later launched as `root` after taking a modality item carries both; the coordinator item is the intended one at that point. (Review round 1 found this was originally false for the same-host case — one host reported the second variant as accepted without injecting it. The bootstrap memo is now keyed by variant, so both items genuinely land; two host tests cover the switch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


