### PR TITLE
fix(wakatime): a corrupt activity state file no longer disables operator controls

### DIFF
--- a/docs/wakatime.md
+++ b/docs/wakatime.md
@@ -62,6 +62,15 @@ heartbeat identity. Project and engine attribution come from the ingress's
 conversation target or its pre-resolved task or spawn metadata. Conflicting or
 unavailable attribution rejects the input.
 
+Recording is optional, and an outage in it never withholds a control. An
+attributed action whose heartbeat cannot be stored — a corrupt, busy, or
+unwritable state file — still sends, spawns, answers, or starts its call. The
+point is dropped, and the Viewer logs one `[wakatime]
+operator_activity_not_stored` diagnostic carrying an outcome class only
+(`state_unreadable`, an `errno` such as `EACCES`, or `unavailable`). Only an
+unattributed, conflicting, or unauthorized action is refused, and that refusal
+is unchanged.
+
 Signed internal-service provenance marks Viewer monitor, MCP and bridge, and
 orchestrator requests as background traffic. Agent capability provenance
 excludes other agent-originated requests from direct operator points. Agent and
@@ -127,9 +136,16 @@ of up to 25 heartbeats. Other restart paths coalesce events through stable
 local keys.
 
 Back up `wakatime-state.json` with its file mode intact if you need to preserve
-an undelivered queue. A corrupt file starts a new forward-only boundary and
-emits a count-only server diagnostic; unreadable pending records cannot be
-recovered without a backup.
+an undelivered queue. A corrupt file starts a new forward-only boundary in the
+scheduler's memory and emits a count-only server diagnostic; unreadable pending
+records cannot be recovered without a backup.
+
+An unreadable file on disk is never overwritten, so nothing is lost before you
+have decided what to keep, and delivery stays stopped until you act: writes
+refuse with `state_write_failed`, and each operator action logs
+`operator_activity_not_stored`. To resume collection, stop the Viewer, move the
+file aside (keep it if you want to attempt recovery), and start the Viewer
+again; a missing file creates a fresh version 1 with a forward-only boundary.
 
 ## Verification
 

--- a/src/app/api/answer/route.test.ts
+++ b/src/app/api/answer/route.test.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { NextRequest } from "next/server";
 
 import { internalServiceHeaders } from "@/lib/agent/operatorAuthority";
 import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorActivity";
+import { enqueueProductionOperatorHeartbeat } from "@/lib/wakatime/sync";
 import type { FileEntry, PendingQuestion } from "@/lib/types";
 
 import { POST } from "./route";
@@ -129,4 +133,72 @@ test("a pending answer records one direct operator gesture and excludes internal
     path: entry.path,
     idempotencyKey: "question:tool-answer-direct-one",
   })]);
+});
+
+test("a corrupt WakaTime state file does not refuse an operator's answer", async () => {
+  const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-answer-corrupt-state-"));
+  const stateFile = path.join(stateDirectory, "wakatime-state.json");
+  const corruptBytes = Buffer.alloc(4_096, 0);
+  fs.writeFileSync(stateFile, corruptBytes, { mode: 0o600 });
+  const entry = {
+    path: "/sessions/operator-answer-corrupt.jsonl",
+    root: "claude-projects",
+    name: "operator-answer-corrupt.jsonl",
+    project: "project-fixture",
+    title: "fixture",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "recent",
+    derivationComplete: true,
+    proc: "running",
+    pid: 44,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  } as FileEntry;
+  const delivered: string[] = [];
+
+  try {
+    const response = await POST.withDependencies(
+      new NextRequest("http://127.0.0.1/api/answer", {
+        method: "POST",
+        headers: {
+          host: "127.0.0.1",
+          origin: "http://127.0.0.1",
+          "sec-fetch-site": "same-origin",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          transcriptPath: entry.path,
+          toolUseId: "tool-answer-corrupt-state",
+          kind: "single",
+          option: 0,
+        }),
+      }),
+      {
+        knownState: async () => ({ entry, pending: { toolUseId: "tool-answer-corrupt-state" } as PendingQuestion, result: null }),
+        resolveTarget: async () => "agents:3.0",
+        recordOperatorActivity: (input) => recordDirectOperatorWakatimeActivity(input, {
+          enabled: () => true,
+          now: () => Date.parse("2026-09-10T09:00:00.000Z"),
+          registrySnapshot: () => ({ conversationAliases: {}, conversations: {} } as never),
+          enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+          reportStorageFailure: () => undefined,
+        }),
+        deliverAnswer: async (_io, _target, _pending, _body) => { delivered.push("answered"); return "Proceed"; },
+        confirmAnswered: async () => "Proceed",
+        paneScreen: async () => "",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(delivered).toEqual(["answered"]);
+    expect(fs.readFileSync(stateFile)).toEqual(corruptBytes);
+  } finally {
+    fs.rmSync(stateDirectory, { recursive: true, force: true });
+  }
 });

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -185,6 +185,74 @@ test("direct spawn records one durable operator gesture while MCP service spawn 
   })]);
 });
 
+test("a corrupt WakaTime state file does not refuse an authorized direct spawn", async () => {
+  const { recordDirectOperatorWakatimeActivity } = await import("@/lib/wakatime/operatorActivity");
+  const { enqueueProductionOperatorHeartbeat } = await import("@/lib/wakatime/sync");
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "operator-spawn-corrupt-state-"));
+  const stateFile = path.join(cwd, "wakatime-state.json");
+  /* The production shape of this outage: an all-NUL state file that throws in
+     `JSON.parse` before the heartbeat queue can be opened. */
+  const corruptBytes = Buffer.alloc(4_096, 0);
+  fs.writeFileSync(stateFile, corruptBytes, { mode: 0o600 });
+  const store = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const outcomes: string[] = [];
+  const dependencies = {
+    ...structuredRouteDependencies(cwd),
+    registry: () => store,
+    defer: () => {},
+    recordOperatorActivity: (input: Parameters<typeof recordDirectOperatorWakatimeActivity>[0]) =>
+      recordDirectOperatorWakatimeActivity(input, {
+        enabled: () => true,
+        now: () => Date.parse("2026-09-10T09:00:00.000Z"),
+        registrySnapshot: () => { throw new Error("resolved attribution should avoid registry access"); },
+        enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+        reportStorageFailure: (event, fields) => { outcomes.push(`${event}:${String(fields.outcome)}`); },
+      }),
+  };
+  const previous = {
+    transport: process.env.LLV_SPAWN_TRANSPORT,
+    hosts: process.env.LLV_STRUCTURED_HOSTS,
+    events: process.env.LLV_RUNTIME_EVENTS,
+    socket: process.env.LLV_RUNTIME_HOST_SOCKET,
+    ui: process.env.NEXT_PUBLIC_RUNTIME_UI,
+  };
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const spawned = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1",
+        origin: "http://127.0.0.1",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "claude · spawn under a corrupt activity state",
+        engine: "claude",
+        cwd,
+        /* Bracketed like the fixture above: a bare `prompt:` at the head of a
+           source line reads as transcript content to the publication gate. */
+        ["prompt"]: "inspect",
+        clientAttemptId: "operator_spawn_corrupt_state_20260910",
+      }),
+    }), dependencies);
+
+    expect(spawned.status).toBe(202);
+    expect(outcomes).toEqual(["operator_activity_not_stored:state_unreadable"]);
+    expect(fs.readFileSync(stateFile)).toEqual(corruptBytes);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      const envKey = ({ transport: "LLV_SPAWN_TRANSPORT", hosts: "LLV_STRUCTURED_HOSTS", events: "LLV_RUNTIME_EVENTS", socket: "LLV_RUNTIME_HOST_SOCKET", ui: "NEXT_PUBLIC_RUNTIME_UI" } as const)[key as keyof typeof previous];
+      if (value === undefined) delete process.env[envKey];
+      else process.env[envKey] = value;
+    }
+  }
+});
+
 test("new semantic, empty, and image-only prompts require an explicit semantic title", async () => {
   const png = Buffer.from("89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489", "hex").toString("base64");
   const post = async (body: Record<string, unknown>) => POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {

--- a/src/app/api/tasks/[id]/send/route.test.ts
+++ b/src/app/api/tasks/[id]/send/route.test.ts
@@ -1,8 +1,13 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { NextRequest } from "next/server";
 
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
+import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorActivity";
+import { enqueueProductionOperatorHeartbeat } from "@/lib/wakatime/sync";
 
 import { POST } from "./route";
 
@@ -73,4 +78,58 @@ test("one authorized task fan-out records one durable operator gesture across re
     idempotencyKey: "task-send:task-send-gesture-one",
     resolvedAttribution: { engine: "claude", project: "project-fixture" },
   }]);
+});
+
+test("a corrupt WakaTime state file does not refuse an authorized task fan-out", async () => {
+  const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-send-corrupt-state-"));
+  const stateFile = path.join(stateDirectory, "wakatime-state.json");
+  const corruptBytes = Buffer.alloc(4_096, 0);
+  fs.writeFileSync(stateFile, corruptBytes, { mode: 0o600 });
+  const task: BoardTask = {
+    id: "task-corrupt-state",
+    project: "project-fixture",
+    status: "inbox",
+    text: "Dispatch this task",
+    placement: "unplaced",
+    assignments: [],
+    createdAt: "2026-09-10T09:00:00.000Z",
+    updatedAt: "2026-09-10T09:00:00.000Z",
+  };
+  const files = [entry("/sessions/corrupt-state.jsonl", "codex")];
+  const outcomes: string[] = [];
+  let deliveries = 0;
+
+  try {
+    const response = await POST.withDependencies(
+      new NextRequest("http://127.0.0.1/api/tasks/task-corrupt-state/send", {
+        method: "POST",
+        headers: { host: "127.0.0.1", origin: "http://127.0.0.1", "sec-fetch-site": "same-origin", "content-type": "application/json" },
+        body: JSON.stringify({ paths: files.map((file) => file.path), clientRequestId: "task-send-corrupt-state" }),
+      }),
+      { params: Promise.resolve({ id: task.id }) },
+      {
+        loadTasks: () => [task],
+        listFiles: async () => files,
+        deliverConversationMessage: async () => {
+          deliveries += 1;
+          return { ok: true as const, outcome: "delivered-to-live" as const, target: "agents:5.0" };
+        },
+        mutateTasks: <R,>(mutator: (tasks: BoardTask[]) => { tasks?: BoardTask[]; result: R }) => mutator([task]).result,
+        recordOperatorActivity: (input) => recordDirectOperatorWakatimeActivity(input, {
+          enabled: () => true,
+          now: () => Date.parse("2026-09-10T09:00:00.000Z"),
+          registrySnapshot: () => { throw new Error("resolved attribution should avoid registry access"); },
+          enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+          reportStorageFailure: (event, fields) => { outcomes.push(`${event}:${String(fields.outcome)}`); },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(deliveries).toBe(1);
+    expect(outcomes).toEqual(["operator_activity_not_stored:state_unreadable"]);
+    expect(fs.readFileSync(stateFile)).toEqual(corruptBytes);
+  } finally {
+    fs.rmSync(stateDirectory, { recursive: true, force: true });
+  }
 });

--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -68,6 +68,9 @@ let structuredMessageCalls = 0;
 let structuredMessageRequest: Record<string, unknown> | null = null;
 let operatorActivityRequests: Record<string, unknown>[] = [];
 let operatorActivityEnabled = true;
+/* Set by a test that needs the REAL recording boundary — the stub below cannot
+   reproduce a storage outage, which is the thing under test. */
+let operatorActivityRecorder: ((request: Record<string, unknown>) => unknown) | null = null;
 let collectedImages: Array<{ base64: string; mime: string }> = [];
 let deletedImagePaths: string[][] = [];
 let structuredMessageResult:
@@ -134,6 +137,7 @@ beforeAll(() => {
     recordDirectOperatorWakatimeActivity: (request) => {
       if (!operatorActivityEnabled) return null;
       operatorActivityRequests.push({ ...request });
+      if (operatorActivityRecorder) return operatorActivityRecorder(request as Record<string, unknown>) as never;
       return { key: "a".repeat(64), engine: "codex", project: "fixture", atMs: Date.now() };
     },
     deliverConversationMessage: (message: unknown) => delivery(message),
@@ -959,5 +963,197 @@ test("/api/tmux folds attachment paths into the structured send and cleans up a 
     structuredMessageRequest = null;
     if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
     else process.env.LLV_STRUCTURED_HOSTS = previous;
+  }
+});
+
+test("/api/tmux delivers an operator message and a dialog answer while the WakaTime state file is corrupt", async () => {
+  const { recordDirectOperatorWakatimeActivity } = await import("@/lib/wakatime/operatorActivity");
+  const { enqueueProductionOperatorHeartbeat } = await import("@/lib/wakatime/sync");
+  const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-tmux-corrupt-state-"));
+  const stateFile = path.join(stateDirectory, "wakatime-state.json");
+  /* The production shape of this outage: a state file that is entirely NUL
+     bytes. `JSON.parse` throws before the queue can be touched. */
+  const corruptBytes = Buffer.alloc(4_096, 0);
+  fs.writeFileSync(stateFile, corruptBytes, { mode: 0o600 });
+  const at = Date.parse("2026-09-10T09:00:00.000Z");
+  const snapshot = {
+    conversationAliases: {},
+    conversations: {
+      conversation_corrupt_state: {
+        id: "conversation_corrupt_state",
+        engine: "codex",
+        generations: [{
+          id: "generation_corrupt_state",
+          path: PATHNAME,
+          accountId: null,
+          launchProfile: {
+            cwd: "/workspace/repository",
+            model: null,
+            effort: null,
+            fast: null,
+            permissionMode: null,
+            readOnly: null,
+            allowSubagents: true,
+            title: null,
+            project: "project-fixture",
+            parentConversationId: null,
+            role: "builder",
+            goal: null,
+            plan: null,
+          },
+          historyHash: null,
+          host: null,
+          createdAt: new Date(at).toISOString(),
+          archivedAt: null,
+        }],
+        continuityPaths: [],
+        abandonedContinuityPaths: [],
+        projectOwnership: {
+          project: "project-fixture",
+          source: "operator",
+          setAt: new Date(at).toISOString(),
+          operationId: "launch-fixture",
+        },
+        migration: null,
+        migrationOptOut: null,
+        supersededBy: null,
+        agentRole: "builder",
+        delegationDepth: 1,
+        turn: { state: "idle", source: "lifecycle", observedAt: new Date(at).toISOString() },
+        createdAt: new Date(at).toISOString(),
+        updatedAt: new Date(at).toISOString(),
+      },
+    },
+  };
+  const storageDiagnostics: string[] = [];
+  operatorActivityRequests = [];
+  operatorActivityRecorder = (request) => recordDirectOperatorWakatimeActivity(request as never, {
+    enabled: () => true,
+    now: () => at,
+    registrySnapshot: () => snapshot as never,
+    enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+    reportStorageFailure: (event, fields) => { storageDiagnostics.push(`${event}:${String(fields.outcome)}`); },
+  });
+  let deliveries = 0;
+  delivery = async () => {
+    deliveries += 1;
+    return { ok: true, outcome: "delivered-to-live", target: "agents:4.0" };
+  };
+  try {
+    const message = await POST(post({
+      path: PATHNAME,
+      text: "the board still has to work",
+      clientMessageId: "corrupt-state-message",
+    }));
+    const dialog = await POST(post({
+      path: PATHNAME,
+      action: "dialog-key",
+      key: "1",
+      clientMessageId: "corrupt-state-dialog",
+    }));
+
+    expect(message.status).toBe(200);
+    expect(deliveries).toBe(1);
+    expect(dialog.status).toBe(200);
+    expect(operatorActivityRequests).toHaveLength(2);
+    expect(storageDiagnostics).toEqual([
+      "operator_activity_not_stored:state_unreadable",
+      "operator_activity_not_stored:state_unreadable",
+    ]);
+    /* Every corrupt byte survives: the outage is reported, never repaired by
+       overwriting an unreadable queue the operator may still want to recover. */
+    expect(fs.readFileSync(stateFile)).toEqual(corruptBytes);
+  } finally {
+    operatorActivityRecorder = null;
+    fs.rmSync(stateDirectory, { recursive: true, force: true });
+  }
+});
+
+test("/api/tmux still refuses a message whose target evidence conflicts, corrupt state file or not", async () => {
+  const { recordDirectOperatorWakatimeActivity } = await import("@/lib/wakatime/operatorActivity");
+  const { enqueueProductionOperatorHeartbeat } = await import("@/lib/wakatime/sync");
+  const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-tmux-conflict-state-"));
+  const stateFile = path.join(stateDirectory, "wakatime-state.json");
+  fs.writeFileSync(stateFile, Buffer.alloc(4_096, 0), { mode: 0o600 });
+  const at = Date.parse("2026-09-10T09:00:00.000Z");
+  const conversation = (id: string, transcript: string) => ({
+    id,
+    engine: "codex",
+    generations: [{
+      id: `generation_${id}`,
+      path: transcript,
+      accountId: null,
+      launchProfile: {
+        cwd: "/workspace/repository",
+        model: null,
+        effort: null,
+        fast: null,
+        permissionMode: null,
+        readOnly: null,
+        allowSubagents: true,
+        title: null,
+        project: "project-fixture",
+        parentConversationId: null,
+        role: "builder",
+        goal: null,
+        plan: null,
+      },
+      historyHash: null,
+      host: null,
+      createdAt: new Date(at).toISOString(),
+      archivedAt: null,
+    }],
+    continuityPaths: [],
+    abandonedContinuityPaths: [],
+    projectOwnership: {
+      project: "project-fixture",
+      source: "operator",
+      setAt: new Date(at).toISOString(),
+      operationId: "launch-fixture",
+    },
+    migration: null,
+    migrationOptOut: null,
+    supersededBy: null,
+    agentRole: "builder",
+    delegationDepth: 1,
+    turn: { state: "idle", source: "lifecycle", observedAt: new Date(at).toISOString() },
+    createdAt: new Date(at).toISOString(),
+    updatedAt: new Date(at).toISOString(),
+  });
+  /* The conversation named by the caller owns a DIFFERENT transcript than the
+     path it presents — an unresolvable identity, not a telemetry outage. */
+  const snapshot = {
+    conversationAliases: {},
+    conversations: {
+      conversation_elsewhere: conversation("conversation_elsewhere", "/sessions/elsewhere.jsonl"),
+      conversation_here: conversation("conversation_here", PATHNAME),
+    },
+  };
+  operatorActivityRequests = [];
+  operatorActivityRecorder = (request) => recordDirectOperatorWakatimeActivity(request as never, {
+    enabled: () => true,
+    now: () => at,
+    registrySnapshot: () => snapshot as never,
+    enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+    reportStorageFailure: () => undefined,
+  });
+  let deliveries = 0;
+  delivery = async () => {
+    deliveries += 1;
+    return { ok: true, outcome: "delivered-to-live", target: "agents:4.0" };
+  };
+  try {
+    const response = await POST(post({
+      path: PATHNAME,
+      conversationId: "conversation_elsewhere",
+      text: "conflicting identity",
+      clientMessageId: "corrupt-state-conflict",
+    }));
+
+    expect(response.status).toBe(503);
+    expect(deliveries).toBe(0);
+  } finally {
+    operatorActivityRecorder = null;
+    fs.rmSync(stateDirectory, { recursive: true, force: true });
   }
 });

--- a/src/lib/runtime/http.test.ts
+++ b/src/lib/runtime/http.test.ts
@@ -2100,3 +2100,116 @@ test("a send no structured delivery owns is refused rather than admitted without
   expect(interrupt.status).toBe(202);
   expect(commands).toHaveLength(1);
 });
+
+test("a corrupt WakaTime state file does not refuse a structured runtime send, steer or answer", async () => {
+  const { enqueueProductionOperatorHeartbeat } = await import("@/lib/wakatime/sync");
+  const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-corrupt-state-"));
+  const stateFile = path.join(stateDirectory, "wakatime-state.json");
+  /* The production shape of this outage: an all-NUL state file that throws in
+     `JSON.parse` before the heartbeat queue can be opened. */
+  const corruptBytes = Buffer.alloc(4_096, 0);
+  fs.writeFileSync(stateFile, corruptBytes, { mode: 0o600 });
+  const at = Date.parse("2026-09-10T09:00:00.000Z");
+  const outcomes: string[] = [];
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: { kind: string; idempotencyKey: string; conversationId: string }) => {
+      commands.push(command);
+      return {
+        operationId: `op-${command.idempotencyKey}`,
+        replayed: false,
+        receipt: {
+          operationId: `op-${command.idempotencyKey}`,
+          idempotencyKey: command.idempotencyKey,
+          conversationId: command.conversationId,
+          kind: command.kind as "send",
+          status: "pending" as const,
+          at: new Date(at).toISOString(),
+          revision: 1,
+        },
+      };
+    },
+  } as unknown as RuntimeHostClient;
+  const dependencies: RuntimeHttpDependencies = {
+    enabled: () => true,
+    structuredEnabled: () => true,
+    client: () => client,
+    recordOperatorActivity: (input) => recordDirectOperatorWakatimeActivity(input, {
+      enabled: () => true,
+      now: () => at,
+      registrySnapshot: () => ({
+        conversationAliases: {},
+        conversations: {
+          conversation_direct: {
+            id: "conversation_direct",
+            engine: "codex",
+            generations: [{
+              id: "generation_direct",
+              path: "/sessions/direct.jsonl",
+              accountId: null,
+              launchProfile: {
+                ...emptyLaunchProfile({}),
+                cwd: "/workspace/repository",
+                project: "project-fixture",
+              },
+              historyHash: null,
+              host: null,
+              createdAt: new Date(at).toISOString(),
+              archivedAt: null,
+            }],
+            continuityPaths: [],
+            abandonedContinuityPaths: [],
+            projectOwnership: {
+              project: "project-fixture",
+              source: "operator",
+              setAt: new Date(at).toISOString(),
+              operationId: "launch-fixture",
+            },
+            migration: null,
+            migrationOptOut: null,
+            supersededBy: null,
+            agentRole: "builder",
+            delegationDepth: 1,
+            turn: { state: "idle", source: "lifecycle", observedAt: new Date(at).toISOString() },
+            createdAt: new Date(at).toISOString(),
+            updatedAt: new Date(at).toISOString(),
+          },
+        },
+      } as never),
+      enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+      reportStorageFailure: (event, fields) => { outcomes.push(`${event}:${String(fields.outcome)}`); },
+    }),
+  };
+
+  try {
+    const sent = await handleRuntimeCommand(request({
+      conversationId: "conversation_direct",
+      text: "the composer still has to work",
+      idempotencyKey: "corrupt-state-send",
+    }), "send", dependencies);
+    const steered = await handleRuntimeCommand(request({
+      conversationId: "conversation_direct",
+      text: "change course",
+      idempotencyKey: "corrupt-state-steer",
+    }), "steer", dependencies);
+    const answered = await handleRuntimeCommand(request({
+      conversationId: "conversation_direct",
+      attentionId: "attention-corrupt-state",
+      resolution: { choice: "1" },
+      idempotencyKey: "corrupt-state-answer",
+    }), "answer", dependencies);
+
+    expect([sent.status, steered.status, answered.status]).toEqual([202, 202, 202]);
+    expect(commands).toHaveLength(3);
+    expect(outcomes).toEqual([
+      "operator_activity_not_stored:state_unreadable",
+      "operator_activity_not_stored:state_unreadable",
+      "operator_activity_not_stored:state_unreadable",
+    ]);
+    /* Every corrupt byte survives: the outage is reported, never repaired by
+       overwriting a queue the operator may still want to recover. */
+    expect(fs.readFileSync(stateFile)).toEqual(corruptBytes);
+  } finally {
+    fs.rmSync(stateDirectory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/runtime/realtimeControl.selectedContext.test.ts
+++ b/src/lib/runtime/realtimeControl.selectedContext.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { captureSelectedContext, type SelectedContextRef } from "@/lib/selection/selectedContext";
 
@@ -136,7 +139,7 @@ test("an explicit empty selection is admitted and readable, distinct from never 
   expect(voiceSelectedContext("conversation_voice")?.reference.state).toBe("none");
 });
 
-test("a live peer records one stable operator event and a recording failure stays retryable", async () => {
+test("a live peer records one stable operator event and an unattributable event stays retryable", async () => {
   const spoken: string[] = [];
   const host = hostFor(spoken);
   const recorded: unknown[] = [];
@@ -151,7 +154,9 @@ test("a live peer records one stable operator event and a recording failure stay
   const dependencies = {
     recordOperatorActivity(input: unknown) {
       recorded.push(input);
-      if (fail) throw new Error("disk unavailable");
+      /* An attribution failure, the only class this boundary still throws:
+         optional storage outages are absorbed inside the recorder itself. */
+      if (fail) throw new Error("direct operator activity target is unavailable");
       return { key: "a".repeat(64), engine: "codex" as const, project: "atlas", atMs: NOW };
     },
   };
@@ -226,4 +231,86 @@ test("hanging up releases the binding, so a later utterance cannot ride the dead
   );
   await executeRealtimeControl({ action: "stop", conversationId: "conversation_voice" }, () => host, OPERATOR);
   expect(voiceSelectedContext("conversation_voice")).toBeNull();
+});
+
+test("a corrupt WakaTime state file does not refuse a live realtime operator event", async () => {
+  const { enqueueProductionOperatorHeartbeat } = await import("@/lib/wakatime/sync");
+  const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-realtime-corrupt-state-"));
+  const stateFile = path.join(stateDirectory, "wakatime-state.json");
+  const corruptBytes = Buffer.alloc(4_096, 0);
+  fs.writeFileSync(stateFile, corruptBytes, { mode: 0o600 });
+  const host = hostFor([]);
+  await start(host, DESK);
+  const outcomes: string[] = [];
+
+  try {
+    const result = await executeRealtimeControl({
+      action: "operatorActivity",
+      conversationId: "conversation_voice",
+      realtimeSessionId: "live-1",
+      operatorEventId: "9".repeat(64),
+    }, () => host, PEER, {
+      recordOperatorActivity: (input) => recordDirectOperatorWakatimeActivity(input, {
+        enabled: () => true,
+        now: () => NOW,
+        registrySnapshot: () => ({
+          conversationAliases: {},
+          conversations: {
+            conversation_voice: {
+              id: "conversation_voice",
+              engine: "codex",
+              generations: [{
+                id: "generation_voice",
+                path: "/sessions/voice.jsonl",
+                accountId: null,
+                launchProfile: {
+                  cwd: "/workspace/repository",
+                  model: null,
+                  effort: null,
+                  fast: null,
+                  permissionMode: null,
+                  readOnly: null,
+                  allowSubagents: true,
+                  title: null,
+                  project: "atlas",
+                  parentConversationId: null,
+                  role: "builder",
+                  goal: null,
+                  plan: null,
+                },
+                historyHash: null,
+                host: null,
+                createdAt: new Date(NOW).toISOString(),
+                archivedAt: null,
+              }],
+              continuityPaths: [],
+              abandonedContinuityPaths: [],
+              projectOwnership: {
+                project: "atlas",
+                source: "operator",
+                setAt: new Date(NOW).toISOString(),
+                operationId: "launch-fixture",
+              },
+              migration: null,
+              migrationOptOut: null,
+              supersededBy: null,
+              agentRole: "builder",
+              delegationDepth: 1,
+              turn: { state: "idle", source: "lifecycle", observedAt: new Date(NOW).toISOString() },
+              createdAt: new Date(NOW).toISOString(),
+              updatedAt: new Date(NOW).toISOString(),
+            },
+          },
+        } as never),
+        enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, stateFile, () => true),
+        reportStorageFailure: (event, fields) => { outcomes.push(`${event}:${String(fields.outcome)}`); },
+      }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(outcomes).toEqual(["operator_activity_not_stored:state_unreadable"]);
+    expect(fs.readFileSync(stateFile)).toEqual(corruptBytes);
+  } finally {
+    fs.rmSync(stateDirectory, { recursive: true, force: true });
+  }
 });

--- a/src/lib/wakatime/operatorActivity.ts
+++ b/src/lib/wakatime/operatorActivity.ts
@@ -6,6 +6,7 @@ import {
   type RegistryFile,
 } from "@/lib/agent/registry";
 import { UNRESOLVED_PROJECT } from "@/lib/projects/identity";
+import { FileTransactionBusyError } from "@/lib/state/fileTransaction";
 import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import type { FileEntry } from "@/lib/types";
 
@@ -32,10 +33,25 @@ interface DirectOperatorWakatimeDependencies {
   now(): number;
   registrySnapshot(): RegistryFile;
   enqueue(action: DirectOperatorWakatimeHeartbeat): void;
+  reportStorageFailure(
+    event: string,
+    fields: Readonly<Record<string, string | number | boolean | null>>,
+  ): void;
 }
 
 function digest(...parts: string[]): string {
   return crypto.createHash("sha256").update(parts.join("\0")).digest("hex");
+}
+
+/** One closed set of outcome classes for a refused optional write. The failure
+    text itself never travels: `fs` messages carry the state path, and a parse
+    failure can quote state bytes. */
+function storageOutcome(error: unknown): string {
+  if (error instanceof FileTransactionBusyError) return "busy";
+  if (error instanceof SyntaxError) return "state_unreadable";
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  if (typeof code === "string" && /^E[A-Z]{1,15}$/.test(code)) return code;
+  return "unavailable";
 }
 
 export function recordDirectOperatorWakatimeActivity(
@@ -47,6 +63,8 @@ export function recordDirectOperatorWakatimeActivity(
     now: overrides.now ?? Date.now,
     registrySnapshot: overrides.registrySnapshot ?? (() => agentRegistry().readOnlySnapshot()),
     enqueue: overrides.enqueue ?? enqueueProductionOperatorHeartbeat,
+    reportStorageFailure: overrides.reportStorageFailure
+      ?? ((event, fields) => console.error(`[wakatime] ${event}`, fields)),
   };
   if (!dependencies.enabled()) return null;
   const idempotencyKey = input.idempotencyKey?.trim() ?? "";
@@ -99,6 +117,17 @@ export function recordDirectOperatorWakatimeActivity(
     ? digest("llv-wakatime-direct-operator-v1", idempotencyKey)
     : crypto.randomBytes(32).toString("hex");
   const action: DirectOperatorWakatimeAction = { key, engine, project, atMs };
-  dependencies.enqueue(action);
+  /* THE ACTION IS ALREADY VALID HERE. Everything above rejects an unattributed,
+     conflicting or unauthorized gesture by throwing, and callers turn that into
+     a refusal. What remains is the optional heartbeat queue — a corrupt, busy or
+     unwritable state file is a telemetry outage, and an outage in a statistics
+     feature must not disable a control the operator is entitled to use (#1621).
+     The point is dropped, the outcome class is reported, and no state is reset:
+     an unreadable file keeps every byte for recovery from a backup. */
+  try {
+    dependencies.enqueue(action);
+  } catch (error) {
+    dependencies.reportStorageFailure("operator_activity_not_stored", { outcome: storageOutcome(error) });
+  }
   return action;
 }

--- a/src/lib/wakatime/operatorActivityStorageFailure.test.ts
+++ b/src/lib/wakatime/operatorActivityStorageFailure.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { RegistryFile } from "@/lib/agent/registry";
+import { FileTransactionBusyError } from "@/lib/state/fileTransaction";
+
+import { recordDirectOperatorWakatimeActivity } from "./operatorActivity";
+import { enqueueProductionOperatorHeartbeat } from "./sync";
+
+const NOW = Date.parse("2026-09-10T09:00:00.000Z");
+
+let stateDirectory: string;
+let corruptStateFile: string;
+let corruptBytes: ReturnType<typeof Buffer.alloc>;
+
+/** The live incident's shape: a state file that is entirely NUL bytes, so
+    `JSON.parse` throws before any queue work can begin. Isolated per test —
+    no HOME, XDG_CONFIG_HOME, LLV_STATE_DIR or live state is read or written. */
+beforeEach(() => {
+  stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-wakatime-corrupt-"));
+  corruptStateFile = path.join(stateDirectory, "wakatime-state.json");
+  corruptBytes = Buffer.alloc(8_192, 0);
+  fs.writeFileSync(corruptStateFile, corruptBytes, { mode: 0o600 });
+});
+
+afterEach(() => {
+  fs.rmSync(stateDirectory, { recursive: true, force: true });
+});
+
+function registry(): RegistryFile {
+  return {
+    conversationAliases: {},
+    conversations: {
+      conversation_direct: {
+        id: "conversation_direct",
+        engine: "codex",
+        generations: [{
+          id: "generation_direct",
+          path: "/sessions/direct.jsonl",
+          accountId: null,
+          launchProfile: {
+            cwd: "/workspace/repository",
+            model: null,
+            effort: null,
+            fast: null,
+            permissionMode: null,
+            readOnly: null,
+            allowSubagents: true,
+            title: null,
+            project: "project-fixture",
+            parentConversationId: null,
+            role: "builder",
+            goal: null,
+            plan: null,
+          },
+          historyHash: null,
+          host: null,
+          createdAt: new Date(NOW).toISOString(),
+          archivedAt: null,
+        }],
+        continuityPaths: [],
+        abandonedContinuityPaths: [],
+        projectOwnership: {
+          project: "project-fixture",
+          source: "operator",
+          setAt: new Date(NOW).toISOString(),
+          operationId: "launch-fixture",
+        },
+        migration: null,
+        migrationOptOut: null,
+        supersededBy: null,
+        agentRole: "builder",
+        delegationDepth: 1,
+        turn: { state: "idle", source: "lifecycle", observedAt: new Date(NOW).toISOString() },
+        createdAt: new Date(NOW).toISOString(),
+        updatedAt: new Date(NOW).toISOString(),
+      },
+    },
+  } as unknown as RegistryFile;
+}
+
+test("a corrupt state file cannot refuse an attributed operator action, and keeps every byte", () => {
+  const diagnostics: Array<{ event: string; fields: Record<string, string | number | boolean | null> }> = [];
+
+  const action = recordDirectOperatorWakatimeActivity({
+    conversationId: "conversation_direct",
+    path: "/sessions/direct.jsonl",
+    idempotencyKey: "operator-message-under-corrupt-state",
+  }, {
+    enabled: () => true,
+    now: () => NOW,
+    registrySnapshot: registry,
+    enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, corruptStateFile, () => true),
+    reportStorageFailure: (event, fields) => { diagnostics.push({ event, fields }); },
+  });
+
+  expect(action).toMatchObject({ engine: "codex", project: "project-fixture", atMs: NOW });
+  expect(diagnostics).toEqual([{
+    event: "operator_activity_not_stored",
+    fields: { outcome: "state_unreadable" },
+  }]);
+  expect(fs.readFileSync(corruptStateFile)).toEqual(corruptBytes);
+});
+
+test("the storage diagnostic carries an outcome class only, never a path, key or state byte", () => {
+  const diagnostics: Array<Record<string, unknown>> = [];
+  recordDirectOperatorWakatimeActivity({
+    conversationId: "conversation_direct",
+    idempotencyKey: "private-operator-request-id",
+  }, {
+    enabled: () => true,
+    now: () => NOW,
+    registrySnapshot: registry,
+    enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, corruptStateFile, () => true),
+    reportStorageFailure: (event, fields) => { diagnostics.push({ event, ...fields }); },
+  });
+
+  const rendered = JSON.stringify(diagnostics);
+  expect(rendered).not.toContain("private-operator-request-id");
+  expect(rendered).not.toContain(corruptStateFile);
+  expect(rendered).not.toContain(stateDirectory);
+  expect(rendered).not.toContain("wakatime-state.json");
+});
+
+test("a storage outage classifies without leaking the underlying failure text", () => {
+  const outcomes: string[] = [];
+  const record = (failure: unknown) => recordDirectOperatorWakatimeActivity({
+    conversationId: "conversation_direct",
+    idempotencyKey: "outage-class",
+  }, {
+    enabled: () => true,
+    now: () => NOW,
+    registrySnapshot: registry,
+    enqueue: () => { throw failure; },
+    reportStorageFailure: (_event, fields) => { outcomes.push(String(fields.outcome)); },
+  });
+
+  /* The failure text an `fs` refusal really carries: the state path it opened.
+     That is exactly what must not reach a diagnostic. */
+  const denied = Object.assign(new Error("EACCES: permission denied, open '/var/lib/viewer/state.json'"), { code: "EACCES" });
+  expect(record(denied)).not.toBeNull();
+  expect(record(new SyntaxError("JSON Parse error"))).not.toBeNull();
+  expect(record(new FileTransactionBusyError("WakaTime state is busy"))).not.toBeNull();
+  expect(record(new Error("something else entirely"))).not.toBeNull();
+  expect(outcomes).toEqual(["EACCES", "state_unreadable", "busy", "unavailable"]);
+});
+
+test("an invalid target is still refused, and never reaches optional storage", () => {
+  let enqueues = 0;
+  const diagnostics: string[] = [];
+
+  expect(() => recordDirectOperatorWakatimeActivity({
+    conversationId: "conversation_direct",
+    path: "/sessions/unrelated.jsonl",
+    idempotencyKey: "conflicting-target-under-corrupt-state",
+  }, {
+    enabled: () => true,
+    now: () => NOW,
+    registrySnapshot: registry,
+    enqueue: () => { enqueues += 1; },
+    reportStorageFailure: (event) => { diagnostics.push(event); },
+  })).toThrow("conflicting target evidence");
+
+  expect(enqueues).toBe(0);
+  expect(diagnostics).toEqual([]);
+});
+
+test("invalid server-resolved attribution is still refused under a corrupt state file", () => {
+  expect(() => recordDirectOperatorWakatimeActivity({
+    idempotencyKey: "unattributed-spawn",
+    resolvedAttribution: { engine: "claude", project: "  " },
+  }, {
+    enabled: () => true,
+    now: () => NOW,
+    registrySnapshot: () => { throw new Error("resolved attribution should avoid registry access"); },
+    enqueue: (heartbeat) => enqueueProductionOperatorHeartbeat(heartbeat, corruptStateFile, () => true),
+    reportStorageFailure: () => undefined,
+  })).toThrow("attribution is invalid");
+});


### PR DESCRIPTION
Closes #1621.

## The blocker

A Viewer whose `state/wakatime-state.json` had become unreadable refused every
direct operator control. A live `POST /api/conversation-host` to a verified
deliverable worker answered `503 direct operator activity could not be
recorded` **before** delivery, and the same refusal gated manual messages,
dialog answers, pending-question answers, task sends, task spawns, direct
spawns and the realtime operator event that starts a voice call. Attribution
had already succeeded — the conversation, engine and project all resolved
read-only. What failed was the optional statistics write.

`readProductionState` re-throws everything that is not `ENOENT`, so `JSON.parse`
on the corrupt file threw out of `recordDirectOperatorWakatimeActivity` into six
identical `catch { 503 }` blocks that could not tell an invalid action from a
telemetry outage.

## The change

One boundary, in `recordDirectOperatorWakatimeActivity`, placed after every
attribution and identity check:

- an **unattributed, conflicting or unauthorized** action still throws and is
  still refused, byte for byte as before;
- an **authorized, attributed** action proceeds even when the heartbeat cannot
  be stored. The point is dropped and the Viewer logs one `[wakatime]
  operator_activity_not_stored` diagnostic carrying an outcome class only —
  `busy`, `state_unreadable`, an `errno`, or `unavailable`. No path, request
  identity, key or state byte appears in it.

No new outbox, queue or framework, and **no state reset**: an unreadable file
keeps every byte, so an undelivered queue stays recoverable from it. The
scheduler's own refusal to overwrite a corrupt file is unchanged; `docs/wakatime.md`
now documents the manual step that resumes collection, since the condition is
otherwise permanent.

## Verification

`bun test` over the twelve affected files: **222 pass, 0 fail**. `bunx tsc
--noEmit` clean. Privacy gate passes with `--check-commits`.

Causal RED → GREEN, re-running the new tests against `HEAD`'s pre-fix
`operatorActivity.ts` with everything else identical:

| | pre-fix | with the fix |
| --- | --- | --- |
| the 8 tolerance assertions | fail (`Expected: 200 / Received: 503`) | pass |
| conflicting target evidence is refused | pass | pass |
| invalid server-resolved attribution is refused | pass | pass |

Each ingress test drives the **real** production storage function against its
own isolated fixture — an all-NUL state file in a per-test `mkdtemp` directory,
never the shared state directory — and asserts three things: the control
succeeds, the outcome class is `state_unreadable`, and the fixture's bytes are
unchanged afterwards. Covered at the message and dialog-key ingress
(`/api/tmux`), the realtime operator event, the pending-answer route, the task
fan-out, and direct spawn.

One existing realtime test asserted 503 for a stub throwing `disk unavailable`;
it now throws the attribution class it was really standing in for, which is the
only class that still refuses.

## Limitations

- Deployment and live acceptance are the operator's. Nothing here was deployed,
  and no live state, lock or file was touched — the corrupt file was read
  read-only to confirm its size and digest.
- The dropped points are gone. This restores the controls; it does not recover
  heartbeats that could not be queued while the file was unreadable.
- Telemetry stays stopped until the unreadable file is moved aside by hand. That
  is deliberate: automatic recovery would mean overwriting a queue the operator
  may want to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
