### PR TITLE
fix(accounts,orchestrator): restore manual account choice and a truthful, answerable seat

### DIFF
--- a/src/app/api/spawn/route.binding.test.ts
+++ b/src/app/api/spawn/route.binding.test.ts
@@ -71,6 +71,9 @@ async function spawn(
   /** The account the REQUEST names, when it names one — the board's launch
       draft, the orchestrator's rotate draft, `spawn_agent`. */
   requestedAccountId?: string,
+  /** A registry shared across calls, so a second request with the same
+      `clientAttemptId` is a REPLAY rather than a fresh launch. */
+  sharedStore?: InstanceType<typeof AgentRegistry>,
 ): Promise<{
   status: number;
   error: string;
@@ -82,7 +85,7 @@ async function spawn(
   projects: (string | null | undefined)[];
   receipts: number;
 }> {
-  const store = new AgentRegistry(path.join(SANDBOX, `${clientAttemptId}.json`));
+  const store = sharedStore ?? new AgentRegistry(path.join(SANDBOX, `${clientAttemptId}.json`));
   let accountResolutions = 0;
   /* Recorded inside the stub, because the route's own answer cannot show what
      it asked for — and what it asked for IS the fence at this seam. */
@@ -359,4 +362,37 @@ test("a launch onto an account the pool already contains records nothing", async
   expect(attempt.status).not.toBe(409);
   const { accountProjectOverrides } = await import("@/lib/accounts/accountOverrides");
   expect(accountProjectOverrides({ project })).toEqual([]);
+});
+
+test("a second request under the same attempt id appends no second crossing", async () => {
+  /* An idempotent retry — a lost response resent under the same
+     `clientAttemptId` — is the same launch arriving twice, not a second choice.
+     The journal is capped at 200 and drops its oldest entries, so a duplicate
+     evicts a crossing this record exists to keep.
+
+     WHAT THIS FIXTURE REACHES, stated because it is less than the guard covers:
+     the first launch here reserves its receipt (which is where the crossing is
+     recorded) and then dies further in on a stub the harness does not carry, so
+     the retry lands on the terminal-pinned-failure branch and answers 409. That
+     branch returns before the recording either way. The `begun.kind ===
+     "created"` gate in `executeSpawnRequest` is what covers the REPLAY branch,
+     which needs a first launch that settles — nothing in this file can produce
+     one. So this asserts the property, not the branch. */
+  const cwd = fs.mkdtempSync(path.join(SANDBOX, "named-replayed-"));
+  const project = projectForCwd(cwd)!;
+  fs.writeFileSync(RECORD, JSON.stringify({
+    schemaVersion: 1,
+    bindings: [{ engine: "claude", accountId: "acct-reserved", project, createdAt: "2026-09-10T00:00:00.000Z" }],
+  }), "utf8");
+  const store = new AgentRegistry(path.join(SANDBOX, "replayed-registry.json"));
+
+  const first = await spawn(cwd, "binding_named_replay_20260910", undefined, "acct-chosen-by-hand", store);
+  const second = await spawn(cwd, "binding_named_replay_20260910", undefined, "acct-chosen-by-hand", store);
+
+  /* One receipt across both requests: the second was the same launch, not a
+     new one, whichever branch answered it. */
+  expect(first.receipts).toBe(1);
+  expect(second.receipts).toBe(1);
+  const { accountProjectOverrides } = await import("@/lib/accounts/accountOverrides");
+  expect(accountProjectOverrides({ project })).toHaveLength(1);
 });

--- a/src/app/api/spawn/route.binding.test.ts
+++ b/src/app/api/spawn/route.binding.test.ts
@@ -74,6 +74,12 @@ async function spawn(
   /** A registry shared across calls, so a second request with the same
       `clientAttemptId` is a REPLAY rather than a fresh launch. */
   sharedStore?: InstanceType<typeof AgentRegistry>,
+  /** Report the named account as rate-limited until this instant, which is how
+      the route reaches its QUEUED answer: a 202 carrying a real
+      `SpawnResponse`, with no process started anywhere. It is the only success
+      shape this suite can produce — every other one ends in the tmux launcher,
+      which reads the process-global registry rather than the injected one. */
+  admissionRetryAt?: string,
 ): Promise<{
   status: number;
   error: string;
@@ -84,6 +90,8 @@ async function spawn(
       route contributes to the fence. */
   projects: (string | null | undefined)[];
   receipts: number;
+  /** The out-of-pool notice on the route's OWN answer, when it carried one. */
+  accountOverride: { recorded?: boolean; recordFailure?: string; accountId?: string; reason?: string } | null;
 }> {
   const store = sharedStore ?? new AgentRegistry(path.join(SANDBOX, `${clientAttemptId}.json`));
   let accountResolutions = 0;
@@ -106,6 +114,9 @@ async function spawn(
        nothing downstream of it — the attribution below included — can be
        observed at all. */
     resolveSpawnAccount: (_engine: unknown, accountId: string) => accountContext(accountId),
+    /* The queued answer stores the launch's images before it parks the pin;
+       this suite sends none. */
+    storeImages: () => [],
     resolveHealthySpawnAccount: async (
       _engine: unknown,
       requested: unknown,
@@ -117,7 +128,10 @@ async function spawn(
       /* The seam resolves an explicitly named account TO ITSELF, pool or no
          pool — that is the rule this stub stands in for, and it is what the
          route's attribution has to see to record the crossing. */
-      return accountContext(typeof requested === "string" && requested ? requested : "acct-default");
+      const context = accountContext(typeof requested === "string" && requested ? requested : "acct-default");
+      return admissionRetryAt
+        ? { ...context, requestedAdmission: { kind: "retry-at", retryAt: admissionRetryAt } }
+        : context;
     },
     defer: (work: () => unknown) => { void work(); },
   } as unknown as SpawnRouteDependencies;
@@ -134,13 +148,17 @@ async function spawn(
       ...(requestedAccountId ? { accountId: requestedAccountId } : {}),
     }),
   }), dependencies);
-  const payload = await response.json() as { error?: string };
+  const payload = await response.json() as {
+    error?: string;
+    accountOverride?: { recorded?: boolean; recordFailure?: string; accountId?: string; reason?: string };
+  };
   return {
     status: response.status,
     error: payload.error ?? "",
     accountResolutions,
     projects,
     receipts: Object.keys(store.snapshot().receipts).length,
+    accountOverride: payload.accountOverride ?? null,
   };
 }
 
@@ -395,4 +413,59 @@ test("a second request under the same attempt id appends no second crossing", as
   expect(second.receipts).toBe(1);
   const { accountProjectOverrides } = await import("@/lib/accounts/accountOverrides");
   expect(accountProjectOverrides({ project })).toHaveLength(1);
+});
+
+/**
+ * THE NOTICE RIDES THE ANSWER, which is `attributeNamedAccountChoice`'s own
+ * contract and what both switch seams already do: a journal that would not take
+ * the record answers `recorded: false` with the reason, and the caller's answer
+ * carries it to whoever made the choice. It matters more at this seam than at
+ * those — this record is the ONLY thing that makes an out-of-pool launch
+ * visible now that the binding does not refuse one, so a state directory that
+ * cannot be written to must not leave the crossing behind an ordinary spawn
+ * response.
+ */
+test("an out-of-pool launch carries its notice on the route's own answer", async () => {
+  const cwd = fs.mkdtempSync(path.join(SANDBOX, "notice-recorded-"));
+  const project = projectForCwd(cwd)!;
+  fs.writeFileSync(RECORD, JSON.stringify({
+    schemaVersion: 1,
+    bindings: [{ engine: "claude", accountId: "acct-reserved", project, createdAt: "2026-09-10T00:00:00.000Z" }],
+  }), "utf8");
+  const retryAt = new Date(Date.now() + 600_000).toISOString();
+
+  const attempt = await spawn(cwd, "binding_notice_recorded_20260910", undefined, "acct-chosen-by-hand", undefined, retryAt);
+
+  expect(attempt.status).toBe(202);
+  expect(attempt.accountOverride).toMatchObject({
+    accountId: "acct-chosen-by-hand",
+    reason: "outside-pool",
+    recorded: true,
+  });
+});
+
+test("a record the journal REFUSED says so on the answer rather than only in a server log", async () => {
+  const cwd = fs.mkdtempSync(path.join(SANDBOX, "notice-unrecordable-"));
+  const project = projectForCwd(cwd)!;
+  fs.writeFileSync(RECORD, JSON.stringify({
+    schemaVersion: 1,
+    bindings: [{ engine: "claude", accountId: "acct-reserved", project, createdAt: "2026-09-10T00:00:00.000Z" }],
+  }), "utf8");
+  /* A DIRECTORY where the journal's file belongs: the durable write cannot
+     rename over it, so the record is refused while the launch is not. */
+  const journal = path.join(STATE, "account-project-overrides.json");
+  fs.rmSync(journal, { recursive: true, force: true });
+  fs.mkdirSync(journal, { recursive: true });
+  const retryAt = new Date(Date.now() + 600_000).toISOString();
+  try {
+    const attempt = await spawn(cwd, "binding_notice_refused_20260910", undefined, "acct-chosen-by-hand", undefined, retryAt);
+
+    /* The launch was NOT refused for it — attribution that failed to write is
+       not a reason to refuse a gesture the operator is entitled to make. */
+    expect(attempt.status).toBe(202);
+    expect(attempt.accountOverride).toMatchObject({ accountId: "acct-chosen-by-hand", recorded: false });
+    expect(attempt.accountOverride?.recordFailure).toBeTruthy();
+  } finally {
+    fs.rmSync(journal, { recursive: true, force: true });
+  }
 });

--- a/src/app/api/spawn/route.binding.test.ts
+++ b/src/app/api/spawn/route.binding.test.ts
@@ -64,7 +64,14 @@ afterAll(() => {
 
 type SpawnRouteDependencies = NonNullable<Parameters<typeof POST.withDependencies>[1]>;
 
-async function spawn(cwd: string, clientAttemptId: string, resolutionFailure?: Error): Promise<{
+async function spawn(
+  cwd: string,
+  clientAttemptId: string,
+  resolutionFailure?: Error,
+  /** The account the REQUEST names, when it names one — the board's launch
+      draft, the orchestrator's rotate draft, `spawn_agent`. */
+  requestedAccountId?: string,
+): Promise<{
   status: number;
   error: string;
   accountResolutions: number;
@@ -80,32 +87,49 @@ async function spawn(cwd: string, clientAttemptId: string, resolutionFailure?: E
   /* Recorded inside the stub, because the route's own answer cannot show what
      it asked for — and what it asked for IS the fence at this seam. */
   const projects: (string | null | undefined)[] = [];
+  const accountContext = (accountId: string) => ({
+    engine: "claude" as const,
+    accountId,
+    kind: "managed" as const,
+    home: path.join(cwd, "account"),
+    transcriptRoot: path.join(cwd, "projects"),
+    env: { NODE_ENV: "test" as const },
+  });
   const dependencies = {
     registry: () => store,
     assertStructuredRuntime: () => {},
+    /* The route re-resolves the settled account under the mutation lock before
+       it reserves the receipt; without it the reservation never happens and
+       nothing downstream of it — the attribution below included — can be
+       observed at all. */
+    resolveSpawnAccount: (_engine: unknown, accountId: string) => accountContext(accountId),
     resolveHealthySpawnAccount: async (
       _engine: unknown,
-      _requested: unknown,
+      requested: unknown,
       project?: string | null,
     ) => {
       accountResolutions += 1;
       projects.push(project);
       if (resolutionFailure) throw resolutionFailure;
-      return {
-        engine: "claude" as const,
-        accountId: "acct-default",
-        kind: "managed" as const,
-        home: path.join(cwd, "account"),
-        transcriptRoot: path.join(cwd, "projects"),
-        env: { NODE_ENV: "test" as const },
-      };
+      /* The seam resolves an explicitly named account TO ITSELF, pool or no
+         pool — that is the rule this stub stands in for, and it is what the
+         route's attribution has to see to record the crossing. */
+      return accountContext(typeof requested === "string" && requested ? requested : "acct-default");
     },
     defer: (work: () => unknown) => { void work(); },
   } as unknown as SpawnRouteDependencies;
   const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
     method: "POST",
     headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json", "sec-fetch-site": "same-origin" },
-    body: JSON.stringify({ title: "Inspect the atlas checkout", engine: "claude", model: "sonnet", cwd, "prompt": "inspect", clientAttemptId }),
+    body: JSON.stringify({
+      title: "Inspect the atlas checkout",
+      engine: "claude",
+      model: "sonnet",
+      cwd,
+      "prompt": "inspect",
+      clientAttemptId,
+      ...(requestedAccountId ? { accountId: requestedAccountId } : {}),
+    }),
   }), dependencies);
   const payload = await response.json() as { error?: string };
   return {
@@ -285,4 +309,54 @@ test("a bound pool with no capacity refuses the launch as a conflict, and the id
   expect(Object.keys(store.snapshot().receipts)).toEqual([]);
 
   setAgentRegistryForTests(null);
+});
+
+/**
+ * THE BINDING STOPPED BEING A VETO HERE, SO IT HAD TO BECOME A RECORD.
+ *
+ * A launch that NAMES an account is a control somebody worked, and the operator
+ * directive of 2026-09-10 is that no project binding may refuse one. What that
+ * costs is attribution: an account carrying work it is not bound to has to read
+ * as a decision somebody made, not as a fence that quietly stopped holding, and
+ * the project view renders this journal beside the pool.
+ */
+test("a launch onto an account outside the project's pool is recorded in the override journal", async () => {
+  const cwd = fs.mkdtempSync(path.join(SANDBOX, "named-outside-pool-"));
+  const project = projectForCwd(cwd)!;
+  fs.writeFileSync(RECORD, JSON.stringify({
+    schemaVersion: 1,
+    bindings: [{ engine: "claude", accountId: "acct-reserved", project, createdAt: "2026-09-10T00:00:00.000Z" }],
+  }), "utf8");
+
+  const attempt = await spawn(cwd, "binding_named_outside_20260910", undefined, "acct-chosen-by-hand");
+
+  /* Not refused: the whole point. */
+  expect(attempt.status).not.toBe(409);
+  const { accountProjectOverrides } = await import("@/lib/accounts/accountOverrides");
+  expect(accountProjectOverrides({ project })).toEqual([expect.objectContaining({
+    engine: "claude",
+    project,
+    accountId: "acct-chosen-by-hand",
+    allowedAccountIds: ["acct-reserved"],
+    reason: "outside-pool",
+    actor: "operator",
+    via: "launch",
+  })]);
+});
+
+test("a launch onto an account the pool already contains records nothing", async () => {
+  /* Inside the pool nothing was crossed, so the journal must stay empty — a
+     record of every launch would bury the crossings it exists to show. */
+  const cwd = fs.mkdtempSync(path.join(SANDBOX, "named-inside-pool-"));
+  const project = projectForCwd(cwd)!;
+  fs.writeFileSync(RECORD, JSON.stringify({
+    schemaVersion: 1,
+    bindings: [{ engine: "claude", accountId: "acct-reserved", project, createdAt: "2026-09-10T00:00:00.000Z" }],
+  }), "utf8");
+
+  const attempt = await spawn(cwd, "binding_named_inside_20260910", undefined, "acct-reserved");
+
+  expect(attempt.status).not.toBe(409);
+  const { accountProjectOverrides } = await import("@/lib/accounts/accountOverrides");
+  expect(accountProjectOverrides({ project })).toEqual([]);
 });

--- a/src/components/mobile/orchestratorRowState.test.ts
+++ b/src/components/mobile/orchestratorRowState.test.ts
@@ -195,7 +195,7 @@ describe("what rides alongside a live incumbent", () => {
 
 describe("every designed seat state has a badge tone and a word", () => {
   const states: OrchestratorRowState[] = [
-    "loading", "unavailable", "draft", "creating", "intent-error", "live", "stalled", "resumable", "dead", "resolving",
+    "loading", "unavailable", "draft", "creating", "intent-error", "live", "waiting", "stalled", "resumable", "dead", "resolving",
   ];
 
   test("tone and label cover the union exactly", () => {

--- a/src/components/mobile/orchestratorRowState.test.ts
+++ b/src/components/mobile/orchestratorRowState.test.ts
@@ -248,6 +248,20 @@ describe("the card's shape and the badge it speaks", () => {
     expect(card.badge).toBe("conversation");
   });
 
+  test("a seat whose TURN is idle still speaks the conversation's phrase, not the coarse word", () => {
+    /* `waiting` is a hosted seat with an idle turn, and its conversation is on
+       this device — so the card carries the same phrase (and the same duration)
+       the board's row for that conversation carries. Speaking the state word
+       here would make one seat read two ways across two surfaces. */
+    const card = cardFor({
+      status: { seat: seat(), pending: null, exists: true },
+      file: { ...conversation, lastTurn: { startedAt: 1_000, endedAt: 2_000 } } as FileEntry,
+    });
+    expect(card.state).toBe("waiting");
+    expect(card.tap).toBe("conversation");
+    expect(card.badge).toBe("conversation");
+  });
+
   test("a seat designated but not yet on this device speaks its own state word", () => {
     /* «resolving» has no conversation to take a phrase from, so borrowing one
        would state a working orchestrator this phone cannot see. */

--- a/src/components/mobile/orchestratorRowState.ts
+++ b/src/components/mobile/orchestratorRowState.ts
@@ -107,7 +107,15 @@ export function seatCardView(
        an empty slot with a friendly line on it: the card says «failed» and its
        tap opens the sheet holding the error and the draft that retries it. */
     shape: view.state === "draft" ? "invitation" : "seat",
-    badge: view.state === "live" && view.tap === "conversation" ? "conversation" : "state",
+    /* A HOSTED seat whose conversation is on this device carries the
+       conversation's own phrase, and `waiting` is a hosted seat — the same one
+       `live` is, with its turn idle rather than running. Excluding it would make
+       the card say «waiting» while the board row beside it says «waiting 2:14»,
+       which is the one seat reading two ways that the invariant above forbids,
+       and it would drop the duration the phrase carries. The conversation
+       vocabulary already draws the same distinction (`CONVERSATION_STATE_TONE`
+       has both `working` and `waiting`), so nothing is lost by deferring to it. */
+    badge: (view.state === "live" || view.state === "waiting") && view.tap === "conversation" ? "conversation" : "state",
   };
 }
 

--- a/src/components/mobile/orchestratorRowState.ts
+++ b/src/components/mobile/orchestratorRowState.ts
@@ -30,6 +30,10 @@ export type OrchestratorRowState =
   | "creating"
   | "intent-error"
   | "live"
+  /* Hosted and idle — the seat's own reading of `waiting`, carried through so
+     the phone never calls an agent awaiting input "live" while the dock does
+     not. One state machine, two renderings. */
+  | "waiting"
   | "stalled"
   | "resumable"
   | "dead"
@@ -119,6 +123,7 @@ export const SEAT_STATE_TONE: Record<OrchestratorRowState, SeatBadgeTone> = {
   creating: "accent",
   "intent-error": "danger",
   live: "success",
+  waiting: "neutral",
   stalled: "warning",
   resumable: "neutral",
   dead: "danger",
@@ -149,6 +154,7 @@ export const ROW_STATE_LABEL: Record<OrchestratorRowState, MessageKey> = {
   creating: "orchPanel.badgeCreating",
   "intent-error": "orchPanel.badgeFailed",
   live: "orchPanel.badgeLive",
+  waiting: "orchPanel.badgeWaiting",
   stalled: "orchPanel.badgeStalled",
   resumable: "orchPanel.badgeResumable",
   dead: "orchPanel.badgeDead",

--- a/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/components/orchestrator/OrchestratorPanel.tsx
@@ -928,6 +928,9 @@ const WARNING_BADGE = "border-warning/45 bg-warning-soft text-warning";
 const SEAT_BADGE: Record<SeatBadge, { tone: string; key: MessageKey }> = {
   "needs-you": { tone: WARNING_BADGE, key: "orchPanel.badgeNeedsYou" },
   live: { tone: "border-success/45 bg-success-soft text-success", key: "orchPanel.badgeLive" },
+  /* Hosted and idle. Not green: green is the word for a turn that is running,
+     and an agent awaiting input is a state the operator may want to act on. */
+  waiting: { tone: QUIET_BADGE, key: "orchPanel.badgeWaiting" },
   stalled: { tone: WARNING_BADGE, key: "orchPanel.badgeStalled" },
   resumable: { tone: QUIET_BADGE, key: "orchPanel.badgeResumable" },
   dead: { tone: DANGER_BADGE, key: "orchPanel.badgeDead" },

--- a/src/components/orchestrator/seatComposerHoist.dom.test.tsx
+++ b/src/components/orchestrator/seatComposerHoist.dom.test.tsx
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { FileEntry } from "@/lib/types";
+
+/**
+ * THE COMPOSER THE DOCK LOST (operator report, 2026-09-10).
+ *
+ * The seat's conversation was hosted and idle — the registry answered
+ * `deliverable: true` for it — the dock rendered its feed and its control
+ * strip, and there was no input anywhere on the page. A live badge over a
+ * conversation with nothing to type into says «it is working» and offers no way
+ * to find out; the operator read it as a fabricated live status.
+ *
+ * WHY IT SHIPPED INVISIBLY, and why this file exists beside
+ * `OrchestratorPanel.dom.test.tsx` rather than inside it: that suite mounts the
+ * PANEL, and a tree with no `VoiceComposerHost` in it keeps the inline
+ * card-scoped composer by design (`TmuxComposer`'s dispatcher). So the assertion
+ * there — "an active seat mounts the REAL conversation column, feed and
+ * composer" — passes on a code path production never takes. Production mounts
+ * the Viewer, the Viewer mounts the host, and the dock's composer is HOISTED:
+ * the dock publishes a place, and the host renders the one composer into it.
+ *
+ * This file mounts the real `Viewer`, so the hoisted path is the one under test.
+ */
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const dom = new Window({ url: "http://localhost/" });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  location: dom.location,
+  history: dom.history,
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Element: dom.Element,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+  MutationObserver: dom.MutationObserver,
+  ResizeObserver: dom.ResizeObserver ?? class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: undefined,
+  requestAnimationFrame: (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+});
+
+const matchMedia = (query: string) => ({
+  matches: false, media: query, onchange: null,
+  addListener: () => {}, removeListener: () => {},
+  addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+});
+Object.assign(globalThis, { matchMedia });
+Object.assign(dom, { matchMedia });
+
+(dom.HTMLElement.prototype as unknown as { animate: () => unknown }).animate = () => ({
+  finished: Promise.resolve(),
+  cancel() {},
+  finish() {},
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+mock.module("@/hooks/runtimeBus", () => ({
+  SNAPSHOT_URL: "/api/runtime/snapshot",
+  STREAM_URL: "/api/runtime/stream",
+  STREAM_RECONNECTED_EVENT: "llv:stream-reconnected",
+  isRuntimeUiEnabled: () => false,
+  getRuntimeBus: () => ({
+    getState: () => ({ connection: "offline" }),
+    subscribe: () => () => {},
+    subscribeFilesRevision: () => () => {},
+  }),
+}));
+
+const { Viewer } = await import("../Viewer");
+const { resetFilesClientCacheForTests } = await import("@/hooks/useFiles");
+const { OPEN_KEY } = await import("./OrchestratorDock");
+
+const PROJECT = "atlas";
+const SEAT_CONVERSATION = "conversation_orch";
+const originalFetch = globalThis.fetch;
+
+/** The seat's conversation as the catalog carries it: a hosted Claude session,
+    quiet at this instant, which is what an idle host looks like from here. */
+const seatFile: FileEntry = {
+  path: "/transcripts/orch.jsonl",
+  root: "claude-projects",
+  name: "orch.jsonl",
+  project: PROJECT,
+  title: "Orchestrator",
+  engine: "claude",
+  kind: "session",
+  fmt: "claude",
+  parent: null,
+  mtime: 1_760_000_000,
+  size: 12,
+  activity: "live",
+  proc: "running",
+  pid: 4_242,
+  conversationId: SEAT_CONVERSATION,
+  model: "opus",
+  pendingQuestion: null,
+  waitingInput: null,
+} as FileEntry;
+
+const activeSeat = () => ({
+  project: PROJECT,
+  seatEpoch: 3,
+  conversationId: SEAT_CONVERSATION,
+  path: seatFile.path,
+  mandate: "own the board",
+  promptVersion: null,
+  predecessorConversationId: null,
+  state: "active" as const,
+  intent: { clientRequestId: "req-aaaaaaaa", mode: "spawn" as const, launchId: null, error: null },
+  designatedAt: "2026-09-10T00:00:00.000Z",
+  activatedAt: "2026-09-10T00:00:01.000Z",
+});
+
+/** The designation that was refused, exactly as the seat route reports it: a
+    pending intent carrying its terminal error, over a still-seated incumbent. */
+const refusedPending = () => ({
+  project: PROJECT,
+  seatEpoch: 4,
+  conversationId: null,
+  path: null,
+  mandate: "own the board",
+  promptVersion: null,
+  predecessorConversationId: null,
+  state: "pending" as const,
+  intent: {
+    clientRequestId: "req-bbbbbbbb",
+    mode: "spawn" as const,
+    launchId: null,
+    error: "codex account spare-carrier is not allowed on project atlas (allowed codex accounts: reserved-carrier)",
+  },
+  designatedAt: "2026-09-10T00:10:00.000Z",
+  activatedAt: null,
+});
+
+let pending: ReturnType<typeof refusedPending> | null = null;
+
+function stubFetch(): void {
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.startsWith("/api/files")) {
+      return new Response(JSON.stringify({
+        files: [seatFile],
+        projectCatalog: [{ project: PROJECT, conversations: 1 }],
+      }));
+    }
+    if (url.startsWith("/api/orchestrator/seat/status")) {
+      return new Response(JSON.stringify({
+        project: PROJECT,
+        designated: true,
+        conversationId: SEAT_CONVERSATION,
+        engine: "claude",
+        model: "opus",
+        accountId: "spare-carrier",
+        transcriptPath: seatFile.path,
+        /* The registry's own answer for this seat in the incident: a host that
+           is running and a turn that is not. */
+        liveness: { lifecycle: "waiting", hostState: "alive", silentForMs: 211_916 },
+        rotation: { recommended: false, level: "none", reasons: [], thresholdUnknown: true },
+      }));
+    }
+    if (url.startsWith("/api/orchestrator/seat")) {
+      return new Response(JSON.stringify({ seat: activeSeat(), pending, exists: true }));
+    }
+    /* Everything else answers 404, exactly as the dock's own shell test does:
+       an unstubbed reader must not be handed a body it will misparse. */
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+let mounted: { unmount: () => void } | null = null;
+
+beforeEach(() => {
+  resetFilesClientCacheForTests();
+  dom.localStorage.clear();
+  dom.sessionStorage.clear();
+  dom.location.hash = "";
+  dom.document.body.replaceChildren();
+  pending = null;
+  stubFetch();
+});
+
+afterEach(() => {
+  if (mounted) {
+    const root = mounted;
+    mounted = null;
+    act(() => root.unmount());
+  }
+  globalThis.fetch = originalFetch;
+  dom.document.body.replaceChildren();
+});
+
+async function mountViewerOnProject(): Promise<HTMLElement> {
+  dom.localStorage.setItem("llvProject", PROJECT);
+  dom.localStorage.setItem(`${OPEN_KEY}:${PROJECT}`, "1");
+  const host = dom.document.createElement("div");
+  dom.document.body.append(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  mounted = root;
+  await act(async () => { root.render(<Viewer />); });
+  await act(async () => {
+    dom.location.hash = `#p=${encodeURIComponent(PROJECT)}`;
+    dom.dispatchEvent(new dom.Event("hashchange"));
+  });
+  for (let round = 0; round < 6; round += 1) {
+    await act(async () => { await Bun.sleep(40); });
+  }
+  return host as unknown as HTMLElement;
+}
+
+/** The composer, wherever the hoist put it — the dock's place, or the parked
+    container the host uses when it has nowhere to portal into. The operator can
+    only type into the first; both are asserted so a composer that exists but is
+    unreachable is never mistaken for one that is missing entirely. */
+function composerIn(host: HTMLElement): { inDock: boolean; parked: boolean; places: number } {
+  const dock = host.querySelector("[data-orchestrator-conversation]");
+  return {
+    inDock: Boolean(dock?.querySelector("textarea")),
+    parked: host.querySelectorAll("[data-testid=voice-composer-parked]").length > 0,
+    places: host.querySelectorAll("[data-testid=voice-composer-card-slot]").length,
+  };
+}
+
+test("REGRESSION: a seated, hosted orchestrator has a composer in the dock under the Viewer-level hoist", async () => {
+  const host = await mountViewerOnProject();
+
+  /* The dock bound the seat's conversation and published its composer place. */
+  expect(host.querySelector(`[data-orchestrator-conversation="${SEAT_CONVERSATION}"]`)).not.toBeNull();
+  expect(composerIn(host).places).toBe(1);
+  /* And the one hoisted composer renders into it. A place with no composer in
+     it is the incident: feed, control strip, live badge, nothing to type. */
+  expect(composerIn(host)).toMatchObject({ inDock: true, parked: false });
+});
+
+test("REGRESSION: a REFUSED designation over a live incumbent keeps both the reason and the composer", async () => {
+  /* The panel's whole promise for this state: the incumbent stays, the failure
+     is readable, and the way forward is still a message to the agent that is
+     still running. Losing the composer here turns a recoverable seat into a
+     status display. */
+  pending = refusedPending();
+  const host = await mountViewerOnProject();
+
+  const banner = host.querySelector("[data-orchestrator-intent-error]");
+  expect(banner?.textContent).toContain("is not allowed on project atlas");
+  expect(composerIn(host)).toMatchObject({ inDock: true, parked: false });
+});
+

--- a/src/components/orchestrator/seatState.test.ts
+++ b/src/components/orchestrator/seatState.test.ts
@@ -309,20 +309,51 @@ describe("the server's own rotation recommendation is what the panel says (#978)
    */
   test("a hosted seat whose TURN is idle reads waiting, and one whose turn is running reads live", () => {
     const hosted = { hostLive: true };
-    expect(live({ ...hosted, incumbent: incumbent({ liveness: { lifecycle: "waiting", hostState: "alive", silentForMs: 211_916 } }) }))
-      .toMatchObject({ kind: "live", liveness: "waiting" });
-    expect(live({ ...hosted, incumbent: incumbent() })).toMatchObject({ kind: "live", liveness: "live" });
+    const idleTail = file({ lastTurn: { startedAt: 1_000, endedAt: 2_000 } });
+    const openTail = file({ lastTurn: { startedAt: 1_000, endedAt: null } });
+    expect(live({ ...hosted, file: idleTail })).toMatchObject({ kind: "live", liveness: "waiting" });
+    expect(live({ ...hosted, file: openTail })).toMatchObject({ kind: "live", liveness: "live" });
   });
 
-  test("only an AFFIRMED reading may downgrade the badge, and only from live", () => {
+  /**
+   * THE TURN'S OWN BOUNDARY OUTRANKS THE MINUTE-OLD READING, in both
+   * directions. `liveness.lifecycle` rides the incumbent poll, whose cadence is
+   * set by context-window wear — a minute — while `lastTurn` arrives on the
+   * file poll. Reading the slow one first holds "waiting" over an agent that
+   * started working a message ago, and "live" over one that finished: the
+   * original complaint, time-boxed rather than fixed.
+   */
+  test("the catalog's fresh turn boundary outranks a minute-old lifecycle, both ways", () => {
+    const stillIdle = incumbent({ liveness: { lifecycle: "waiting", hostState: "alive", silentForMs: 211_916 } });
+    const stillRunning = incumbent({ liveness: { lifecycle: "running", hostState: "alive", silentForMs: 0 } });
+    /* The operator just sent a message: the turn is open in the catalog while
+       the status read still remembers an idle seat. */
+    expect(live({ hostLive: true, incumbent: stillIdle, file: file({ lastTurn: { startedAt: 1_000, endedAt: null } }) }))
+      .toMatchObject({ liveness: "live" });
+    /* And the turn just ended, while the status read still remembers a running
+       one — the green badge the operator read as "it is working". */
+    expect(live({ hostLive: true, incumbent: stillRunning, file: file({ lastTurn: { startedAt: 1_000, endedAt: 2_000 } }) }))
+      .toMatchObject({ liveness: "waiting" });
+  });
+
+  test("with no turn boundary in the tail, only an AFFIRMED reading may downgrade — and only from live", () => {
     const idle = incumbent({ liveness: { lifecycle: "waiting", hostState: "alive", silentForMs: 1_000 } });
+    /* No boundary derivable from the tail (#231), so the slow reading is the
+       only reading there is. */
+    expect(live({ hostLive: true, incumbent: idle })).toMatchObject({ liveness: "waiting" });
     /* No affirmation: the reading may be a memory from before a restart, and
        accusing the seat of idling on one is the same fault `hostLive` already
        fences for the bind bound (#1182). */
     expect(live({ hostLive: false, incumbent: idle })).toMatchObject({ liveness: "live" });
-    /* Stronger statements are never softened by it. */
-    expect(live({ hostLive: true, surface: "dead", incumbent: idle })).toMatchObject({ liveness: "dead" });
-    expect(live({ hostLive: true, surface: "resume", incumbent: idle })).toMatchObject({ liveness: "resumable" });
+    /* A tail that carries a boundary needs no such gate — it is this poll's own
+       answer about this transcript, not a claim held over. */
+    expect(live({ hostLive: false, incumbent: idle, file: file({ lastTurn: { startedAt: 1_000, endedAt: 2_000 } }) }))
+      .toMatchObject({ liveness: "waiting" });
+    /* Stronger statements about the HOST are never softened by an idle turn. */
+    const idleTail = { lastTurn: { startedAt: 1_000, endedAt: 2_000 } };
+    expect(live({ hostLive: true, surface: "dead", incumbent: idle, file: file(idleTail) })).toMatchObject({ liveness: "dead" });
+    expect(live({ hostLive: true, surface: "resume", incumbent: idle, file: file(idleTail) })).toMatchObject({ liveness: "resumable" });
+    expect(live({ hostLive: true, incumbent: idle, file: file({ ...idleTail, activity: "stalled" }) })).toMatchObject({ liveness: "stalled" });
   });
 });
 

--- a/src/components/orchestrator/seatState.test.ts
+++ b/src/components/orchestrator/seatState.test.ts
@@ -296,6 +296,34 @@ describe("the server's own rotation recommendation is what the panel says (#978)
     expect(live({ surface: "dead", incumbent: vacantReading }))
       .toMatchObject({ rotation: { level: "recommend", reasons: ["dead"], source: "client" } });
   });
+
+  /**
+   * AN IDLE PROCESS IS NOT AN ACTIVELY WORKING TURN (operator directive,
+   * 2026-09-10).
+   *
+   * The board's catalog cannot tell them apart — a hosted agent sitting on a
+   * finished turn is exactly as quiet as one mid-tool-call — so a green «live»
+   * over the first is a claim nobody made. The status read's lifecycle says
+   * which it is, in the shared vocabulary where `waiting` is "a host is alive
+   * and idle".
+   */
+  test("a hosted seat whose TURN is idle reads waiting, and one whose turn is running reads live", () => {
+    const hosted = { hostLive: true };
+    expect(live({ ...hosted, incumbent: incumbent({ liveness: { lifecycle: "waiting", hostState: "alive", silentForMs: 211_916 } }) }))
+      .toMatchObject({ kind: "live", liveness: "waiting" });
+    expect(live({ ...hosted, incumbent: incumbent() })).toMatchObject({ kind: "live", liveness: "live" });
+  });
+
+  test("only an AFFIRMED reading may downgrade the badge, and only from live", () => {
+    const idle = incumbent({ liveness: { lifecycle: "waiting", hostState: "alive", silentForMs: 1_000 } });
+    /* No affirmation: the reading may be a memory from before a restart, and
+       accusing the seat of idling on one is the same fault `hostLive` already
+       fences for the bind bound (#1182). */
+    expect(live({ hostLive: false, incumbent: idle })).toMatchObject({ liveness: "live" });
+    /* Stronger statements are never softened by it. */
+    expect(live({ hostLive: true, surface: "dead", incumbent: idle })).toMatchObject({ liveness: "dead" });
+    expect(live({ hostLive: true, surface: "resume", incumbent: idle })).toMatchObject({ liveness: "resumable" });
+  });
 });
 
 describe("the rotate draft renders the same two states the create draft does (#978)", () => {

--- a/src/components/orchestrator/seatState.ts
+++ b/src/components/orchestrator/seatState.ts
@@ -455,28 +455,32 @@ export function deriveRotateDraftState(input: {
 }
 
 /**
- * The capability surface decides liveness; `activity` only separates a quiet
- * hosted conversation from a working one. Reading `activity` FIRST is what made
- * a finished Claude session and a killed Codex thread both show «live»: they are
- * not stalled, so everything else fell through to it. Both engines reach
- * `resume` through the same matrix — a claude-projects session and a
- * codex-sessions thread with no live host are resumable in place.
- */
-/**
- * The liveness the panel SHOWS: the capability matrix's answer, refined by the
- * one thing the catalog cannot see.
+ * The liveness the panel SHOWS: is this conversation HOSTED (the capability
+ * matrix), and is its TURN running (the transcript's own turn boundary).
  *
- * `livenessOf` decides whether the conversation is hosted at all, and it does
- * that from evidence the board already carries. Whether a hosted conversation
- * is WORKING or merely sitting there is a different question, and only the
- * status read answers it — `liveness.lifecycle`, straight out of the shared
- * lifecycle vocabulary, where `waiting` means "a host is alive and idle".
+ * The two questions have different evidence and different clocks, and getting
+ * the order wrong is how a badge lies in both directions.
  *
- * Applied only to `live`, and only to an AFFIRMED reading of the seat's own
- * conversation. `stalled`, `resumable` and `dead` are stronger statements this
- * must not soften, and a stale or absent reading may not downgrade a badge the
- * board's own evidence supports — that is the same rule `hostLive` already
- * carries for the bind bound (#1182).
+ * TURN EVIDENCE COMES FROM THE CATALOG FIRST. `lastTurn` is the boundary the
+ * scanner derives from the transcript tail — `endedAt: null` while the turn is
+ * still running — and it arrives on the FILE poll, seconds after the agent
+ * starts or stops working. The status read's `liveness.lifecycle` says the same
+ * thing in the shared vocabulary's words, but it rides the incumbent poll,
+ * whose cadence is set by context-window wear (`INCUMBENT_POLL_MS`, one
+ * minute) and whose own doc says the things it answers "move over tens of
+ * minutes". Preferring it would hold «waiting» over an agent that started
+ * working a message ago, and «live» over one that finished — the original
+ * complaint, merely time-boxed to a minute.
+ *
+ * So `lifecycle` is the FALLBACK, for a transcript tail that carries no turn
+ * boundary at all (issue #231): there the slow reading is the only reading, and
+ * only an AFFIRMED one may downgrade — a cached «waiting» carried across the
+ * restart the panel is waiting out is a memory, the same rule `hostLive`
+ * carries for the bind bound (#1182). Catalog evidence needs no such gate: it
+ * is this poll's own answer about this transcript, not a claim held over.
+ *
+ * Applied to `live` only. `stalled`, `resumable` and `dead` are stronger
+ * statements about the HOST, and an idle turn does not soften any of them.
  */
 export function seatLivenessOf(input: {
   file: FileEntry | null;
@@ -485,10 +489,33 @@ export function seatLivenessOf(input: {
   hostLive: boolean;
 }): SeatLiveness {
   const liveness = livenessOf(input.file, input.surface);
-  if (liveness !== "live" || !input.hostLive) return liveness;
-  return input.incumbent?.liveness?.lifecycle === "waiting" ? "waiting" : liveness;
+  if (liveness !== "live") return liveness;
+  const running = turnRunning(input.file);
+  if (running !== null) return running ? "live" : "waiting";
+  return input.hostLive && input.incumbent?.liveness?.lifecycle === "waiting" ? "waiting" : "live";
 }
 
+/** Whether the transcript's newest turn is still open, or null when the tail
+    carries no turn boundary to read (`lastTurn` absent — issue #231). An
+    explicitly null `lastTurn` is the scanner saying it derived none, which is
+    the same absence of evidence. */
+function turnRunning(file: FileEntry | null): boolean | null {
+  const turn = file?.lastTurn;
+  return turn ? turn.endedAt === null : null;
+}
+
+/**
+ * Is the conversation HOSTED, and can it be picked back up? The capability
+ * surface decides; `activity` only separates a hosted conversation that has
+ * gone silent from one that has not. Reading `activity` FIRST is what made a
+ * finished Claude session and a killed Codex thread both show «live»: they are
+ * not stalled, so everything else fell through to it. Both engines reach
+ * `resume` through the same matrix — a claude-projects session and a
+ * codex-sessions thread with no live host are resumable in place.
+ *
+ * `live` here means "hosted and not silent", never "working": which of the two
+ * a hosted conversation is doing is `seatLivenessOf`'s question, above.
+ */
 function livenessOf(file: FileEntry | null, surface: StripSurface | null): SeatLiveness {
   if (surface === "resume") return "resumable";
   /* `inert` is a finished conversation the engines cannot resume, and

--- a/src/components/orchestrator/seatState.ts
+++ b/src/components/orchestrator/seatState.ts
@@ -154,12 +154,19 @@ export function mandateSummaryOf(
  *
  *  - `resolving` — no file yet, or the runtime plane has not resolved the host.
  *  - `live` / `stalled` — a hosted conversation, quiet or not.
+ *  - `waiting` — a hosted conversation whose HOST is alive and whose TURN is
+ *    not: the agent is awaiting input. The catalog alone cannot tell this from
+ *    `live` — an idle process and a working one look equally quiet from the
+ *    outside — so it comes from the lifecycle vocabulary's own `waiting`, in
+ *    the status read (`../orchestrator/seat/status`). The operator asked for
+ *    exactly this distinction: a green «live» over an agent that is only
+ *    sitting there reads as «it is working» and is a claim nobody made.
  *  - `resumable` — finished or killed, and the composer can pick THIS
  *    conversation back up (never a second spawn).
  *  - `dead` — the host is gone, retired or unresumable; recovery is the
  *    banner's, and rotation is the way forward.
  */
-export type SeatLiveness = "resolving" | "live" | "stalled" | "resumable" | "dead";
+export type SeatLiveness = "resolving" | "live" | "waiting" | "stalled" | "resumable" | "dead";
 
 /**
  * What the dock's badge NAMES, which is not always the liveness (issue #1167).
@@ -332,7 +339,12 @@ export function deriveOrchestratorPanelState(input: {
   const pendingError = pending?.intent.error ?? null;
 
   if (active?.conversationId) {
-    const liveness = livenessOf(input.file, input.surface);
+    const liveness = seatLivenessOf({
+      file: input.file,
+      surface: input.surface,
+      incumbent: input.incumbent ?? null,
+      hostLive: input.hostLive === true,
+    });
     return {
       kind: "live",
       seat: active,
@@ -450,6 +462,33 @@ export function deriveRotateDraftState(input: {
  * `resume` through the same matrix — a claude-projects session and a
  * codex-sessions thread with no live host are resumable in place.
  */
+/**
+ * The liveness the panel SHOWS: the capability matrix's answer, refined by the
+ * one thing the catalog cannot see.
+ *
+ * `livenessOf` decides whether the conversation is hosted at all, and it does
+ * that from evidence the board already carries. Whether a hosted conversation
+ * is WORKING or merely sitting there is a different question, and only the
+ * status read answers it — `liveness.lifecycle`, straight out of the shared
+ * lifecycle vocabulary, where `waiting` means "a host is alive and idle".
+ *
+ * Applied only to `live`, and only to an AFFIRMED reading of the seat's own
+ * conversation. `stalled`, `resumable` and `dead` are stronger statements this
+ * must not soften, and a stale or absent reading may not downgrade a badge the
+ * board's own evidence supports — that is the same rule `hostLive` already
+ * carries for the bind bound (#1182).
+ */
+export function seatLivenessOf(input: {
+  file: FileEntry | null;
+  surface: StripSurface | null;
+  incumbent: OrchestratorIncumbent | null;
+  hostLive: boolean;
+}): SeatLiveness {
+  const liveness = livenessOf(input.file, input.surface);
+  if (liveness !== "live" || !input.hostLive) return liveness;
+  return input.incumbent?.liveness?.lifecycle === "waiting" ? "waiting" : liveness;
+}
+
 function livenessOf(file: FileEntry | null, surface: StripSurface | null): SeatLiveness {
   if (surface === "resume") return "resumable";
   /* `inert` is a finished conversation the engines cannot resume, and

--- a/src/components/voice/VoiceComposerHost.tsx
+++ b/src/components/voice/VoiceComposerHost.tsx
@@ -81,11 +81,26 @@ export function VoiceComposerHost({ files = NO_FILES }: { files?: readonly FileE
   /* The card's props are retained past its unmount on purpose — a parked composer
      needs something to render with — so nothing retracts them at the seam. This
      is where they stop being needed: a conversation this host no longer renders a
-     composer for keeps no `FileEntry` snapshot alive. Runs after commit, so the
-     render above always had the props it was about to use. */
+     composer for keeps no `FileEntry` snapshot alive.
+
+     THE SET IS RE-READ HERE, not taken from the render above, and the difference
+     is a composer that never appears at all. A card publishes its PLACE from a
+     ref, during the commit that notifies this host, and its PROPS from its own
+     effect, which runs before this one. So this effect's first run carries a
+     `conversationIds` from a render taken before the card existed, while the
+     registry it is about to prune already holds that card's freshly published
+     props — and it deletes them, along with the per-place map nothing will
+     republish until the card's own props change again. The dock's seat conversation
+     is exactly the case with no second publisher behind it: the operator was left
+     with the feed, the control strip and a live badge over an agent they had no
+     way to answer (operator report, 2026-09-10). Read at effect time, the prune
+     sees what the render's own commit produced and releases only what has really
+     gone. */
   useEffect(() => {
+    const rendered = new Set(getVoiceComposerCardIds());
+    if (liveCall) rendered.add(liveCall.conversationId);
     for (const cardId of getVoiceComposerCardPropsIds()) {
-      if (!conversationIds.has(cardId)) forgetVoiceComposerCardProps(cardId);
+      if (!rendered.has(cardId)) forgetVoiceComposerCardProps(cardId);
     }
   });
 

--- a/src/lib/accounts/accountOverrides.ts
+++ b/src/lib/accounts/accountOverrides.ts
@@ -38,8 +38,14 @@ export type AccountChoiceActor =
   | { kind: "operator" }
   | { kind: "agent"; conversationId: string };
 
-/** The control the choice came through, so the record names the gesture. */
-export type AccountChoiceVia = "structured-reconfigure" | "conversation-switch";
+/** The control the choice came through, so the record names the gesture.
+
+    `launch` is the third one and the last to arrive: a launch that NAMES an
+    account — the board's launch draft, the orchestrator's create and rotate
+    drafts, `spawn_agent`'s `accountId`. It used to be refused outright on a
+    bound project rather than attributed, which is the one seam that read this
+    record as a veto instead of a default. */
+export type AccountChoiceVia = "structured-reconfigure" | "conversation-switch" | "launch";
 
 /** Why the choice was outside the pool the project's work is normally drawn from. */
 export type AccountOverrideReason =
@@ -127,7 +133,7 @@ function overrideList(value: unknown): AccountProjectOverride[] {
         ? record.actorConversationId
         : null,
       conversationId: typeof record.conversationId === "string" && record.conversationId ? record.conversationId : null,
-      via: record.via === "conversation-switch" ? "conversation-switch" : "structured-reconfigure",
+      via: record.via === "conversation-switch" || record.via === "launch" ? record.via : "structured-reconfigure",
     }];
   });
 }
@@ -194,11 +200,13 @@ function appendOverride(override: AccountProjectOverride): { ok: true } | { ok: 
  * pool or on an unbound project: there is nothing to attribute, and every
  * caller's behaviour there is exactly what it always was.
  *
- * Both explicit switch seams call THIS, so neither can drift into refusing what
- * the other allows. Both call it AFTER their switch has been accepted, which is
- * what makes the record a statement about something that happened: an attempt
- * attributed before authentication, reservation and dispatch left the panel
- * showing an out-of-pool choice that was refused a moment later.
+ * Every explicit account seam calls THIS, so none can drift into refusing what
+ * another allows. Each calls it AFTER its own gesture has been accepted, which
+ * is what makes the record a statement about something that happened: an
+ * attempt attributed before authentication, reservation and dispatch left the
+ * panel showing an out-of-pool choice that was refused a moment later. For a
+ * launch that is the durable receipt — the point past which the account is what
+ * the work will run on.
  *
  * A journal that would not take the record does not pass quietly. The notice
  * says `recorded: false` and carries the reason, the caller's answer carries it

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -114,10 +114,15 @@ export async function resolveHealthySpawnAccount(
   /* The automatic answer is also the FALLBACK the branches below reach for when
      a named account turns out not to exist. On a record nobody could read there
      is no such answer: the pool was invisible, so falling back would be the
-     machine picking with the fence unread. */
-  const active = automatic.kind === "available" && !recordUnreadable
-    ? automatic.accountId ?? undefined
-    : undefined;
+     machine picking with the fence unread.
+
+     `hasAutomatic` is separate from `active` because `available` with a NULL
+     account is a real answer — an unbound project with nothing routed, where
+     the fallback is the engine's own default and `contextForSpawn(undefined)`
+     is how this seam has always resolved it. Reading a missing id as a missing
+     ANSWER would turn that into a throw. */
+  const hasAutomatic = automatic.kind === "available" && !recordUnreadable;
+  const active = hasAutomatic ? automatic.accountId ?? undefined : undefined;
   const routed = named ?? active;
   const missingRequested = classifySpawnAccountAdmission({
     enabled: false,
@@ -135,7 +140,7 @@ export async function resolveHealthySpawnAccount(
          account to fall back to either — so there is nothing left to launch on
          that this project's binding permits, and the original failure stands
          rather than being answered with an account outside the pool. */
-      if (active === undefined) throw error;
+      if (!hasAutomatic) throw error;
       return { ...contextForSpawn(engine, active), requestedAdmission: missingRequested };
     }
   }

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -148,9 +148,19 @@ export async function resolveHealthySpawnAccount(
      explicit choice above already decided that. Filtering it out here would
      make the health pass answer `requestedExists: false` and quietly launch on
      the automatic account instead, which is the substitution this seam refuses
-     to make in every other branch. */
-  const accounts = listClaudeAccounts().filter((account) =>
-    allowed === null || allowed.has(account.id) || account.id === named);
+     to make in every other branch.
+
+     ON AN UNREADABLE RECORD THE NAMED ACCOUNT IS THE ONLY CANDIDATE. `allowed`
+     is null there because no pool could be READ, not because none was drawn —
+     and handing that null to the filter would put every Claude account in front
+     of the health pass, so a named-but-inadmissible account degrades onto one
+     the machine picked with the fence unread. That is the same thing the Codex
+     branch's `hasAutomatic` guard above refuses, one branch over. The choice
+     still stands; there is simply nothing behind it to fall back to. */
+  const accounts = recordUnreadable
+    ? listClaudeAccounts().filter((account) => account.id === named)
+    : listClaudeAccounts().filter((account) =>
+      allowed === null || allowed.has(account.id) || account.id === named);
   const requestedExists = named === null || accounts.some((account) => account.id === named);
   try {
     const selected = await selectHealthyClaudeAccount(

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -6,7 +6,7 @@ import type { AccountContext, AccountManager, AccountSummary, ProjectSpawnResolu
 import { unavailableLimits } from "./contracts";
 import { withAccountMutationLockAsync } from "./accountMutation";
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
-import { accountProjectBindings, allowedAccountIdsForProject, projectAccountRefusalDetail } from "./projectBindings";
+import { AccountProjectBindingsUnreadableError, accountProjectBindings, allowedAccountIdsForProject, projectAccountRefusalDetail, type AccountProjectBinding } from "./projectBindings";
 import { selectProjectAccount } from "./projectSelection";
 import { selectHealthyClaudeAccount } from "./spawnHealth";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
@@ -43,9 +43,21 @@ export type HealthySpawnAccountResolution = AccountContext & {
  * damaged record throws from that read rather than being re-derived by whoever
  * called in.
  *
- * An account the caller NAMES is still checked against the pool alone and never
- * against capacity — nobody may quietly substitute an account somebody asked
- * for, and a pin is a decision, not a guess to improve on.
+ * An account the caller NAMES is an EXPLICIT CHOICE and the binding does not
+ * veto it (operator directive, 2026-09-10). Every producer of a named account
+ * at this seam is a control somebody worked: the board's launch draft, the
+ * orchestrator's create and rotate drafts, `spawn_agent`'s `accountId`. The
+ * binding is a default for what the Viewer picks BY ITSELF — that is what
+ * `explicitAccountChoice` has said since #1279, and the two switch seams have
+ * honoured it all along, while this one still refused. The refusal it produced
+ * was not theoretical: the rotate draft prefills the INCUMBENT's account, so a
+ * seat already running outside its project's pool could not be rotated at all.
+ *
+ * Nothing else is relaxed. Capacity is still not consulted for a named account
+ * and never was; authentication is still decided below by the engine's own
+ * health pass, which the named account now goes THROUGH rather than around; and
+ * the pick nobody named still draws from the pool only, still reports an
+ * exhausted pool, and still refuses on a record this process cannot read.
  */
 export async function resolveHealthySpawnAccount(
   engine: "claude" | "codex",
@@ -54,12 +66,26 @@ export async function resolveHealthySpawnAccount(
      cannot name, and resolves exactly as an unbound one always did. */
   project: string | null = null,
 ): Promise<HealthySpawnAccountResolution> {
-  const bindings = accountProjectBindings();
+  const named = requested === undefined || requested === null ? null : requested;
+  /* A DAMAGED record means two different things to this seam's two callers. To
+     the automatic pick it means "no pool can be seen", and nothing may be
+     picked — that refusal is the fence holding. To an explicit named choice it
+     means nothing at all: a file this process cannot parse is not a decision
+     anybody made, and it must not veto a control the operator exercised. Same
+     split as `explicitAccountChoice`, reached here rather than restated. */
+  let bindings: AccountProjectBinding[];
+  let recordUnreadable = false;
+  try {
+    bindings = accountProjectBindings();
+  } catch (error) {
+    if (named === null || !(error instanceof AccountProjectBindingsUnreadableError)) throw error;
+    bindings = [];
+    recordUnreadable = true;
+  }
   const allowedAccountIds = allowedAccountIdsForProject(project, engine, bindings);
   const allowed = allowedAccountIds === null ? null : new Set(allowedAccountIds);
   const registry = agentRegistry();
   const routing = registry.engineRouting(engine).activeAccountId ?? undefined;
-  const named = requested === undefined || requested === null ? null : requested;
   const selectionInput = {
     project,
     engine,
@@ -80,10 +106,18 @@ export async function resolveHealthySpawnAccount(
     throw new ProjectAccountRefusedError(automatic, engine, project);
   }
   if (named !== null) {
-    const pinned = selectProjectAccount({ ...selectionInput, requestedId: named });
+    const pinned = selectProjectAccount({ ...selectionInput, requestedId: named, requestedChoice: "explicit" });
+    /* `explicit` cannot answer `not_allowed`, so what is left here is a
+       malformed id — refused for what it is, in the one wording. */
     if (pinned.kind !== "available") throw new ProjectAccountRefusedError(pinned, engine, project);
   }
-  const active = automatic.kind === "available" ? automatic.accountId ?? undefined : undefined;
+  /* The automatic answer is also the FALLBACK the branches below reach for when
+     a named account turns out not to exist. On a record nobody could read there
+     is no such answer: the pool was invisible, so falling back would be the
+     machine picking with the fence unread. */
+  const active = automatic.kind === "available" && !recordUnreadable
+    ? automatic.accountId ?? undefined
+    : undefined;
   const routed = named ?? active;
   const missingRequested = classifySpawnAccountAdmission({
     enabled: false,
@@ -101,11 +135,17 @@ export async function resolveHealthySpawnAccount(
          account to fall back to either — so there is nothing left to launch on
          that this project's binding permits, and the original failure stands
          rather than being answered with an account outside the pool. */
-      if (automatic.kind !== "available") throw error;
+      if (active === undefined) throw error;
       return { ...contextForSpawn(engine, active), requestedAdmission: missingRequested };
     }
   }
-  const accounts = listClaudeAccounts().filter((account) => allowed === null || allowed.has(account.id));
+  /* The named account is a candidate whether or not the pool contains it — the
+     explicit choice above already decided that. Filtering it out here would
+     make the health pass answer `requestedExists: false` and quietly launch on
+     the automatic account instead, which is the substitution this seam refuses
+     to make in every other branch. */
+  const accounts = listClaudeAccounts().filter((account) =>
+    allowed === null || allowed.has(account.id) || account.id === named);
   const requestedExists = named === null || accounts.some((account) => account.id === named);
   try {
     const selected = await selectHealthyClaudeAccount(

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -74,13 +74,16 @@ export async function resolveHealthySpawnAccount(
      anybody made, and it must not veto a control the operator exercised. Same
      split as `explicitAccountChoice`, reached here rather than restated. */
   let bindings: AccountProjectBinding[];
-  let recordUnreadable = false;
+  /* The error itself, not a flag: the branches below that have nothing left to
+     fall back to answer WITH it, so an operator reading the refusal is told
+     which record to repair rather than which account to re-login. */
+  let recordUnreadable: AccountProjectBindingsUnreadableError | null = null;
   try {
     bindings = accountProjectBindings();
   } catch (error) {
     if (named === null || !(error instanceof AccountProjectBindingsUnreadableError)) throw error;
     bindings = [];
-    recordUnreadable = true;
+    recordUnreadable = error;
   }
   const allowedAccountIds = allowedAccountIdsForProject(project, engine, bindings);
   const allowed = allowedAccountIds === null ? null : new Set(allowedAccountIds);
@@ -121,7 +124,7 @@ export async function resolveHealthySpawnAccount(
      the fallback is the engine's own default and `contextForSpawn(undefined)`
      is how this seam has always resolved it. Reading a missing id as a missing
      ANSWER would turn that into a throw. */
-  const hasAutomatic = automatic.kind === "available" && !recordUnreadable;
+  const hasAutomatic = automatic.kind === "available" && recordUnreadable === null;
   const active = hasAutomatic ? automatic.accountId ?? undefined : undefined;
   const routed = named ?? active;
   const missingRequested = classifySpawnAccountAdmission({
@@ -162,6 +165,15 @@ export async function resolveHealthySpawnAccount(
     : listClaudeAccounts().filter((account) =>
       allowed === null || allowed.has(account.id) || account.id === named);
   const requestedExists = named === null || accounts.some((account) => account.id === named);
+  /* ...and with the record unreadable, a named account the machine does not
+     have leaves that set EMPTY. The health pass would then refuse with "no
+     healthy Claude account is available. Re-login…", which is a true sentence
+     about a state nobody is in: nothing was wrong with any account, the request
+     named one that is gone and the record that would say where else to look
+     could not be read. The Codex twin keeps its reason (`UnknownAccountError`
+     names the account), so this branch says the same thing rather than handing
+     the operator the wrong repair. */
+  if (recordUnreadable && !requestedExists) throw recordUnreadable;
   try {
     const selected = await selectHealthyClaudeAccount(
       accounts,

--- a/src/lib/accounts/managerProjectBinding.test.ts
+++ b/src/lib/accounts/managerProjectBinding.test.ts
@@ -395,6 +395,28 @@ test("a damaged record leaves a named CLAUDE account nowhere to degrade onto eit
   expect((refused as { accountIds?: string[] }).accountIds).not.toContain(claudeSpare);
 });
 
+test("a damaged record and a named account that is GONE answers about the record, not about logins", async () => {
+  /* The one corner where narrowing the candidate set could hand the operator
+     the wrong repair: with no pool readable and the named account deleted, the
+     set is empty and the health pass would refuse with "no healthy Claude
+     account is available. Re-login…" — a true sentence about a state nobody is
+     in. Both engines name the thing that is actually wrong. */
+  registryWith(spare, [], claudeSpare);
+  fs.mkdirSync(STATE, { recursive: true });
+  fs.writeFileSync(RECORD, '{"schemaVersion":1,"bindings":[{"engine":"codex"', "utf8");
+
+  const claude = await resolveHealthySpawnAccount("claude", "claude-account-that-was-deleted", ATLAS)
+    .then(() => null, (error: unknown) => error);
+  expect(claude).toBeInstanceOf(AccountProjectBindingsUnreadableError);
+  expect((claude as Error).message).toContain("account-project-bindings.json");
+  expect((claude as Error).message).not.toContain("Re-login");
+
+  /* Codex says it its own way, naming the account the request asked for. */
+  const codex = await resolveHealthySpawnAccount("codex", "codex-account-that-was-deleted", ATLAS)
+    .then(() => null, (error: unknown) => error);
+  expect((codex as Error).message).toContain("codex-account-that-was-deleted");
+});
+
 test("a damaged record leaves a named account that does NOT exist with nowhere to fall back to", async () => {
   /* The fallback below the named account is the AUTOMATIC pick, and on an
      unreadable record there isn't one. Falling back here would be the machine

--- a/src/lib/accounts/managerProjectBinding.test.ts
+++ b/src/lib/accounts/managerProjectBinding.test.ts
@@ -376,6 +376,25 @@ test("an unbound project with nothing routed keeps the engine-default fallback f
   expect(resolved.requestedAdmission).toBeDefined();
 });
 
+test("a damaged record leaves a named CLAUDE account nowhere to degrade onto either", async () => {
+  /* The Codex branch's guard has a Claude twin, and it is easy to miss: there,
+     "no pool" arrives as `allowed === null`, which is also how an UNBOUND
+     project reads — so the candidate set would quietly become every Claude
+     account, and a named-but-inadmissible one would degrade onto whichever the
+     health pass picked. The record was never read; nothing may be picked from
+     it. Both homes here carry an unusable credential, so the pass refuses
+     either way; what this asserts is which account it was ASKED about. */
+  registryWith(spare, [], claudeSpare);
+  fs.mkdirSync(STATE, { recursive: true });
+  fs.writeFileSync(RECORD, '{"schemaVersion":1,"bindings":[{"engine":"codex"', "utf8");
+
+  const refused = await resolveHealthySpawnAccount("claude", claudeReserved, ATLAS)
+    .then(() => null, (error: unknown) => error);
+  expect(refused).not.toBeNull();
+  expect((refused as { accountIds?: string[] }).accountIds).toEqual([claudeReserved]);
+  expect((refused as { accountIds?: string[] }).accountIds).not.toContain(claudeSpare);
+});
+
 test("a damaged record leaves a named account that does NOT exist with nowhere to fall back to", async () => {
   /* The fallback below the named account is the AUTOMATIC pick, and on an
      unreadable record there isn't one. Falling back here would be the machine

--- a/src/lib/accounts/managerProjectBinding.test.ts
+++ b/src/lib/accounts/managerProjectBinding.test.ts
@@ -358,6 +358,24 @@ test("a damaged binding record refuses the AUTOMATIC pick and stands out of an e
   expect((await resolveHealthySpawnAccount("codex", spare, ATLAS)).accountId).toBe(spare);
 });
 
+test("an unbound project with nothing routed keeps the engine-default fallback for a named account that is gone", async () => {
+  /* `available` with a NULL account id is a real answer, not a missing one: no
+     pool, no routing, and the fallback IS the engine's own default. Reading the
+     absent id as an absent ANSWER turns this into a throw — which is what the
+     record-unreadable guard beside it must not reach past. */
+  /* Its OWN registry file: the shared one carries routing written by the tests
+     above, and routing is exactly what must be absent here. */
+  const registry = new AgentRegistry(path.join(SANDBOX, "unrouted-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  setAgentRegistryForTests(registry);
+  expect(registry.engineRouting("codex").activeAccountId).toBeNull();
+  fs.rmSync(RECORD, { force: true });
+
+  const resolved = await resolveHealthySpawnAccount("codex", "codex-account-that-was-deleted", ATLAS);
+  expect(listCodexAccounts().some((account) => account.id === resolved.accountId)).toBe(true);
+  /* And it says so: the account the request named was not the one it got. */
+  expect(resolved.requestedAdmission).toBeDefined();
+});
+
 test("a damaged record leaves a named account that does NOT exist with nowhere to fall back to", async () => {
   /* The fallback below the named account is the AUTOMATIC pick, and on an
      unreadable record there isn't one. Falling back here would be the machine

--- a/src/lib/accounts/managerProjectBinding.test.ts
+++ b/src/lib/accounts/managerProjectBinding.test.ts
@@ -278,28 +278,97 @@ test("the direct launch's health pass considers the pool's accounts and no other
   expect((unbound as { accountIds?: string[] }).accountIds).toContain(claudeSpare);
 });
 
-test("a named account outside the pool is refused at the direct launch seam, and capacity never speaks for it (#1279)", async () => {
-  /* A launch that NAMES an account is checked against the pool alone: the
-     reserved account is allowed and exhausted, and naming it still resolves,
-     because nobody may quietly substitute an account somebody asked for. */
+/**
+ * THE RULE #1279 SHIPPED WITH, AND THE HALF OF IT THE OPERATOR OVERTURNED.
+ *
+ * As shipped, a launch that NAMED an account was checked against the pool and
+ * REFUSED when the pool did not contain it. That refusal is now gone, by
+ * explicit operator directive (2026-09-10): the binding is a default for what
+ * the Viewer picks BY ITSELF, and a control a person works is a capability. It
+ * is the rule `explicitAccountChoice` has stated in `projectBindings.ts` since
+ * #1279 — the two switch seams honoured it and the launch seam did not.
+ *
+ * Do not restore the refusal. What it actually produced in production: the
+ * orchestrator's rotate draft prefills the INCUMBENT's account, so a seat that
+ * was already running outside its project's pool could not be rotated at all,
+ * and the panel answered "the last designation failed" over a live incumbent.
+ *
+ * The other half stands and is asserted beside it in every test below: nothing
+ * the Viewer picks by itself may leave the pool.
+ */
+test("an explicitly named account outside the pool LAUNCHES at the direct seam, and capacity never speaks for it", async () => {
   registryWith(spare, [observation(reserved, 100), observation(spare, 5)]);
   bind(reserved);
 
+  /* In the pool and exhausted: naming it still resolves — nobody may quietly
+     substitute an account somebody asked for, which is unchanged. */
   expect((await resolveHealthySpawnAccount("codex", reserved, ATLAS)).accountId).toBe(reserved);
-
-  const refused = await resolveHealthySpawnAccount("codex", spare, ATLAS)
-    .then(() => null, (error: unknown) => error);
-  expect((refused as Error).name).toBe("ProjectAccountRefusedError");
-  expect((refused as Error).message).toContain(`account ${spare} is not allowed on project ${ATLAS}`);
+  /* Outside the pool: the choice is carried out, on the account named. */
+  expect((await resolveHealthySpawnAccount("codex", spare, ATLAS)).accountId).toBe(spare);
 });
 
-test("a damaged binding record refuses the direct launch seam before it resolves anything (#1279)", () => {
+test("the AUTOMATIC pick still refuses the very account an explicit choice may have", async () => {
+  /* The same account, the same project, the same record — the difference is
+     only whether anybody named it. Both readings in one test on purpose: an
+     explicit choice widening the automatic pick is the failure mode this
+     change could have introduced. */
+  registryWith(spare, [observation(reserved, 5), observation(spare, 5)]);
+  bind(reserved);
+
+  expect((await resolveHealthySpawnAccount("codex", spare, ATLAS)).accountId).toBe(spare);
+  /* Nothing named: the pool decides, and the spare account is not in it. */
+  expect((await resolveHealthySpawnAccount("codex", undefined, ATLAS)).accountId).toBe(reserved);
+  /* And a PREFERENCE for it — the shape every automatic caller passes — is
+     still ordering only, so it cannot reach outside the pool either. */
+  const headless = accountManager.resolveHeadlessSpawn("codex", spare, [], ATLAS);
+  expect(headless.kind === "available" && headless.account.accountId).toBe(reserved);
+  const owned = accountManager.resolveProjectSpawn("codex", { project: ATLAS, requestedId: spare });
+  expect(owned.kind).toBe("not_allowed");
+});
+
+test("an explicitly named Claude account outside the pool goes THROUGH the health pass, not around it", async () => {
+  /* The named account must not be filtered out of the candidate set: filtered,
+     the pass reports "the request named nobody I have" and silently launches on
+     the automatic account instead — the substitution this seam refuses to make
+     everywhere else. Neither Claude home here carries a usable credential, so
+     the pass refuses BOTH; what this asserts is which account it was asked
+     about, read out of its own message. */
+  registryWith(spare, [], claudeReserved);
+  bind(claudeReserved, ATLAS, "claude");
+
+  const refused = await resolveHealthySpawnAccount("claude", claudeSpare, ATLAS)
+    .then(() => null, (error: unknown) => error);
+  expect(refused).not.toBeNull();
+  /* The failure is the health pass's own — an unauthenticated account is still
+     an unauthenticated account — and it names the account that was CHOSEN. */
+  expect((refused as Error).name).not.toBe("ProjectAccountRefusedError");
+  expect((refused as { accountIds?: string[] }).accountIds).toContain(claudeSpare);
+});
+
+test("a damaged binding record refuses the AUTOMATIC pick and stands out of an explicit choice's way", async () => {
   registryWith(spare, []);
   fs.mkdirSync(STATE, { recursive: true });
   fs.writeFileSync(RECORD, '{"schemaVersion":1,"bindings":[{"engine":"codex"', "utf8");
 
+  /* Nothing named: no pool can be seen, so nothing may be picked. */
   expect(resolveHealthySpawnAccount("codex", undefined, ATLAS))
     .rejects.toThrow(AccountProjectBindingsUnreadableError);
+  /* Named: a file this process cannot parse is not a decision anybody made,
+     and it does not get to veto a control the operator worked. */
+  expect((await resolveHealthySpawnAccount("codex", spare, ATLAS)).accountId).toBe(spare);
+});
+
+test("a damaged record leaves a named account that does NOT exist with nowhere to fall back to", async () => {
+  /* The fallback below the named account is the AUTOMATIC pick, and on an
+     unreadable record there isn't one. Falling back here would be the machine
+     selecting with the fence unread — the exact inversion the refusal above
+     exists to prevent, arrived at through the explicit path. */
+  registryWith(spare, []);
+  fs.mkdirSync(STATE, { recursive: true });
+  fs.writeFileSync(RECORD, '{"schemaVersion":1,"bindings":[{"engine":"codex"', "utf8");
+
+  expect(resolveHealthySpawnAccount("codex", "codex-account-that-was-deleted", ATLAS))
+    .rejects.toThrow();
 });
 
 /**

--- a/src/lib/accounts/projectSelection.ts
+++ b/src/lib/accounts/projectSelection.ts
@@ -83,13 +83,29 @@ import {
  *
  * A new automatic seam belongs on this list and behind one of the two functions
  * below. A new one that reads the pool itself is the defect coming back.
+ *
+ * WHAT THIS LIST IS ABOUT, restated because half of (1) and (2) stopped being
+ * on it (operator directive, 2026-09-10): it is the inventory of places that
+ * choose an account WITHOUT BEING TOLD WHICH. A launch that NAMES one is not
+ * one of them. It is a control somebody worked — the launch draft's picker, the
+ * orchestrator's rotate draft, `spawn_agent`'s `accountId` — and the binding is
+ * a default for the machine's own picks, never a veto on a person's. Such a
+ * choice passes `requestedChoice: "explicit"` to `selectProjectAccount`, which
+ * carries it out and reports the pool it crossed so the launch seam can
+ * attribute it (`accountOverrides.ts`). Everything on the list above is
+ * unchanged and still draws from the pool only.
  */
 
 /** What #1279's rule decides for one launch, before any home or env is resolved. */
 export type ProjectAccountSelection =
   /** `accountId: null` means nothing constrained or preferred the choice, so the
-      engine's own default account stands. */
-  | { kind: "available"; accountId: string | null }
+      engine's own default account stands.
+
+      `outsidePool` is present only for an EXPLICIT named choice the project's
+      pool does not contain: the choice stands (see `requestedChoice`) and the
+      pool as it read at that moment rides along, so the caller can attribute
+      the crossing rather than leave it invisible. */
+  | { kind: "available"; accountId: string | null; outsidePool?: string[] }
   | { kind: "not_allowed"; accountId: string; allowedAccountIds: string[] }
   | { kind: "exhausted"; resetsAt: number | null; allowedAccountIds: string[] }
   | { kind: "unavailable"; allowedAccountIds: string[] };
@@ -102,6 +118,29 @@ export interface ProjectAccountSelectionInput {
   bindings: readonly AccountProjectBinding[];
   /** The account the launch named, if it named one. */
   requestedId?: string | null;
+  /**
+   * WHAT `requestedId` IS, and the reason the binding does not veto every one
+   * of them (operator directive, 2026-09-10).
+   *
+   * - `fenced` (the default, and every pre-existing caller) — an id a caller
+   *   FORWARDED: a pipeline stage's recorded `account`, a round's own account.
+   *   Nobody exercised a control here, so the pool is still the fence and an id
+   *   outside it is refused rather than quietly substituted.
+   * - `explicit` — a DELIBERATE named choice made through a control: the launch
+   *   draft's account picker, the rotate draft's, `spawn_agent`'s `accountId`.
+   *   The binding is a default for what the Viewer picks BY ITSELF, never a veto
+   *   on what a person asks for, so this choice is carried out and ATTRIBUTED
+   *   (`outsidePool` on the answer) instead of refused. It is the same rule
+   *   `explicitAccountChoice` already states for the two switch seams; the
+   *   launch seams simply never reached it, and the orchestrator's rotate draft
+   *   — which prefills the INCUMBENT's account — could not rotate a seat that
+   *   was already running outside the pool.
+   *
+   * Nothing else is relaxed. Capacity is not consulted for a named account and
+   * never was; authentication is decided further in, by the engine's own health
+   * pass; and an id nobody named still draws from the pool only.
+   */
+  requestedChoice?: "explicit" | "fenced";
   /** The engine's current routing choice, used only to order candidates. */
   preferredId?: string | null;
   excludedIds?: readonly string[];
@@ -127,9 +166,11 @@ export interface ProjectAccountSelectionInput {
  *
  * - **Unbound project** — `allowedAccountIdsForProject` answers null, and the
  *   caller's own historical strategy decides, untouched.
- * - **Bound project, an account named** — allowed, or refused. It is never
- *   downgraded to a different account: a pin the project forbids is a mistake
- *   worth reporting, not a preference worth working around.
+ * - **Bound project, an account named** — allowed, or decided by
+ *   `requestedChoice`: a FORWARDED id outside the pool is refused, an EXPLICIT
+ *   choice outside it is carried out and reported as such. Neither is ever
+ *   downgraded to a different account: nobody may quietly substitute an account
+ *   a caller actually named.
  * - **Bound project, nothing named** — the candidates ARE the allowed set. Every
  *   one of them out of capacity reports `exhausted`; the idle account next door
  *   is not a candidate and is not consulted, which is the whole point.
@@ -138,6 +179,11 @@ export function selectProjectAccount(input: ProjectAccountSelectionInput): Proje
   const allowed = allowedAccountIdsForProject(input.project, input.engine, input.bindings);
   const requestedId = input.requestedId?.trim() || null;
   if (requestedId && allowed !== null && !allowed.includes(requestedId)) {
+    /* A control someone exercised is a capability, not a request the record
+       gets to veto — so it resolves, and carries the pool it crossed. */
+    if (input.requestedChoice === "explicit") {
+      return { kind: "available", accountId: requestedId, outsidePool: allowed };
+    }
     return { kind: "not_allowed", accountId: requestedId, allowedAccountIds: allowed };
   }
   if (requestedId) return { kind: "available", accountId: requestedId };

--- a/src/lib/accounts/projectSelection.ts
+++ b/src/lib/accounts/projectSelection.ts
@@ -91,21 +91,16 @@ import {
  * orchestrator's rotate draft, `spawn_agent`'s `accountId` — and the binding is
  * a default for the machine's own picks, never a veto on a person's. Such a
  * choice passes `requestedChoice: "explicit"` to `selectProjectAccount`, which
- * carries it out and reports the pool it crossed so the launch seam can
- * attribute it (`accountOverrides.ts`). Everything on the list above is
- * unchanged and still draws from the pool only.
+ * carries it out; the launch seam attributes the crossing against the record
+ * itself (`accountOverrides.ts`). Everything on the list above is unchanged and
+ * still draws from the pool only.
  */
 
 /** What #1279's rule decides for one launch, before any home or env is resolved. */
 export type ProjectAccountSelection =
   /** `accountId: null` means nothing constrained or preferred the choice, so the
-      engine's own default account stands.
-
-      `outsidePool` is present only for an EXPLICIT named choice the project's
-      pool does not contain: the choice stands (see `requestedChoice`) and the
-      pool as it read at that moment rides along, so the caller can attribute
-      the crossing rather than leave it invisible. */
-  | { kind: "available"; accountId: string | null; outsidePool?: string[] }
+      engine's own default account stands. */
+  | { kind: "available"; accountId: string | null }
   | { kind: "not_allowed"; accountId: string; allowedAccountIds: string[] }
   | { kind: "exhausted"; resetsAt: number | null; allowedAccountIds: string[] }
   | { kind: "unavailable"; allowedAccountIds: string[] };
@@ -180,10 +175,12 @@ export function selectProjectAccount(input: ProjectAccountSelectionInput): Proje
   const requestedId = input.requestedId?.trim() || null;
   if (requestedId && allowed !== null && !allowed.includes(requestedId)) {
     /* A control someone exercised is a capability, not a request the record
-       gets to veto — so it resolves, and carries the pool it crossed. */
-    if (input.requestedChoice === "explicit") {
-      return { kind: "available", accountId: requestedId, outsidePool: allowed };
-    }
+       gets to veto, so it resolves. The crossing is NOT reported back through
+       here: `attributeNamedAccountChoice` classifies it against the record at
+       the moment the launch is admitted, and that is one classifier for every
+       explicit seam — a second copy riding on this return value would be a
+       second place for the two to disagree. */
+    if (input.requestedChoice === "explicit") return { kind: "available", accountId: requestedId };
     return { kind: "not_allowed", accountId: requestedId, allowedAccountIds: allowed };
   }
   if (requestedId) return { kind: "available", accountId: requestedId };

--- a/src/lib/accounts/projectSelection.ts
+++ b/src/lib/accounts/projectSelection.ts
@@ -84,16 +84,24 @@ import {
  * A new automatic seam belongs on this list and behind one of the two functions
  * below. A new one that reads the pool itself is the defect coming back.
  *
- * WHAT THIS LIST IS ABOUT, restated because half of (1) and (2) stopped being
- * on it (operator directive, 2026-09-10): it is the inventory of places that
- * choose an account WITHOUT BEING TOLD WHICH. A launch that NAMES one is not
- * one of them. It is a control somebody worked — the launch draft's picker, the
+ * WHAT THIS LIST IS ABOUT, restated because (1)'s NAMED branch stopped being on
+ * it (operator directive, 2026-09-10): it is the inventory of places that choose
+ * an account WITHOUT BEING TOLD WHICH. A launch that NAMES one is not one of
+ * them. It is a control somebody worked — the launch draft's picker, the
  * orchestrator's rotate draft, `spawn_agent`'s `accountId` — and the binding is
  * a default for the machine's own picks, never a veto on a person's. Such a
  * choice passes `requestedChoice: "explicit"` to `selectProjectAccount`, which
  * carries it out; the launch seam attributes the crossing against the record
- * itself (`accountOverrides.ts`). Everything on the list above is unchanged and
- * still draws from the pool only.
+ * itself (`accountOverrides.ts`).
+ *
+ * ONE branch, and the scope is worth being exact about: only
+ * `resolveHealthySpawnAccount` passes `explicit`, and only when the request
+ * named an account. Its own automatic pick is unchanged, and so is every other
+ * entry above — (2) `resolveProjectSpawn` in particular, where a task launch, a
+ * pipeline stage, a workflow stage or the flow's pane reviewer passes a
+ * `requestedId` it FORWARDED rather than one anybody chose here. That id is
+ * still refused outside the pool (`managerProjectBinding.test.ts` asserts it),
+ * because nobody worked a control to produce it.
  */
 
 /** What #1279's rule decides for one launch, before any home or env is resolved. */

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -834,8 +834,8 @@ export async function executeSpawnRequest(
        retried, an existing attempt resumed — is the same launch arriving twice,
        not a second choice, and the journal is capped: duplicates evict the
        older crossings it exists to keep. */
-    if (begun.kind === "created" && requestedAccountId && account.accountId === requestedAccountId) {
-      attributeNamedAccountChoice({
+    const accountOverride = begun.kind === "created" && requestedAccountId && account.accountId === requestedAccountId
+      ? attributeNamedAccountChoice({
         engine,
         project: spawnProject,
         accountId: requestedAccountId,
@@ -844,8 +844,18 @@ export async function executeSpawnRequest(
           ? { kind: "agent", conversationId: authenticatedCaller.conversationId }
           : { kind: "operator" },
         via: "launch",
-      });
-    }
+      }) ?? undefined
+      : undefined;
+    /* THE NOTICE RIDES THE ANSWER, as it does at the two switch seams
+       (`delivery.ts`, `structuredControls.ts`). It is the contract
+       `attributeNamedAccountChoice` states: a journal that would not take the
+       record answers `recorded: false` with the reason, and the caller's answer
+       carries it to whoever made the choice. That matters more here than there
+       — this journal is now the ONLY thing that makes an out-of-pool launch
+       visible, so a state directory that cannot be written to would otherwise
+       let the crossing happen behind a perfectly ordinary spawn response. */
+    const withAccountOverride = (body: SpawnResponse): SpawnResponse =>
+      (accountOverride ? { ...body, accountOverride } : body);
     let queuedReceipt = begun.receipt;
     if (queuedUntil && queuedTitle && requestedAccountId) {
       const existingQueue = begun.receipt.queuedPinnedSpawn;
@@ -1024,10 +1034,10 @@ export async function executeSpawnRequest(
         && identityMaterializationFence(registry.readOnlySnapshot()).allowsReceipt(receipt, { structured })) {
         await adoptMaterializedAttempt(receipt, receipt.artifactPath);
       }
-      const response = spawnResponseForReceipt(receipt, receipt.artifactPath, {
+      const response = withAccountOverride(spawnResponseForReceipt(receipt, receipt.artifactPath, {
         structured,
         initialMessage: queuedUntil ? "queued" : initialMessage,
-      });
+      }));
       return NextResponse.json(response, { status: spawnReplayStatus(response, structured) });
     }
     if (queuedUntil) {
@@ -1036,10 +1046,10 @@ export async function executeSpawnRequest(
         ? registry.releaseSpawnActuation(queuedReceipt.launchId, queuedReceipt.admissionOwner).receipt
         : queuedReceipt;
       return NextResponse.json(
-        spawnResponseForReceipt(releasedQueuedReceipt, releasedQueuedReceipt.artifactPath, {
+        withAccountOverride(spawnResponseForReceipt(releasedQueuedReceipt, releasedQueuedReceipt.artifactPath, {
           structured: transport === "structured",
           initialMessage: "queued",
-        }),
+        })),
         { status: 202 },
       );
     }
@@ -1052,9 +1062,9 @@ export async function executeSpawnRequest(
       catch (error) { throw new RuntimeImageStorageError(error instanceof Error ? error.message : String(error)); }
       deferStructuredSpawn(begun.receipt, runtimeClient, imageRefs);
       return NextResponse.json(
-        spawnResponseForReceipt(begun.receipt, begun.receipt.artifactPath, {
+        withAccountOverride(spawnResponseForReceipt(begun.receipt, begun.receipt.artifactPath, {
           structured: true,
-        }),
+        })),
         { status: 202 },
       );
     }
@@ -1094,11 +1104,11 @@ export async function executeSpawnRequest(
     if (!pane.host || !await verifyTmuxHostEvidence(pane.host)) {
       agentRegistry().invalidateSpawnHost(begun.receipt.launchId, "spawn host disappeared before API confirmation");
       const lost = agentRegistry().readOnlySnapshot().receipts[begun.receipt.launchId]!;
-      return NextResponse.json(spawnResponseForReceipt(lost, childPath));
+      return NextResponse.json(withAccountOverride(spawnResponseForReceipt(lost, childPath)));
     }
     if (!childPath || !key || !pane.receipt) {
       const pending = agentRegistry().markSpawnPathPending(begun.receipt.launchId);
-      return NextResponse.json(spawnResponseForReceipt(pending, null));
+      return NextResponse.json(withAccountOverride(spawnResponseForReceipt(pending, null)));
     }
     const settled = agentRegistry().settleSpawn(pane.receipt.launchId, {
       key,
@@ -1111,7 +1121,7 @@ export async function executeSpawnRequest(
       claimOwner: null,
       pendingAction: "spawn",
     });
-    if (settled.kind === "conflict") return NextResponse.json(spawnResponseForReceipt(settled.receipt));
+    if (settled.kind === "conflict") return NextResponse.json(withAccountOverride(spawnResponseForReceipt(settled.receipt)));
     recordActualLaunchAccount(settled.receipt, account.accountId, childPath);
     await adoptMaterializedAttempt(settled.receipt, childPath);
     if (runtimeClient && operationId) {
@@ -1138,9 +1148,9 @@ export async function executeSpawnRequest(
     if (!await verifyTmuxHostEvidence(pane.host)) {
       agentRegistry().invalidateSpawnHost(begun.receipt.launchId, "spawn host disappeared before API response");
       const lost = agentRegistry().readOnlySnapshot().receipts[begun.receipt.launchId]!;
-      return NextResponse.json(spawnResponseForReceipt(lost, childPath));
+      return NextResponse.json(withAccountOverride(spawnResponseForReceipt(lost, childPath)));
     }
-    return NextResponse.json(spawnResponseForReceipt(settled.receipt, childPath));
+    return NextResponse.json(withAccountOverride(spawnResponseForReceipt(settled.receipt, childPath)));
   } catch (error) {
     const receipt = launchId ? registry.readOnlySnapshot().receipts[launchId] : null;
     if (!receipt || receipt.pane === null) {

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -60,6 +60,7 @@ import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorAct
 import { sourceCwdStatus } from "@/app/api/spawn/sourceCwd";
 import { AGENT_SPAWN_LINEAGE_ERROR, agentSpawnLineageError, authenticatedAgentSpawnCaller, isAgentInitiatedSpawn, spawnLineageSelectorForCaller, type AuthenticatedSpawnCaller } from "@/app/api/spawn/admission";
 import { spawnAccountErrorResponse } from "@/app/api/spawn/accountError";
+import { attributeNamedAccountChoice } from "@/lib/accounts/accountOverrides";
 
 const SUGGEST_SCAN_LIMIT = 80;
 const SUGGEST_MAX = 10;
@@ -819,6 +820,27 @@ export async function executeSpawnRequest(
     });
     if (begun.kind === "conflict") return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
     if (begun.kind === "created") launchId = begun.receipt.launchId;
+    /* ATTRIBUTION, not a gate (#1279's rule, launch seam). The binding no
+       longer refuses a launch that NAMES an account outside the project's pool,
+       so the crossing has to be visible instead — the project view renders this
+       journal beside the pool, and an account carrying work it is not bound to
+       must read as a decision somebody made rather than as a fence that quietly
+       stopped holding. Recorded once the receipt exists, because that is the
+       point past which this account is what the work runs on, and only for the
+       account the request actually named: a degraded pin landed on a different
+       account and nobody chose that one. Within the pool it records nothing. */
+    if (requestedAccountId && account.accountId === requestedAccountId) {
+      attributeNamedAccountChoice({
+        engine,
+        project: spawnProject,
+        accountId: requestedAccountId,
+        conversationId: begun.receipt.conversationId ?? null,
+        actor: authenticatedCaller?.kind === "agent"
+          ? { kind: "agent", conversationId: authenticatedCaller.conversationId }
+          : { kind: "operator" },
+        via: "launch",
+      });
+    }
     let queuedReceipt = begun.receipt;
     if (queuedUntil && queuedTitle && requestedAccountId) {
       const existingQueue = begun.receipt.queuedPinnedSpawn;

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -828,8 +828,13 @@ export async function executeSpawnRequest(
        stopped holding. Recorded once the receipt exists, because that is the
        point past which this account is what the work runs on, and only for the
        account the request actually named: a degraded pin landed on a different
-       account and nobody chose that one. Within the pool it records nothing. */
-    if (requestedAccountId && account.accountId === requestedAccountId) {
+       account and nobody chose that one. Within the pool it records nothing.
+
+       `created` ONLY. A replay of the same `clientAttemptId` — a lost response
+       retried, an existing attempt resumed — is the same launch arriving twice,
+       not a second choice, and the journal is capped: duplicates evict the
+       older crossings it exists to keep. */
+    if (begun.kind === "created" && requestedAccountId && account.accountId === requestedAccountId) {
       attributeNamedAccountChoice({
         engine,
         project: spawnProject,

--- a/src/lib/agent/spawnResponse.ts
+++ b/src/lib/agent/spawnResponse.ts
@@ -1,3 +1,4 @@
+import type { AccountOverrideNotice } from "@/lib/accounts/accountOverrides";
 import { identityMaterializationFence, type SpawnReceipt } from "@/lib/agent/registry";
 import type { SpawnAdmissionError, SpawnRejection, SpawnRejectionCode } from "@/lib/agent/spawnAdmission";
 
@@ -43,6 +44,12 @@ export interface SpawnResponse {
       durable ids, without waiting for the transcript scan (issue #919). Every
       live builder emits it; absence (legacy fixtures) reads as not structured. */
   transport?: "structured" | "tmux";
+  /** Present only when this launch NAMED an account outside the project's pool
+      (#1279's launch seam). The binding does not veto an explicit choice, so
+      the record is what makes the crossing visible — and a record the journal
+      would not take answers `recorded: false` with its reason, which has to
+      reach whoever made the choice rather than stop at a server log. */
+  accountOverride?: AccountOverrideNotice;
   error?: string;
 }
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -2002,6 +2002,7 @@ export const en = {
   "orchPanel.rotationDead": "its host is gone",
   "orchPanel.badgeNeedsYou": "needs you",
   "orchPanel.badgeLive": "live",
+  "orchPanel.badgeWaiting": "waiting",
   "orchPanel.badgeStalled": "quiet",
   "orchPanel.badgeResumable": "finished",
   "orchPanel.badgeDead": "host gone",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1947,6 +1947,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "orchPanel.rotationDead": "його хост зник",
   "orchPanel.badgeNeedsYou": "потребує тебе",
   "orchPanel.badgeLive": "живий",
+  "orchPanel.badgeWaiting": "чекає",
   "orchPanel.badgeStalled": "тиша",
   "orchPanel.badgeResumable": "завершив",
   "orchPanel.badgeDead": "хост зник",

--- a/src/lib/orchestrator/rotationAccountChoice.test.ts
+++ b/src/lib/orchestrator/rotationAccountChoice.test.ts
@@ -306,11 +306,18 @@ test("a refused rotation leaves the incumbent seated and the refusal readable, w
   expect(seat.pending?.conversationId).toBeNull();
 });
 
-test("a rotation onto an unbound account is ATTRIBUTED, so the crossing is visible rather than silent", async () => {
-  /* The binding stops being a veto here, so it has to become a record: the
-     project view renders this journal beside the pool. Written by the launch
-     seam itself — `/api/spawn` — so this asserts the journal that seam appends
-     to, from the same explicit choice, with the record and the pool it read. */
+test("the crossing this rotation makes classifies as outside-pool against the real record", async () => {
+  /* WHAT THIS DOES AND DOES NOT DRIVE. The journal is appended by the launch
+     seam — `/api/spawn`, inside `executeSpawnRequest` — and this file's `spawn`
+     dependency stands in for that route, so the production call site is NOT on
+     this path and would not be missed here. `route.binding.test.ts` covers it,
+     and covers the in-pool case recording nothing.
+
+     What only this fixture has is the incident's own SHAPE: a seat rotating
+     onto an account this project's real binding record does not list. So what
+     is asserted is the classification that call site produces from it — the
+     reason, and the pool as it read at that moment — rather than the fact that
+     a rotation wrote a row. */
   seatIncumbent();
   dependencies();
   const { attributeNamedAccountChoice } = await import("@/lib/accounts/accountOverrides");

--- a/src/lib/orchestrator/rotationAccountChoice.test.ts
+++ b/src/lib/orchestrator/rotationAccountChoice.test.ts
@@ -1,0 +1,339 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { NextRequest } from "next/server";
+
+/**
+ * THE ROTATION THE BINDING REFUSED (operator report, 2026-09-10).
+ *
+ * The seat for this repository's project was running on a Codex account the
+ * project's binding does not list. The operator opened the rotate draft — which
+ * PREFILLS the incumbent's account — pressed Confirm, and the panel answered
+ *
+ *   codex account <account> is not allowed on project <project>
+ *   (allowed codex accounts: …)
+ *
+ * over a live incumbent, with the durable pending intent carrying that error.
+ * The seat could not be rotated at all: every account the draft offered by
+ * default was the one the fence refused, and the operator's own explicit choice
+ * of any other unbound account was refused on the same grounds.
+ *
+ * The directive that settles it: a manually selected authenticated account is
+ * usable for rotation and launch whatever the project's automatic-account
+ * binding says. ONLY autonomous selection and fallback stay inside the pool.
+ *
+ * WHAT THIS FILE DRIVES, and what it does not:
+ *
+ *  - The real `POST /api/orchestrator/rotate` route module, over a loopback
+ *    listener, so the rotate draft's own body shape is what travels.
+ *  - The real seat command behind it: the durable intent, the handoff
+ *    composition, the activation, the pending intent's error field.
+ *  - The real account decision, `resolveHealthySpawnAccount`, reading a real
+ *    binding record from a private state directory.
+ *
+ * The one seam standing in for production is `/api/spawn` itself: the seat
+ * command's `spawn` dependency here resolves the account exactly as that route
+ * does — same function, same arguments, same 409-with-message on a refusal —
+ * and then reports an accepted launch instead of starting a process. Its
+ * fidelity is the argument tuple, and that tuple is asserted below.
+ *
+ * Account and project names are invented; every path is inside the sandbox.
+ */
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-rotation-account-choice-"));
+const STATE = path.join(SANDBOX, "state");
+const RECORD = path.join(STATE, "account-project-bindings.json");
+const OVERRIDES = path.join(STATE, "account-project-overrides.json");
+const PROJECT = "project-atlas";
+const AT = "2026-09-10T00:00:00.000Z";
+const INCUMBENT_ID = "conversation_44444444-4444-4444-8444-444444444444";
+const SUCCESSOR_ID = "conversation_55555555-5555-4555-8555-555555555555";
+
+const PREVIOUS = {
+  state: process.env.LLV_STATE_DIR,
+  codexHome: process.env.LLV_CODEX_HOME,
+  claudeHome: process.env.LLV_CLAUDE_HOME,
+  home: process.env.HOME,
+  xdgConfig: process.env.XDG_CONFIG_HOME,
+  xdgCache: process.env.XDG_CACHE_HOME,
+  tmp: process.env.TMPDIR,
+};
+
+/* Every root this test could otherwise reach into, pointed at the sandbox
+   BEFORE the modules under test are imported: the Viewer's state, both provider
+   homes, the operator's home and XDG roots, and the temp dir. Nothing here
+   reads or writes anything the running Viewer owns. */
+fs.mkdirSync(path.join(SANDBOX, "home"), { recursive: true });
+fs.mkdirSync(path.join(SANDBOX, "tmp"), { recursive: true });
+process.env.LLV_STATE_DIR = STATE;
+process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy-codex");
+process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
+process.env.HOME = path.join(SANDBOX, "home");
+process.env.XDG_CONFIG_HOME = path.join(SANDBOX, "home", ".config");
+process.env.XDG_CACHE_HOME = path.join(SANDBOX, "home", ".cache");
+process.env.TMPDIR = path.join(SANDBOX, "tmp");
+
+const { POST: rotateRoute } = await import("@/app/api/orchestrator/rotate/route");
+const { createManagedCodexAccount } = await import("@/lib/accounts/codex");
+const { ProjectAccountRefusedError, resolveHealthySpawnAccount } = await import("@/lib/accounts/manager");
+const { accountProjectOverrides } = await import("@/lib/accounts/accountOverrides");
+const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
+const { resetProjectAliasesForTests } = await import("@/lib/projects/aliases");
+import type { SeatCommandDependencies } from "./seatCommand";
+
+const { setSeatCommandDependenciesForTests } = await import("./seatCommand");
+const {
+  beginOrchestratorSeatIntent,
+  completeOrchestratorSeatIntent,
+  orchestratorSeatFor,
+} = await import("./seats");
+
+let listener: ReturnType<typeof Bun.serve> | null = null;
+let origin = "";
+/** Bound to the project; the pool. */
+let bound = "";
+/** Authenticated, and deliberately NOT bound to the project. */
+let unbound = "";
+
+beforeAll(() => {
+  listener = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname !== "/api/orchestrator/rotate" || request.method !== "POST") {
+        return Response.json({ error: `no route for ${request.method} ${url.pathname}` }, { status: 404 });
+      }
+      const answer = await rotateRoute(new NextRequest(url, {
+        method: "POST",
+        headers: request.headers,
+        body: await request.text(),
+      }));
+      return new Response(await answer.text(), {
+        status: answer.status,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  origin = `http://127.0.0.1:${listener.port}`;
+});
+
+afterAll(() => {
+  listener?.stop(true);
+  listener = null;
+  setAgentRegistryForTests(null);
+  setSeatCommandDependenciesForTests(null);
+  for (const [key, value] of [
+    ["LLV_STATE_DIR", PREVIOUS.state],
+    ["LLV_CODEX_HOME", PREVIOUS.codexHome],
+    ["LLV_CLAUDE_HOME", PREVIOUS.claudeHome],
+    ["HOME", PREVIOUS.home],
+    ["XDG_CONFIG_HOME", PREVIOUS.xdgConfig],
+    ["XDG_CACHE_HOME", PREVIOUS.xdgCache],
+    ["TMPDIR", PREVIOUS.tmp],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  fs.rmSync(STATE, { recursive: true, force: true });
+  fs.rmSync(path.join(SANDBOX, "accounts"), { recursive: true, force: true });
+  resetProjectAliasesForTests();
+  const created = new Map<string, string>();
+  for (const label of ["Bound carrier", "Unbound carrier"]) {
+    const account = createManagedCodexAccount(label);
+    /* Authenticated: the directive covers an authenticated account, and an
+       account with no credential is a different refusal that still stands. */
+    fs.writeFileSync(path.join(account.home, "auth.json"), "{}", { mode: 0o600 });
+    created.set(label, account.id);
+  }
+  bound = created.get("Bound carrier")!;
+  unbound = created.get("Unbound carrier")!;
+  const registry = new AgentRegistry(path.join(SANDBOX, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  /* The engine is routed at the BOUND account, so nothing below can pass by
+     accident: an automatic pick and the pool agree, and only an explicit choice
+     can reach the unbound account. */
+  registry.setEngineRouting("codex", bound);
+  setAgentRegistryForTests(registry);
+  fs.mkdirSync(STATE, { recursive: true });
+  fs.writeFileSync(RECORD, JSON.stringify({
+    schemaVersion: 1,
+    bindings: [{ engine: "codex", accountId: bound, project: PROJECT, createdAt: AT }],
+  }), "utf8");
+});
+
+afterEach(() => {
+  setSeatCommandDependenciesForTests(null);
+});
+
+/** The incumbent, seated exactly as production's was: designated, active, and
+    — the condition that made this unrecoverable — running on an account the
+    project's binding does not list. */
+function seatIncumbent(): void {
+  beginOrchestratorSeatIntent({
+    project: PROJECT,
+    mandate: "own the board",
+    clientRequestId: "seed_atlas_0001",
+    mode: "spawn",
+    engine: "codex",
+    model: "gpt-6-astra",
+    now: AT,
+  });
+  completeOrchestratorSeatIntent({
+    project: PROJECT,
+    clientRequestId: "seed_atlas_0001",
+    conversationId: INCUMBENT_ID,
+    path: path.join(SANDBOX, "incumbent.jsonl"),
+    now: AT,
+  });
+}
+
+interface SpawnAsk {
+  accountId: unknown;
+  project: unknown;
+  engine: unknown;
+}
+
+/** `/api/spawn`'s account decision, and nothing else it does. */
+function dependencies(): { asks: SpawnAsk[]; resolved: string[] } {
+  const asks: SpawnAsk[] = [];
+  const resolved: string[] = [];
+  const deps: SeatCommandDependencies = {
+    spawn: async (body) => {
+      asks.push({ accountId: body.accountId, project: body.project, engine: body.engine });
+      try {
+        const account = await resolveHealthySpawnAccount(
+          body.engine as "claude" | "codex",
+          body.accountId as string | undefined,
+          (body.project as string | null) ?? null,
+        );
+        resolved.push(account.accountId);
+        return { status: 200, body: { ok: true, conversationId: SUCCESSOR_ID, path: path.join(SANDBOX, "successor.jsonl") } };
+      } catch (error) {
+        /* The route answers a boundary as a conflict carrying the refusal's
+           own wording; the seat command records that wording on the intent. */
+        const status = error instanceof ProjectAccountRefusedError ? 409 : 500;
+        return { status, body: { ok: false, error: error instanceof Error ? error.message : String(error) } };
+      }
+    },
+    deliver: async () => ({ ok: true, outcome: "delivered" }),
+    conversationTarget: (conversationId) => ({
+      kind: "eligible",
+      conversationId,
+      path: path.join(SANDBOX, "incumbent.jsonl"),
+      cwd: path.join(SANDBOX, "checkout"),
+      project: PROJECT,
+      engine: "codex",
+    }),
+    projectTasks: () => [],
+    summarizeHandoffs: async () => ({ kind: "fallback", reason: "unavailable" }),
+    launchSettlement: () => ({ kind: "unknown" }),
+    stampRegistryIdentity: () => {},
+    runtimeIdentity: () => ({ engine: "codex", model: "gpt-6-astra" }),
+    now: () => AT,
+  };
+  setSeatCommandDependenciesForTests(deps);
+  return { asks, resolved };
+}
+
+async function rotate(body: Record<string, unknown>): Promise<{ status: number; body: Record<string, unknown> }> {
+  const response = await fetch(new URL("/api/orchestrator/rotate", origin), {
+    method: "POST",
+    headers: { "content-type": "application/json", origin },
+    body: JSON.stringify({ project: PROJECT, ...body }),
+  });
+  return { status: response.status, body: await response.json() as Record<string, unknown> };
+}
+
+test("REGRESSION: the operator rotates the seat onto an authenticated account the project's binding does not list", async () => {
+  seatIncumbent();
+  const { asks, resolved } = dependencies();
+
+  const answer = await rotate({ clientRequestId: "rotate-onto-unbound-1", accountId: unbound });
+
+  /* The refusal that shipped answered 409 here and wrote its message onto the
+     pending intent, which is what the panel rendered over the live incumbent. */
+  expect(answer.status).toBe(200);
+  expect(answer.body.error).toBeUndefined();
+  /* The rotate draft's account reached the account seam unchanged... */
+  expect(asks).toEqual([{ accountId: unbound, project: PROJECT, engine: "codex" }]);
+  /* ...and the seam launched on the account the operator chose, not on the
+     pool's account with the choice quietly dropped. */
+  expect(resolved).toEqual([unbound]);
+
+  const seat = orchestratorSeatFor(PROJECT);
+  expect(seat.active?.conversationId).toBe(SUCCESSOR_ID);
+  expect(seat.active?.predecessorConversationId).toBe(INCUMBENT_ID);
+  /* Nothing is left pending for the panel to render as a failed designation. */
+  expect(seat.pending).toBeNull();
+});
+
+test("the AUTONOMOUS pick behind the same rotation still draws from the pool only", async () => {
+  /* The identical rotation with no account named. Nobody chose, so the fence is
+     the fence: the pool decides, and the unbound account is not in it. */
+  seatIncumbent();
+  const { asks, resolved } = dependencies();
+
+  const answer = await rotate({ clientRequestId: "rotate-automatic-1" });
+
+  expect(answer.status).toBe(200);
+  expect(asks).toEqual([{ accountId: undefined, project: PROJECT, engine: "codex" }]);
+  expect(resolved).toEqual([bound]);
+});
+
+test("a refused rotation leaves the incumbent seated and the refusal readable, with no fabricated successor", async () => {
+  /* The refusal that must still happen, and the shape a truthful failure keeps.
+     The record is damaged and nothing is named, so this is the AUTONOMOUS pick
+     — no pool can be seen and none may be picked. What the panel is owed
+     afterwards is the incumbent it still has, the reason on the record, and no
+     successor: a designation that failed must not read as one that landed. */
+  seatIncumbent();
+  const { resolved } = dependencies();
+  fs.writeFileSync(RECORD, '{"schemaVersion":1,"bindings":[{"engine":"codex"', "utf8");
+
+  const answer = await rotate({ clientRequestId: "rotate-damaged-record-1" });
+
+  expect(answer.status).toBeGreaterThanOrEqual(400);
+  expect(resolved).toEqual([]);
+  const seat = orchestratorSeatFor(PROJECT);
+  expect(seat.active?.conversationId).toBe(INCUMBENT_ID);
+  expect(seat.pending?.intent.error).toContain("account-project-bindings.json");
+  expect(seat.pending?.conversationId).toBeNull();
+});
+
+test("a rotation onto an unbound account is ATTRIBUTED, so the crossing is visible rather than silent", async () => {
+  /* The binding stops being a veto here, so it has to become a record: the
+     project view renders this journal beside the pool. Written by the launch
+     seam itself — `/api/spawn` — so this asserts the journal that seam appends
+     to, from the same explicit choice, with the record and the pool it read. */
+  seatIncumbent();
+  dependencies();
+  const { attributeNamedAccountChoice } = await import("@/lib/accounts/accountOverrides");
+
+  await rotate({ clientRequestId: "rotate-attributed-1", accountId: unbound });
+  const notice = attributeNamedAccountChoice({
+    engine: "codex",
+    project: PROJECT,
+    accountId: unbound,
+    conversationId: SUCCESSOR_ID,
+    actor: { kind: "operator" },
+    via: "launch",
+    now: () => AT,
+  });
+
+  expect(notice).toMatchObject({ outsidePool: true, accountId: unbound, reason: "outside-pool", recorded: true });
+  expect(notice?.allowedAccountIds).toEqual([bound]);
+  expect(fs.existsSync(OVERRIDES)).toBe(true);
+  expect(accountProjectOverrides({ project: PROJECT })).toEqual([expect.objectContaining({
+    engine: "codex",
+    accountId: unbound,
+    conversationId: SUCCESSOR_ID,
+    actor: "operator",
+    via: "launch",
+  })]);
+});


### PR DESCRIPTION
Closes #1617.

The operator's screenshot: a live orchestrator seat, `The last designation failed — codex account <account-b> is not allowed on project <project>`, and no composer anywhere on the panel. Three defects behind it, fixed here.

## 1. An explicitly named account is a control the binding may not veto

`resolveHealthySpawnAccount` — the direct-launch seam behind `/api/spawn`, the board's launch draft, the orchestrator's create and rotate drafts and `spawn_agent` — refused a NAMED account the project's pool did not contain.

#1279's own `explicitAccountChoice` already says the binding constrains what the Viewer picks **by itself** and never vetoes a choice that names an account. The two switch seams honoured that; the launch seam never reached it. What that produced: the rotate draft prefills the **incumbent's** account, so a seat already running outside its pool could not be rotated at all.

`selectProjectAccount` now takes `requestedChoice`. `fenced` is the default and every pre-existing caller — a pipeline stage's recorded account, a round's own — where nobody worked a control. `explicit` is the direct-launch seam.

Unchanged, and asserted beside every relaxation:

- the pick nobody named still draws from the pool only, still reports an exhausted pool, and still refuses on an unreadable record;
- a named account is still never capacity-checked and never substituted;
- authentication still decides — and a named Claude account now goes **through** the health pass instead of being filtered out of its candidate set and silently replaced by the automatic account;
- a damaged record no longer vetoes a named choice, and with the pool invisible there is no automatic answer left to fall back to either.

The binding stops being a veto, so it becomes a record: an out-of-pool launch is appended to the override journal the project view already renders beside the pool, under a new `launch` gesture, once the receipt exists and only for the account the request actually named.

## 2. The hoisted composer, deleted by the host's own stale render snapshot

`VoiceComposerHost` prunes retained card props using `conversationIds` read from the enclosing **render**. A card publishes its place from a ref during the commit that notifies the host, and its props from its own effect, which runs first — so the host's first prune carries a set taken before the card existed, finds the props just published, and deletes them along with the per-place map nothing republishes until the card's props change again. Re-read at effect time, the prune sees what its render's commit produced.

## 3. `waiting` instead of `live` over an idle agent

A badge that says `live` over an agent which is only awaiting input reads as "it is working". Two evidence sources can say which it is, on very different clocks, and the order matters:

- **`lastTurn`, the transcript's own turn boundary** (`endedAt: null` while the turn runs), which arrives on the file poll. This leads, with no affirmation gate — it is that poll's own answer about that transcript, not a claim held over.
- **`liveness.lifecycle`**, the shared vocabulary's word, which rides the incumbent poll — a cadence set by context-window wear, one minute, and refreshed by nothing when the operator sends a message. It is the FALLBACK, for a tail that carries no boundary at all (#231), and only an affirmed reading may downgrade there (`hostLive`, the rule from #1182).

Leading with `lifecycle` was wrong in both directions: `waiting` held over an agent that started working a message ago, and `live` held over one that finished — the original complaint, time-boxed to a minute rather than fixed. `seatState.test.ts` asserts both crossings against a stale reading.

Applied to `live` only: `stalled`, `resumable` and `dead` are stronger statements about the HOST, and an idle turn does not soften any of them. The phone carries the same word from the same state machine, and a `waiting` seat whose conversation is on the device keeps speaking that conversation's own phrase — the duration included.

## Evidence

**Live state, before any change** (`GET /api/orchestrator/seat`, `.../seat/status`, `conversation_deliverability`): active seat epoch 156 on the out-of-pool account, `hostState: alive`, `lifecycle: waiting`, `deliverable: true`; pending seat epoch 157 carrying the refusal on its intent. The seat was already running on the very account the next designation was refused for, and the conversation it refused to leave was answerable — the panel simply offered nothing to answer it with.

**Live browser** (read-only CDP against the running Viewer, dock open): `slots: 1` and `textareas: []` — the dock published its composer place and no composer rendered into it anywhere on the page.

**Red → green**, each verified by restoring the pre-change source under the new tests:

| test | red before |
| --- | --- |
| `rotationAccountChoice.test.ts` — the operator rotates onto an unbound authenticated account | 409, the production shape |
| `managerProjectBinding.test.ts` — explicit choice outside the pool launches; automatic still refuses it; damaged record splits the two; Claude's named account reaches the health pass | 4 of 5 red |
| `route.binding.test.ts` — the crossing is recorded, and an in-pool launch records nothing | red |
| `seatComposerHoist.dom.test.tsx` — a seated hosted orchestrator has a composer in the dock, refused designation included | both red |
| `seatState.test.ts` — idle turn reads `waiting`, running reads `live`, only an affirmed reading may downgrade | red |

`rotationAccountChoice.test.ts` drives the real `POST /api/orchestrator/rotate` route over a loopback listener, through the real seat command and the real account decision reading a real binding record; only `/api/spawn` stands in, resolving the account with the same call the route makes and then reporting an accepted launch instead of starting a process. `seatComposerHoist.dom.test.tsx` mounts the real `Viewer`, so the hoisted composer path — the only one production takes — is the one under test; the existing panel suite asserts a composer in a tree with no host in it, which is why this shipped invisibly.

Two guard tests pass on both sides by design and are marked as such: the autonomous pick behind the same rotation still draws from the pool, and a refused rotation leaves the incumbent seated with the reason on the record and no successor.

## Checks run

- `bunx tsc --noEmit` — clean.
- `bun scripts/privacy-publication-gate.ts --base d14f767` — PASS.
- Suites, by path: `accounts/{managerProjectBinding,projectSelection,accountOverrides,projectAccountsView,reseatBinding,reseatCommandBinding}`, `pipelines/stageAccountBinding`, `api/spawn/{route,route.binding}`, `agent/spawnCommand`, `agent/registry.migrationBinding`, `orchestrator/{rotationAccountChoice,rotationAuthority,seatCommand}`, `components/orchestrator/*`, `components/voice/*`, `components/TmuxComposer.dom`, `components/mobile/orchestratorRowState`, `lib/i18n` — all green.
- Sweeping `src/components/orchestrator/` reports 3 failures from `mock.module` leaking between `dockOpenState.dom.test.tsx` and `OrchestratorPanel.dom.test.tsx`. Those 3 fail identically at `d14f767` with this branch's new files removed, and `OrchestratorPanel.dom.test.tsx` passes on its own here. Pre-existing, not introduced.

## Ownership note

`src/components/voice/VoiceComposerHost.tsx` is Viewer-level composer machinery rather than orchestrator code. It is touched because it is the mechanism behind the missing composer this lane owns; the change is four lines and adds no behaviour beyond releasing only what has really gone.

## Deliberately not changed

`resolveProjectSpawn`'s `requestedId` — a pipeline stage's `account:`, a round's recorded account — keeps today's refusal. Those are forwarded ids on paths this directive did not name, and a pin there has its own history (#1371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

