### PR TITLE
fix(board): a catalog open keeps its promise until the conversation is on screen (#1625)

### DIFF
--- a/scripts/capture-issue-1625-catalog-focus.ts
+++ b/scripts/capture-issue-1625-catalog-focus.ts
@@ -1,0 +1,561 @@
+/**
+ * Rendered acceptance for #1625, in a real browser against the production
+ * build:
+ *
+ *   bun run build && bun scripts/capture-issue-1625-catalog-focus.ts
+ *
+ * The question is the operator's own: after clicking a row in the desktop agent
+ * catalog, is the conversation they asked for ON SCREEN and readable? The
+ * earlier rendered acceptance (#1614) opened whichever row the list happened to
+ * draw first — a recent agent in the top band, under no layout pressure — and
+ * asked only whether a node for it existed anywhere in the DOM. Both of those
+ * pass while the reported defect is live, so this capture opens the shape that
+ * actually failed: a HISTORICAL conversation, outside the board's own window,
+ * belonging to a COMPLETED pipeline, whose task band sits far down a long stack
+ * of preceding bands.
+ *
+ * It measures, in the page, at the real production build:
+ *
+ *   - the first open: the requested node's rectangle against the board
+ *     viewport, and whether its own title is rendered inside it;
+ *   - the repeat open, after the operator has gone back to the list;
+ *   - that a manual pan afterwards is RESPECTED — the camera is read again
+ *     after more than one scanner poll, and must not have crept back.
+ *
+ * Then it proves the audit can go red: the same reading is taken against a page
+ * where the defect has been reintroduced by hand (the world pushed so the node
+ * leaves the viewport, and the node removed outright). A run where either of
+ * those still reads as "shown" exits non-zero.
+ *
+ * Everything is served against a purpose-built synthetic home under the temp
+ * root — its own HOME, XDG dirs, TMPDIR, viewer state dir and provider homes —
+ * so nothing here reads or writes the operator's live state, and no real path
+ * appears in any frame. Nothing is deployed.
+ *
+ * Frames and the measurement JSON land outside the repository, under
+ * <BOARD_CAPTURE_DIR>/<unique-run>/out.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { chromium, type Browser, type Page } from "playwright-core";
+
+import { createCaptureDirectory } from "./capture-directory";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const BASE = createCaptureDirectory({
+  envName: "BOARD_CAPTURE_DIR",
+  prefix: "llv-issue-1625",
+  raw: process.env.BOARD_CAPTURE_DIR,
+  repoRoot,
+});
+const HOME = path.join(BASE, "home");
+const OUT_DIR = path.join(BASE, "out");
+const STATE_DIR = path.join(HOME, ".config", "agent-log-viewer", "state");
+
+/** Conversations on disk. The board draws a bounded window of the freshest. */
+const CONVERSATIONS = 260;
+/** Task bands. The requested conversation's band must have many above it. */
+const TASKS = 15;
+/** Members each staffed band holds, so the stack is genuinely tall. */
+const PER_BAND = 5;
+const PROJECT_NAME = "catalog";
+/** The row this capture opens, named so it can be found in the catalog. */
+const TARGET_TITLE = "Folded pipeline builder from the archive";
+
+const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
+const line = (record: Record<string, unknown>) => JSON.stringify(record) + "\n";
+
+function conversationFile(index: number): { file: string; uuid: string } {
+  const cwd = path.join(HOME, "Projects", PROJECT_NAME);
+  const folder = path.join(HOME, ".claude/projects", projectSlug(cwd));
+  fs.mkdirSync(folder, { recursive: true });
+  const uuid = `${String(index + 1).padStart(8, "0")}-3333-4333-8333-333333333333`;
+  return { file: path.join(folder, `${uuid}.jsonl`), uuid };
+}
+
+interface Seeded { file: string; uuid: string; title: string }
+
+/**
+ * The corpus. The freshest {@link TASKS} × {@link PER_BAND} conversations are
+ * what the board's window draws, so their task bands hold real members and the
+ * stack is tall. The LAST conversation written is deliberately the oldest one
+ * on disk: it is outside that window, which is what makes opening it from the
+ * catalog an ephemeral admission rather than a jump to a card already drawn.
+ */
+function seedConversations(): Seeded[] {
+  const cwd = path.join(HOME, "Projects", PROJECT_NAME);
+  fs.mkdirSync(cwd, { recursive: true });
+  const seeded: Seeded[] = [];
+  for (let index = 0; index < CONVERSATIONS; index += 1) {
+    const { file, uuid } = conversationFile(index);
+    const stamp = "2100-01-02T09:00:00.000Z";
+    const last = index === CONVERSATIONS - 1;
+    const title = last ? TARGET_TITLE : `Agent ${index} watching area ${index}`;
+    const body = last
+      ? "Recorded months ago by a pipeline that has since finished. Every line of it has to be readable once it is opened from the catalog."
+      : `${title} — recorded.`;
+    fs.writeFileSync(
+      file,
+      line({ type: "user", uuid: `${uuid}-u`, timestamp: stamp, cwd, message: { role: "user", content: `${title}.` } })
+      + line({ type: "assistant", uuid: `${uuid}-a`, timestamp: stamp, cwd, message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text: body }] } }),
+      "utf8",
+    );
+    /* Fresh at the front, and the target far older than anything else. */
+    const ageMs = last ? 400 * 24 * 3600 * 1000 : 60_000 + index * 60_000;
+    fs.utimesSync(file, new Date(stamp), new Date(Date.now() - ageMs));
+    seeded.push({ file, uuid, title });
+  }
+  return seeded;
+}
+
+function seedHome(): void {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.mkdirSync(path.join(BASE, "tmp", `claude-${process.getuid?.() ?? 1000}`), { recursive: true });
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.mkdirSync(path.join(HOME, ".codex/sessions"), { recursive: true });
+}
+
+/**
+ * The task corpus: {@link TASKS} assigned tasks, each holding a run of fresh
+ * conversations, plus — created FIRST, so it ranks below every other band — the
+ * one task whose only assignment is the archived target. That band is drawn
+ * empty until the catalog admits its conversation, and it sits at the bottom of
+ * the stack, thousands of world pixels from the framing the board opens on.
+ */
+function seedTasks(project: string, conversations: Seeded[]): string {
+  const targetTaskId = "task-0000-4000-8000-b00000000000";
+  const target = conversations[conversations.length - 1]!;
+  const tasks: unknown[] = [{
+    id: targetTaskId,
+    project,
+    status: "assigned",
+    text: "Archived pipeline task\nIts agent finished long ago; the board draws nothing for it until the catalog opens it.",
+    placement: "unplaced",
+    assignments: [{ path: target.file, conversationId: null, panePid: null, state: "delivered", error: null, at: "2100-01-01T00:00:00.000Z" }],
+    createdAt: "2100-01-01T00:00:00.000Z",
+    updatedAt: "2100-01-01T00:00:00.000Z",
+  }];
+  for (let index = 0; index < TASKS; index += 1) {
+    const created = new Date(Date.UTC(2100, 0, 2, 0, index % 60, 0)).toISOString();
+    const held = conversations.slice(index * PER_BAND, index * PER_BAND + PER_BAND);
+    tasks.push({
+      id: `task-${String(index + 1).padStart(4, "0")}-4000-8000-b00000000000`,
+      project,
+      status: "assigned",
+      text: `Staffed task ${index}\nAgents are on this one.`,
+      placement: "unplaced",
+      assignments: held.map((entry) => ({ path: entry.file, conversationId: null, panePid: null, state: "delivered", error: null, at: created })),
+      createdAt: created,
+      updatedAt: created,
+    });
+  }
+  fs.writeFileSync(path.join(STATE_DIR, "tasks.json"), JSON.stringify({ tasks }, null, 2) + "\n", "utf8");
+  return targetTaskId;
+}
+
+/** A finished two-stage pipeline whose implement stage IS the target: the
+    folded, completed membership the reported opens both had. */
+function seedPipeline(project: string, targetTaskId: string, conversations: Seeded[]): void {
+  const target = conversations[conversations.length - 1]!;
+  const reviewer = conversations[conversations.length - 2]!;
+  const role = (roleId: string) => ({ roleId, engine: "claude", model: "opus", effort: "high", access: "read-write", promptScaffold: null });
+  const attempt = (roleId: string, entry: Seeded) => ({
+    n: 1,
+    state: "passed",
+    effectiveRole: role(roleId),
+    launchId: `launch-${roleId}`,
+    conversationId: null,
+    sessionId: entry.uuid,
+    agentPath: entry.file,
+    paneId: null,
+    flowId: null,
+    startedAt: "2100-01-01T00:00:00.000Z",
+    completedAt: "2100-01-01T01:00:00.000Z",
+    input: null,
+    activatedBy: null,
+    output: "done",
+    verdict: { status: "pass" },
+    error: null,
+  });
+  const stage = (id: string, next: string | null, roleId: string) => ({
+    id, kind: "run", role: { roleId }, engine: "claude", model: "opus",
+    effort: "high", access: "read-write", prompt: "Finished work.", next, onFail: null, effectiveRole: role(roleId),
+  });
+  const pipelines = [{
+    id: "archived",
+    task: "Archived pipeline task",
+    taskIds: [targetTaskId],
+    spec: "Finished long ago.",
+    project,
+    repoDir: path.join(HOME, "Projects", PROJECT_NAME),
+    worktreeDir: path.join(HOME, "Projects", `${PROJECT_NAME}-archived`),
+    branch: "pipeline/archived",
+    baseBranch: "main",
+    baseRef: "0".repeat(40),
+    lastPassedCommit: "0".repeat(40),
+    stages: [stage("implement", "review", "builder"), stage("review", null, "reviewer")],
+    runs: [
+      { stageId: "implement", attempts: [attempt("builder", target)] },
+      { stageId: "review", attempts: [attempt("reviewer", reviewer)] },
+    ],
+    cursor: null,
+    state: "completed",
+    pausedState: null,
+    stateDetail: null,
+    srcPath: null,
+    srcConversationId: null,
+    createdAt: "2100-01-01T00:00:00.000Z",
+    closedAt: "2100-01-01T02:00:00.000Z",
+  }];
+  fs.writeFileSync(path.join(STATE_DIR, "pipelines.json"), JSON.stringify({ schemaVersion: 5, pipelines }, null, 2) + "\n", "utf8");
+}
+
+/**
+ * The server's environment: every variable that decides where the Viewer reads
+ * and writes points at the synthetic home, and every stray `LLV_*` the caller
+ * exported is dropped, so this run cannot reach the operator's state. The rest
+ * is inherited because `bun --bun` needs it.
+ */
+function buildEnvironment(port: number): NodeJS.ProcessEnv {
+  const config = path.join(HOME, ".config");
+  const inherited = { ...process.env };
+  for (const name of Object.keys(inherited)) {
+    if (name.startsWith("LLV_") || name.startsWith("__NEXT_PRIVATE")) delete inherited[name];
+  }
+  return {
+    ...inherited,
+    NODE_ENV: "production",
+    HOME,
+    TMPDIR: path.join(BASE, "tmp"),
+    TMUX_TMPDIR: path.join(BASE, "tmux"),
+    XDG_CONFIG_HOME: config,
+    XDG_CACHE_HOME: path.join(BASE, "cache"),
+    XDG_RUNTIME_DIR: path.join(BASE, "runtime"),
+    LLV_STATE_DIR: STATE_DIR,
+    LLV_CLAUDE_HOME: path.join(HOME, ".claude"),
+    LLV_CODEX_HOME: path.join(HOME, ".codex"),
+    LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+    LLV_REAPER_ENABLED: "0",
+    NEXT_TELEMETRY_DISABLED: "1",
+    PORT: String(port),
+    TZ: "UTC", LANG: "C.UTF-8", LC_ALL: "C.UTF-8", USER: "demo", LOGNAME: "demo", SHELL: "/bin/sh",
+  };
+}
+
+/** Served under the interpreter running this script — the pinned Bun, which is
+    the only one that can load this build's compiled server modules. */
+const CAPTURE_BUN = process.env.BOARD_CAPTURE_BUN?.trim() || process.execPath;
+
+function startServer(port: number): ChildProcess {
+  return spawn(CAPTURE_BUN, ["--bun", "node_modules/.bin/next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: repoRoot, env: buildEnvironment(port), stdio: ["ignore", "inherit", "inherit"],
+  });
+}
+
+async function waitForServer(url: string, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`production server exited with ${child.exitCode}`);
+    try {
+      if ((await fetch(`${url}/api/files`)).ok) return;
+    } catch { /* still booting */ }
+    await Bun.sleep(400);
+  }
+  throw new Error("production server did not become ready");
+}
+
+interface FilesPayload { files?: { path?: string; project?: string }[]; tasks?: { id: string }[] }
+
+async function waitForBoard(baseUrl: string, expectTasks: boolean): Promise<{ project: string; cards: number }> {
+  const deadline = Date.now() + 180_000;
+  let cards = 0;
+  while (Date.now() < deadline) {
+    const payload = await (await fetch(`${baseUrl}/api/files`)).json() as FilesPayload;
+    const files = payload.files ?? [];
+    cards = files.length;
+    const project = files.find((file) => file.project)?.project;
+    if (project && cards > 0 && (!expectTasks || (payload.tasks ?? []).length > 0)) return { project, cards };
+    await Bun.sleep(2_000);
+  }
+  throw new Error(`scan never produced a board window; last saw ${cards} cards`);
+}
+
+async function stop(server: ChildProcess | null): Promise<void> {
+  if (!server) return;
+  server.kill("SIGTERM");
+  const deadline = Date.now() + 20_000;
+  while (server.exitCode === null && Date.now() < deadline) await Bun.sleep(200);
+  if (server.exitCode === null) server.kill("SIGKILL");
+}
+
+/* ------------------------------------------------------------------------- */
+/* In-page reading: is the requested conversation shown?                      */
+/* ------------------------------------------------------------------------- */
+
+interface Shown {
+  /** The node exists in the board's DOM at all. */
+  present: boolean;
+  /** Its rectangle, in viewport coordinates. */
+  top: number; left: number; right: number; bottom: number;
+  /** The board viewport it is measured against. */
+  canvas: { top: number; left: number; width: number; height: number };
+  /** On screen with enough of its head visible to read. */
+  shown: boolean;
+  /** Its own title, rendered inside the node — content, not just a rectangle. */
+  titleRendered: boolean;
+  presentation: string;
+  camera: string;
+}
+
+/** Runs inside the page; playwright serializes it, so it stays self-contained. */
+function readShown(probe: { path: string; title: string }): Shown {
+  const viewport = document.querySelector<HTMLElement>('[aria-label^="Agent board"]');
+  const empty = {
+    present: false, top: 0, left: 0, right: 0, bottom: 0,
+    canvas: { top: 0, left: 0, width: 0, height: 0 },
+    shown: false, titleRendered: false, presentation: "none", camera: "",
+  };
+  if (!viewport) return empty;
+  const canvasRect = viewport.getBoundingClientRect();
+  const canvas = { top: canvasRect.top, left: canvasRect.left, width: canvasRect.width, height: canvasRect.height };
+  const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale("));
+  const camera = (world as HTMLElement | undefined)?.style.transform ?? "";
+  const node = Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-node]"))
+    .find((candidate) => candidate.getAttribute("data-scheme-node") === probe.path);
+  if (!node) return { ...empty, canvas, camera };
+  const rect = node.getBoundingClientRect();
+  /* Enough of the head — the title row and the lines under it — inside the
+     board's own viewport to be read. A pane taller than the canvas is shown
+     when its top is inside it; one pushed past an edge is not. */
+  const head = Math.min(rect.height, 120);
+  const shown = rect.top >= canvasRect.top
+    && rect.top + head <= canvasRect.bottom
+    && rect.left < canvasRect.right
+    && rect.right > canvasRect.left;
+  return {
+    present: true,
+    top: rect.top, left: rect.left, right: rect.right, bottom: rect.bottom,
+    canvas,
+    shown,
+    titleRendered: (node.textContent ?? "").includes(probe.title.slice(0, 24)),
+    presentation: node.getAttribute("data-scheme-node-presentation") ?? "?",
+    camera,
+  };
+}
+
+/* --- deliberate defects, so the reading is shown going red ----------------- */
+
+/** Push the world down so the requested node leaves the viewport — the reported
+    geometry, reintroduced by hand. */
+function reintroduceOffscreenTarget(): void {
+  const viewport = document.querySelector<HTMLElement>('[aria-label^="Agent board"]');
+  const world = viewport && Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale("));
+  if (world) (world as HTMLElement).style.transform += " translateY(4000px)";
+}
+
+/** Take the node away outright: the state where the board drew nothing for the
+    requested path at all. */
+function reintroduceMissingTarget(path: string): void {
+  Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-node]"))
+    .find((candidate) => candidate.getAttribute("data-scheme-node") === path)
+    ?.remove();
+}
+
+const seedInit = (seed: { project: string }) => {
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("llv_lang", "en");
+  localStorage.setItem("llvSound", "0");
+  localStorage.setItem("llvSchemeMode", "select");
+  /* No saved camera: the first open is the one the operator reported first. */
+  void seed;
+};
+
+const countListRows = () => document.querySelectorAll("[data-conversation-list-row]").length;
+
+/** Scrolls the catalog until the row for `title` is drawn, then returns the
+    point at its own centre — a row the list has not paged to cannot be clicked
+    and must not be judged as if it could. */
+async function findCatalogRow(page: Page, title: string): Promise<{ x: number; y: number; path: string; pages: number }> {
+  const deadline = Date.now() + 120_000;
+  let pages = 0;
+  while (Date.now() < deadline) {
+    const found = await page.evaluate((wanted: string) => {
+      const scroller = document.querySelector<HTMLElement>("[data-conversation-list-scroll]");
+      const view = scroller?.getBoundingClientRect();
+      if (!view) return null;
+      for (const row of Array.from(document.querySelectorAll<HTMLElement>("[data-conversation-list-row]"))) {
+        const button = row.querySelector<HTMLElement>("button");
+        if (!button || !(button.getAttribute("aria-label") ?? "").includes(wanted)) continue;
+        button.scrollIntoView({ block: "center" });
+        const rect = button.getBoundingClientRect();
+        const fresh = scroller!.getBoundingClientRect();
+        if (rect.top < fresh.top || rect.bottom > fresh.bottom) return null;
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2, path: row.getAttribute("data-conversation-list-row") ?? "" };
+      }
+      return null;
+    }, title);
+    if (found) return { ...found, pages };
+    const before = await page.evaluate(countListRows);
+    await page.evaluate(() => {
+      const scroller = document.querySelector<HTMLElement>("[data-conversation-list-scroll]");
+      if (scroller) scroller.scrollTop = scroller.scrollHeight;
+    });
+    await page.mouse.move(800, 600);
+    await page.mouse.wheel(0, 4_000);
+    await page.waitForTimeout(1_200);
+    const after = await page.evaluate(countListRows);
+    pages += 1;
+    if (after === before && pages > 40) break;
+  }
+  throw new Error(`the catalog never drew a row for "${title}"`);
+}
+
+async function clickViewSwitch(page: Page, label: string): Promise<void> {
+  const probe = await page.evaluate((wanted: string) => {
+    const button = document.querySelector<HTMLElement>(`button[aria-pressed][aria-label="${wanted}"]`);
+    if (!button) return null;
+    const rect = button.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }, label);
+  if (!probe) throw new Error(`no «${label}» view switch`);
+  await page.mouse.click(probe.x, probe.y);
+}
+
+/** One catalog open, end to end: switch to the list, page to the archived row,
+    click it, and read what the board did about it. */
+async function openFromCatalog(page: Page, title: string): Promise<{ probe: { x: number; y: number; path: string; pages: number }; shown: Shown }> {
+  await clickViewSwitch(page, "conversations");
+  await page.waitForSelector("[data-conversation-list-rows]", { timeout: 120_000 });
+  const probe = await findCatalogRow(page, title);
+  await page.mouse.click(probe.x, probe.y);
+  await page.waitForSelector("[data-scheme-band]", { timeout: 120_000 });
+  /* Long enough for the band projection to settle at the real camera and
+     viewport — the very interval the defect lived in — and then some. */
+  await page.waitForTimeout(6_000);
+  const shown = await page.evaluate(readShown, { path: probe.path, title });
+  return { probe, shown };
+}
+
+/* ------------------------------------------------------------------------- */
+
+async function main(): Promise<void> {
+  seedHome();
+  const conversations = seedConversations();
+  const failures: string[] = [];
+  const must = (ok: boolean, message: string) => { if (!ok) failures.push(message); };
+
+  const port = 3_000 + (process.pid % 900);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let server: ChildProcess | null = null;
+  let browser: Browser | null = null;
+  const report: Record<string, unknown> = {};
+  try {
+    server = startServer(port);
+    await waitForServer(baseUrl, server);
+    /* The project key is the scan's own, so the corpus is written once the
+       server has named it, and the scan is then waited on again for the tasks
+       and the pipeline that were just written under it. */
+    const { project } = await waitForBoard(baseUrl, false);
+    const targetTaskId = seedTasks(project, conversations);
+    seedPipeline(project, targetTaskId, conversations);
+    const { cards } = await waitForBoard(baseUrl, true);
+    await Bun.sleep(6_000);
+    report.corpus = { conversations: CONVERSATIONS, tasks: TASKS + 1, boardWindowCards: cards, project };
+
+    browser = await chromium.launch({ args: ["--no-sandbox", "--disable-dev-shm-usage"] });
+    const context = await browser.newContext({ viewport: { width: 1600, height: 1000 }, reducedMotion: "no-preference" });
+    await context.addInitScript(seedInit, { project });
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}/#p=${encodeURIComponent(project)}`, { waitUntil: "domcontentloaded", timeout: 120_000 });
+    await page.waitForSelector("[data-scheme-band]", { timeout: 120_000 });
+    await page.waitForTimeout(3_000);
+
+    const bands = await page.evaluate(() => document.querySelectorAll("[data-scheme-band]").length);
+    report.bands = bands;
+    must(bands >= 12, `the board drew ${bands} bands — too few for the layout pressure this issue is about`);
+
+    /* 1. Opened from a board that is already on screen. */
+    const first = await openFromCatalog(page, TARGET_TITLE);
+    report.firstOpen = first;
+    await page.screenshot({ path: path.join(OUT_DIR, "1625-first-open.png") });
+    must(first.shown.present, "the first catalog open drew no node for the requested conversation");
+    must(first.shown.shown, `the first catalog open left the requested conversation off screen (top ${Math.round(first.shown.top)}, canvas ${Math.round(first.shown.canvas.top)}..${Math.round(first.shown.canvas.top + first.shown.canvas.height)})`);
+    must(first.shown.titleRendered, "the requested conversation is on screen but its own content is not rendered in it");
+
+    /* The reading has to be able to go red, or its verdict is worth nothing. */
+    await page.evaluate(reintroduceOffscreenTarget);
+    const offscreen = await page.evaluate(readShown, { path: first.probe.path, title: TARGET_TITLE });
+    must(!offscreen.shown, "the audit did NOT flag a requested conversation pushed out of the viewport — it cannot see that defect");
+    await page.evaluate(reintroduceMissingTarget, first.probe.path);
+    const missing = await page.evaluate(readShown, { path: first.probe.path, title: TARGET_TITLE });
+    must(!missing.present && !missing.shown, "the audit did NOT flag a requested conversation with no node at all");
+    report.redChecks = { offscreen: !offscreen.shown, missing: !missing.present };
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-scheme-band]", { timeout: 120_000 });
+    await page.waitForTimeout(3_000);
+
+    /* 2. The same row again, this time from a freshly loaded tab: the list
+          unmounts and the board MOUNTS with the request already standing,
+          which is the catalog remount the operator reported. */
+    const repeat = await openFromCatalog(page, TARGET_TITLE);
+    report.repeatOpen = repeat;
+    await page.screenshot({ path: path.join(OUT_DIR, "1625-repeat-open.png") });
+    must(repeat.shown.present && repeat.shown.shown, `the repeat catalog open left the requested conversation off screen (top ${Math.round(repeat.shown.top)})`);
+    must(repeat.shown.titleRendered, "the repeat open put the node on screen without its content");
+
+    /* 3. And the operator's own pan wins from there. The camera is read again
+          after more than one scanner poll (10s), so a rule that re-armed on a
+          poll would show up as the camera creeping back. */
+    const parked = await page.evaluate(() => {
+      const viewport = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!;
+      const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale("))!;
+      return (world as HTMLElement).style.transform;
+    });
+    /* Over the canvas gutter, clear of any pane: a wheel inside a scrolling
+       conversation feed scrolls the feed and never reaches the camera, which
+       would leave this case silently unexercised. */
+    const gutter = await page.evaluate(() => {
+      const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
+      return { x: canvas.left + 10, y: canvas.top + canvas.height / 2 };
+    });
+    await page.mouse.move(gutter.x, gutter.y);
+    await page.mouse.wheel(0, 5_000);
+    await page.waitForTimeout(1_500);
+    const panned = await page.evaluate(() => {
+      const viewport = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!;
+      const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale("))!;
+      return (world as HTMLElement).style.transform;
+    });
+    await page.waitForTimeout(25_000);
+    const afterPolls = await page.evaluate(() => {
+      const viewport = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!;
+      const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale("))!;
+      return (world as HTMLElement).style.transform;
+    });
+    report.pan = { parked, panned, afterPolls };
+    await page.screenshot({ path: path.join(OUT_DIR, "1625-after-pan.png") });
+    must(panned !== parked, "the wheel did not move the camera, so the pan case was never exercised");
+    must(afterPolls === panned, `the camera moved on its own after the pan: ${panned} then ${afterPolls}`);
+
+    await page.context().close();
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+    await stop(server);
+  }
+
+  report.failures = failures;
+  fs.writeFileSync(path.join(OUT_DIR, "measurements.json"), JSON.stringify(report, null, 2) + "\n", "utf8");
+  console.log(`measurements: ${path.join(OUT_DIR, "measurements.json")}`);
+  console.log(`frames: ${OUT_DIR}`);
+  if (failures.length) {
+    process.exitCode = 1;
+    console.error(`#1625 acceptance FAILED:\n  ${failures.join("\n  ")}`);
+  } else {
+    console.log("#1625 acceptance passed: the requested conversation is on screen and readable on the first and the repeat catalog open, a later pan is respected, and both red self-checks went red.");
+  }
+}
+
+await main();

--- a/src/components/scheme/SchemeBoard.catalogFocus.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.catalogFocus.dom.test.tsx
@@ -1,0 +1,355 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { BoardTask } from "@/lib/tasks/types";
+import type { FileEntry } from "@/lib/types";
+
+import { SchemeBoard } from "./SchemeBoard";
+
+/**
+ * Catalog opens of historical agents (#1625).
+ *
+ * The desktop catalog is how the operator reaches a conversation the board is
+ * not already showing: clicking a row admits it as an isolated ephemeral manual
+ * node and asks the board to focus it. That request arrives WITH the board —
+ * the list unmounts and the board mounts in the same gesture — so the first
+ * band projection it can be answered against is the provisional one, built at
+ * the initial zoom and viewport width before the camera's own measurements have
+ * reached the layout. On a deep stack of task bands the requested conversation
+ * settles thousands of world pixels away from that provisional rectangle, and a
+ * one-shot aim taken against it left the operator's own conversation far
+ * outside the viewport with nothing left to correct it.
+ *
+ * The composition here is the reported one: many preceding task bands, a
+ * COMPLETED pipeline folded into its band, and the requested conversation a
+ * member of a band near the bottom of the stack — not the generic top-band
+ * agent that the earlier rendered acceptance opened and that passes either way.
+ */
+
+const dom = new Window();
+const VIEWPORT = { x: 0, y: 0, left: 0, top: 0, right: 1600, bottom: 1000, width: 1600, height: 1000 };
+class TestResizeObserver {
+  constructor(private callback: () => void) {}
+  observe(element: HTMLElement) {
+    if (element.getAttribute("aria-label")?.startsWith("Agent board")) {
+      Object.defineProperty(element, "getBoundingClientRect", { configurable: true, value: () => ({ ...VIEWPORT, toJSON() {} }) });
+      queueMicrotask(this.callback);
+    }
+  }
+  unobserve() {}
+  disconnect() {}
+}
+/* happy-dom holds a mutation observer's callback in a WeakRef and nothing else
+   references it, so the first collection after observe() silences it; the board
+   defers rank moves on a later report. Hand it a non-collecting reference for
+   the duration of observe(), exactly as SchemeBoard.bands.dom.test.tsx does. */
+class StrongRef<T> {
+  constructor(private readonly value: T) {}
+  deref(): T { return this.value; }
+}
+class TestMutationObserver extends dom.MutationObserver {
+  observe(...args: Parameters<InstanceType<typeof dom.MutationObserver>["observe"]>) {
+    const collecting = globalThis.WeakRef;
+    (globalThis as unknown as { WeakRef: unknown }).WeakRef = StrongRef;
+    try { super.observe(...args); } finally { (globalThis as unknown as { WeakRef: unknown }).WeakRef = collecting; }
+  }
+}
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = () => ({
+  matches: false, media: "", addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, onchange: null, dispatchEvent: () => false,
+});
+const requestFrame = (callback: FrameRequestCallback) => dom.setTimeout(() => callback(0), 0);
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDivElement: dom.HTMLDivElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent,
+  WheelEvent: dom.WheelEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver,
+  MutationObserver: TestMutationObserver,
+  IntersectionObserver: undefined,
+  requestAnimationFrame: requestFrame,
+  cancelAnimationFrame: (id: number) => dom.clearTimeout(id as never),
+});
+
+const roots = new Set<Root>();
+let previousFetch: typeof fetch | undefined;
+afterEach(() => {
+  if (previousFetch) globalThis.fetch = previousFetch;
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+const settle = async () => {
+  for (let index = 0; index < 8; index += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+
+const PROJECT = "catalog-focus";
+/* Enough bands, with enough members each, that the requested conversation lands
+   thousands of world pixels down the stack — the pressure the operator's board
+   carries and the earlier synthetic capture did not. */
+const BANDS = 15;
+const PER_BAND = 6;
+/* Late enough to be far from the top framing, with bands still below it. */
+const TARGET_BAND = 11;
+const TARGET_MEMBER = 4;
+const pathOf = (band: number, member: number) => `/agents/band-${band}/agent-${member}.jsonl`;
+const TARGET = pathOf(TARGET_BAND, TARGET_MEMBER);
+/* The completed pipeline the operator opened from: folded into its own band,
+   two stages, both finished. */
+const PIPELINE_BAND = TARGET_BAND;
+
+function file(band: number, member: number): FileEntry {
+  const path = pathOf(band, member);
+  return {
+    path,
+    root: "claude-projects",
+    name: `agent-${member}.jsonl`,
+    project: PROJECT,
+    title: `Band ${band} agent ${member}`,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 2,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: `conversation-band-${band}-agent-${member}`,
+    authoritativeTurn: { state: "idle", source: "lifecycle", terminalAt: null },
+  } as FileEntry;
+}
+
+function task(band: number, entries: FileEntry[]): BoardTask {
+  const createdAt = `2026-0${1 + (band % 9)}-1${band % 9}T00:00:00.000Z`;
+  return {
+    id: `task-band-${band}`,
+    project: PROJECT,
+    status: "assigned",
+    text: `Task band ${band}`,
+    placement: "unplaced",
+    assignments: entries.map((entry) => ({ path: entry.path, conversationId: entry.conversationId!, panePid: null, state: "delivered", error: null, at: createdAt })),
+    createdAt,
+    updatedAt: createdAt,
+  } as BoardTask;
+}
+
+/** A finished pipeline whose two stage conversations are members of its band. */
+function completedPipeline(): Pipeline {
+  const role = (id: string) => ({ roleId: id === "implement" ? "builder" : "reviewer", engine: "claude" as const, model: "opus", effort: "high", access: "read-write" as const, promptScaffold: null });
+  const stage = (id: string, next: string | null) => ({ id, kind: "run" as const, prompt: "", next, onFail: null, effectiveRole: role(id) });
+  const attempt = (id: string, member: number) => ({
+    n: 1,
+    state: "passed" as const,
+    effectiveRole: role(id),
+    launchId: `launch-band-${id}`,
+    conversationId: `conversation-band-${TARGET_BAND}-agent-${member}`,
+    sessionId: `session-band-${id}`,
+    agentPath: pathOf(TARGET_BAND, member),
+    paneId: null,
+    flowId: null,
+    startedAt: "2026-02-01T00:00:00.000Z",
+    completedAt: "2026-02-01T01:00:00.000Z",
+    input: null,
+    activatedBy: null,
+    output: "done",
+    verdict: { status: "pass" as const },
+    error: null,
+  });
+  return {
+    id: "band-pipeline",
+    task: `Task band ${PIPELINE_BAND}`,
+    taskIds: [`task-band-${PIPELINE_BAND}`],
+    project: PROJECT,
+    repoDir: "/repo",
+    worktreeDir: "/repo-band-pipeline",
+    branch: "pipeline/band",
+    baseBranch: "main",
+    baseRef: "aaaaaaa",
+    lastPassedCommit: "aaaaaaa",
+    stages: [stage("implement", "review"), stage("review", null)],
+    runs: [
+      { stageId: "implement", attempts: [attempt("implement", TARGET_MEMBER)] },
+      { stageId: "review", attempts: [attempt("review", TARGET_MEMBER + 1)] },
+    ],
+    cursor: { stageId: "review", state: "passed", input: null, activatedBy: null },
+    state: "completed",
+    pausedState: null,
+    stateDetail: null,
+    srcPath: null,
+    srcConversationId: null,
+    createdAt: "2026-02-01T00:00:00.000Z",
+    closedAt: "2026-02-02T00:00:00.000Z",
+  } as unknown as Pipeline;
+}
+
+const files: FileEntry[] = [];
+const tasks: BoardTask[] = [];
+for (let band = 0; band < BANDS; band += 1) {
+  const entries = Array.from({ length: PER_BAND }, (_, member) => file(band, member));
+  files.push(...entries);
+  tasks.push(task(band, entries));
+}
+const pipelines = [completedPipeline()];
+/* What a catalog open leaves behind: the requested transcript admitted on its
+   own, outside every group, exactly as ProjectDashboard's ephemeral pass does. */
+const ISOLATED: ReadonlySet<string> = new Set([TARGET]);
+
+function mountBoard(focus: string | null) {
+  previousFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.add(root);
+  const render = (next: string | null, extraTasks: BoardTask[] = []) => flushSync(() => root.render(
+    <SchemeBoard
+      project={PROJECT}
+      groups={[]}
+      manual={files}
+      files={files}
+      flows={[]}
+      pipelines={pipelines}
+      surfacePipelines={pipelines}
+      tasks={[...tasks, ...extraTasks]}
+      allTasks={[...tasks, ...extraTasks]}
+      drafts={[]}
+      isolatedManualPaths={ISOLATED}
+      focus={next}
+      onSelect={() => {}}
+      onClose={() => {}}
+      onDraftClose={() => {}}
+      onDraftSpawned={() => {}}
+    />,
+  ));
+  render(focus);
+  return { host, render };
+}
+
+const viewportOf = (host: HTMLElement) => host.querySelector('[aria-label^="Agent board"]') as HTMLDivElement;
+const worldOf = (viewport: HTMLElement) => Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
+function cameraOf(viewport: HTMLElement) {
+  const match = /translate\((-?[\d.e+-]+)px, (-?[\d.e+-]+)px\) scale\(([\d.e+-]+)\)/.exec(worldOf(viewport).style.transform)!;
+  return { x: parseFloat(match[1]!), y: parseFloat(match[2]!), z: parseFloat(match[3]!) };
+}
+/** Where the requested conversation actually is on screen, and whether enough
+    of it is there to read — the acceptance question, asked of the DOM. */
+function onScreen(host: HTMLElement, path: string) {
+  const shell = host.querySelector(`[data-scheme-node="${path}"]`) as HTMLElement | null;
+  if (!shell) return null;
+  const cam = cameraOf(viewportOf(host));
+  const match = /translate\((-?[\d.e+-]+)px, (-?[\d.e+-]+)px\)/.exec(shell.style.transform)!;
+  const x = parseFloat(match[1]!);
+  const y = parseFloat(match[2]!);
+  const w = parseFloat(shell.style.width);
+  const h = parseFloat(shell.style.height);
+  const top = cam.y + y * cam.z;
+  const left = cam.x + x * cam.z;
+  return {
+    top,
+    left,
+    /* At least the head: the title row and the first lines under it. */
+    readable: top >= 0 && top + Math.min(h * cam.z, 120) <= VIEWPORT.height && left < VIEWPORT.width && left + w * cam.z > 0,
+    presentation: shell.getAttribute("data-scheme-node-presentation"),
+  };
+}
+function pan(host: HTMLElement, dy: number) {
+  const viewport = viewportOf(host);
+  const wheel = new dom.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: dy });
+  Object.defineProperties(wheel, { clientX: { value: 800 }, clientY: { value: 500 }, ctrlKey: { value: false } });
+  flushSync(() => viewport.dispatchEvent(wheel as unknown as Event));
+}
+
+test("a catalog open that mounts the board with its request standing brings the requested conversation on screen and readable", async () => {
+  const { host } = mountBoard(TARGET);
+  await settle();
+
+  /* The composition really is the reported one: a deep band stack with the
+     completed pipeline's stage conversations folded into a band near the
+     bottom, not a top-band agent under no layout pressure. */
+  expect(host.querySelectorAll("[data-scheme-band]").length).toBe(BANDS);
+  const placed = onScreen(host, TARGET);
+  expect(placed).not.toBeNull();
+  expect(placed!.readable).toBe(true);
+  /* Opened means opened: the requested conversation reads natively, so what is
+     on screen is its content and not a tile of it. */
+  expect(placed!.presentation).toBe("native");
+  /* And it is genuinely deep in the stack — a fixture that stopped placing it
+     far down would pass this test without asking the question. */
+  const shell = host.querySelector(`[data-scheme-node="${TARGET}"]`) as HTMLElement;
+  expect(parseFloat(/translate\((?:-?[\d.e+-]+)px, (-?[\d.e+-]+)px\)/.exec(shell.style.transform)![1]!)).toBeGreaterThan(2500);
+});
+
+test("a repeated catalog open of the same conversation brings it back after the operator has panned away", async () => {
+  const { host, render } = mountBoard(TARGET);
+  await settle();
+  expect(onScreen(host, TARGET)!.readable).toBe(true);
+
+  /* The highlight expires; the operator scrolls the board somewhere else. */
+  render(null);
+  await settle();
+  pan(host, 4_000);
+  await settle();
+  const wandered = onScreen(host, TARGET);
+  expect(wandered === null || !wandered.readable).toBe(true);
+
+  /* Opening the same row again is a new request and moves the view again. */
+  render(TARGET);
+  await settle();
+  expect(onScreen(host, TARGET)!.readable).toBe(true);
+});
+
+test("a pan after the open is respected: a later scanner poll reflows the bands and the camera stays where the operator left it", async () => {
+  const { host, render } = mountBoard(TARGET);
+  await settle();
+  expect(onScreen(host, TARGET)!.readable).toBe(true);
+
+  /* The operator pans away with the request still standing. */
+  pan(host, 3_000);
+  await settle();
+  const parked = cameraOf(viewportOf(host));
+
+  /* A poll delivers another task: every band below it reflows, which is the
+     event the old rule used to answer by pulling the view back. The request is
+     over — the camera must not move on its own. */
+  const extra = task(BANDS, [file(BANDS, 0)]);
+  render(TARGET, [extra]);
+  await settle();
+  const after = cameraOf(viewportOf(host));
+  expect(after.y).toBeCloseTo(parked.y, 3);
+  expect(after.z).toBeCloseTo(parked.z, 6);
+
+  /* And with the highlight expired it stays put through one more reflow. */
+  render(null, [extra]);
+  await settle();
+  expect(cameraOf(viewportOf(host)).y).toBeCloseTo(parked.y, 3);
+});
+
+test("without a request the board opens on the camera the operator left, untouched", async () => {
+  dom.sessionStorage.setItem("llvCam:" + PROJECT, JSON.stringify({ z: 0.58, x: 0, y: -2400 }));
+  const { host } = mountBoard(null);
+  await settle();
+  const cam = cameraOf(viewportOf(host));
+  expect(cam.z).toBeCloseTo(0.58, 6);
+  expect(cam.y).toBeCloseTo(-2400, 3);
+});

--- a/src/components/scheme/useSchemeCamera.focus.dom.test.tsx
+++ b/src/components/scheme/useSchemeCamera.focus.dom.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { SchemeLayout, SchemeRect } from "./layout";
+import { READABLE_Z, useSchemeCamera, type SchemeCamera } from "./useSchemeCamera";
+
+/**
+ * The focus contract at the hook, with no board around it (#1625).
+ *
+ * A focus request asks for a READABLE framing of the conversation it names, not
+ * merely for the node's rectangle to be somewhere in the viewport. Coming back
+ * to a conversation on a board zoomed out to the overview scale therefore has
+ * to zoom in to it, even though the node is technically on screen the whole
+ * time — a chip is not something the operator can read.
+ *
+ * That guarantee is old (`centerOn(node, READABLE_Z)` has always carried it)
+ * and easy to lose to a completion predicate that answers "is it visible?"
+ * before the first move is made, so it is pinned here on its own.
+ */
+
+const dom = new Window();
+const VIEWPORT = { x: 0, y: 0, left: 0, top: 0, right: 1400, bottom: 900, width: 1400, height: 900, toJSON() {} };
+class TestResizeObserver {
+  constructor(private callback: () => void) {}
+  observe(element: HTMLElement) {
+    Object.defineProperty(element, "getBoundingClientRect", { configurable: true, value: () => VIEWPORT });
+    queueMicrotask(this.callback);
+  }
+  unobserve() {}
+  disconnect() {}
+}
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = () => ({
+  matches: false, media: "", addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, onchange: null, dispatchEvent: () => false,
+});
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLDivElement: dom.HTMLDivElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent,
+  WheelEvent: dom.WheelEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver,
+  requestAnimationFrame: (callback: FrameRequestCallback) => dom.setTimeout(() => callback(0), 0),
+  cancelAnimationFrame: (id: number) => dom.clearTimeout(id as never),
+});
+
+let root: Root | null = null;
+let camera: SchemeCamera;
+afterEach(() => {
+  flushSync(() => root?.unmount());
+  root = null;
+  document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+const settle = async () => {
+  for (let index = 0; index < 8; index += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+
+const PROJECT = "focus-zoom";
+/* Small enough, and near enough the origin, that it is already inside the
+   viewport at the overview scale the board opens on. */
+const target = { file: { path: "/target" }, x: 100, y: 100, w: 600, h: 780 };
+const layout = {
+  nodes: [target], drafts: [], groups: [], decks: [], stacks: [], slots: [], regionTasks: [],
+  byPath: new Map<string, SchemeRect>([["/target", target as SchemeRect]]),
+} as unknown as SchemeLayout;
+const world = { x: 0, y: 0, w: 2_000, h: 4_000 };
+
+function Harness({ focus }: { focus: string | null }) {
+  camera = useSchemeCamera({ project: PROJECT, layout, world, mapMode: false, focus, setSelected: () => {} });
+  return <div aria-label="Agent board" ref={camera.viewportRef} />;
+}
+function mount(focus: string | null) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  flushSync(() => root!.render(<Harness focus={focus} />));
+}
+const render = (focus: string | null) => flushSync(() => root!.render(<Harness focus={focus} />));
+
+test("a board restored at the overview scale zooms in to the conversation it opens with", async () => {
+  dom.sessionStorage.setItem(`llvCam:${PROJECT}`, JSON.stringify({ x: 0, y: 0, z: 0.2 }));
+  mount("/target");
+  await settle();
+  expect(camera.cam.z).toBeGreaterThanOrEqual(READABLE_Z);
+});
+
+test("a focus that arrives after the viewport is measured still zooms in, even though the node was already on screen", async () => {
+  dom.sessionStorage.setItem(`llvCam:${PROJECT}`, JSON.stringify({ x: 0, y: 0, z: 0.2 }));
+  mount(null);
+  await settle();
+  /* The saved overview camera is restored untouched, and at it the node's
+     rectangle already overlaps the viewport — «visible» and «readable» are
+     different questions, and only the second one is the request. */
+  expect(camera.cam.z).toBe(0.2);
+  const sx = camera.cam.x + target.x * camera.cam.z;
+  const sy = camera.cam.y + target.y * camera.cam.z;
+  expect(sx).toBeGreaterThanOrEqual(0);
+  expect(sy).toBeGreaterThanOrEqual(0);
+  expect(sx).toBeLessThan(VIEWPORT.width);
+  expect(sy).toBeLessThan(VIEWPORT.height);
+
+  render("/target");
+  await settle();
+  expect(camera.cam.z).toBeGreaterThanOrEqual(READABLE_Z);
+  /* And it is framed, not merely scaled: head near the top of the viewport. */
+  expect(camera.cam.y + target.y * camera.cam.z).toBeGreaterThanOrEqual(0);
+  expect(camera.cam.y + target.y * camera.cam.z).toBeLessThan(VIEWPORT.height / 2);
+});
+
+test("a focus already framed at a readable scale is left exactly where it is", async () => {
+  mount("/target");
+  await settle();
+  const framed = { ...camera.cam };
+  expect(framed.z).toBeGreaterThanOrEqual(READABLE_Z);
+  /* The request is complete. Re-rendering with the SAME focus is not a new
+     request and must not move the camera again. */
+  render("/target");
+  await settle();
+  expect(camera.cam).toEqual(framed);
+});

--- a/src/components/scheme/useSchemeCamera.test.ts
+++ b/src/components/scheme/useSchemeCamera.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { SchemeRect } from "./layout";
-import { cameraMatchesFraming, cameraShowsWorld, centredCamera, fitCameraToRect, hasBoardContent, nodeIsFramed } from "./useSchemeCamera";
+import { READABLE_Z, cameraMatchesFraming, cameraShowsWorld, centredCamera, fitCameraToRect, hasBoardContent, nodeIsFramed } from "./useSchemeCamera";
 
 const empty = { nodes: [], drafts: [] };
 const rect: SchemeRect = { x: 0, y: 0, w: 260, h: 100 };
@@ -119,5 +119,23 @@ describe("nodeIsFramed — what a focus request actually asks (#1625)", () => {
 
   test("an unmeasured viewport frames nothing, so a request stays owed", () => {
     expect(nodeIsFramed(pane, centredCamera(pane, 0.58, view), { w: 1, h: 1 })).toBe(false);
+  });
+
+  test("a board zoomed out to chips frames nothing, however well the rectangle lines up", () => {
+    /* Perfectly placed and entirely on screen — and drawn as a chip, which is
+       located rather than readable. The focus request is not satisfied by it. */
+    const overview = centredCamera(pane, 0.2, view);
+    expect(nodeIsFramed(pane, overview, view)).toBe(false);
+    expect(nodeIsFramed(pane, centredCamera(pane, READABLE_Z, view), view)).toBe(true);
+  });
+
+  test("a sliver hanging off the side is not framed", () => {
+    const framed = centredCamera(pane, 0.58, view);
+    /* One pixel of the pane inside the right edge. */
+    expect(nodeIsFramed(pane, { ...framed, x: framed.x + view.w }, view)).toBe(false);
+    /* And one pixel inside the left edge. */
+    expect(nodeIsFramed(pane, { ...framed, x: framed.x - view.w }, view)).toBe(false);
+    /* Half of it across the edge still reads. */
+    expect(nodeIsFramed(pane, { ...framed, x: framed.x - pane.w * 0.58 / 2 }, view)).toBe(true);
   });
 });

--- a/src/components/scheme/useSchemeCamera.test.ts
+++ b/src/components/scheme/useSchemeCamera.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { SchemeRect } from "./layout";
-import { cameraMatchesFraming, cameraShowsWorld, fitCameraToRect, hasBoardContent } from "./useSchemeCamera";
+import { cameraMatchesFraming, cameraShowsWorld, centredCamera, fitCameraToRect, hasBoardContent, nodeIsFramed } from "./useSchemeCamera";
 
 const empty = { nodes: [], drafts: [] };
 const rect: SchemeRect = { x: 0, y: 0, w: 260, h: 100 };
@@ -81,5 +81,43 @@ describe("a restored camera must still show the world (#1614)", () => {
 
   test("an unmeasured viewport cannot judge and does not veto a restore", () => {
     expect(cameraShowsWorld(savedFarDown, { x: 0, y: 0, w: 1400, h: 9_000 }, { w: 1, h: 1 })).toBe(true);
+  });
+});
+
+describe("nodeIsFramed — what a focus request actually asks (#1625)", () => {
+  const view = { w: 1600, h: 1000 };
+  /* A conversation pane on a band board: taller than it is wide, and at this
+     zoom taller than a third of the viewport. */
+  const pane: SchemeRect = { x: 68.9, y: 9336.9, w: 1034.5, h: 1172.4 };
+
+  test("the camera centredCamera asks for frames the node it was computed from", () => {
+    const cam = centredCamera(pane, 0.58, view);
+    expect(nodeIsFramed(pane, cam, view)).toBe(true);
+    /* Head near the top, so a pane taller than the viewport starts readable. */
+    expect(cam.y + pane.y * cam.z).toBeCloseTo(view.h * 0.08 + 40 * 0.58, 6);
+  });
+
+  test("the rectangle the live board reported, under the camera it reported, is not framed", () => {
+    /* The production reading: the requested conversation sat above the
+       viewport, which is exactly the state the operator could not read. */
+    expect(nodeIsFramed(pane, { x: -8, y: -6438.3056, z: 0.58 }, view)).toBe(false);
+    /* And the aim taken against a provisional projection leaves it below. */
+    expect(nodeIsFramed(pane, { x: -2.88, y: -2813.9344, z: 0.58 }, view)).toBe(false);
+  });
+
+  test("a pane taller than the viewport is framed by its head, not by fitting whole", () => {
+    const tall: SchemeRect = { x: 0, y: 0, w: 600, h: 40_000 };
+    expect(nodeIsFramed(tall, { x: 0, y: 100, z: 0.58 }, view)).toBe(true);
+    /* One pixel of head showing at the bottom edge is not readable. */
+    expect(nodeIsFramed(tall, { x: 0, y: view.h - 1, z: 0.58 }, view)).toBe(false);
+  });
+
+  test("a node pushed off the side is not framed even at the right height", () => {
+    expect(nodeIsFramed(pane, { x: -3_000, y: -5_305.8, z: 0.58 }, view)).toBe(false);
+    expect(nodeIsFramed(pane, { x: view.w + 10, y: -5_305.8, z: 0.58 }, view)).toBe(false);
+  });
+
+  test("an unmeasured viewport frames nothing, so a request stays owed", () => {
+    expect(nodeIsFramed(pane, centredCamera(pane, 0.58, view), { w: 1, h: 1 })).toBe(false);
   });
 });

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -209,19 +209,30 @@ export function centredCamera(node: SchemeRect, z: number, vp: { w: number; h: n
 /** How much of a node's head must be on screen before an opened conversation
     counts as shown: its title row and the first lines under it. */
 const FRAMED_HEAD = 120;
+/** The scale below which a conversation is drawn as a chip rather than as
+    content. `centerOn` has always raised the camera to it for a focus, which is
+    what makes an opened conversation readable rather than merely located. */
+export const READABLE_Z = 0.55;
 
 /**
  * Whether `node` is on screen and readable at this camera — the question a
  * focus request actually asks, as opposed to "did a camera move happen".
- * The head is what is judged: a pane taller than the viewport is framed when
- * its top is inside it, and one pushed past an edge is not.
+ *
+ * Readable is the operative word, and it rules out two things that "the
+ * rectangle overlaps the viewport" would accept: a board zoomed out far enough
+ * that the node is a chip, and a node hanging off an edge with a sliver of
+ * itself showing. The head is what is judged, so a pane taller than the
+ * viewport is framed when its top is inside it and one pushed past an edge is
+ * not.
  */
 export function nodeIsFramed(node: SchemeRect, camera: Camera, vp: { w: number; h: number }): boolean {
   if (!(vp.w > 1) || !(vp.h > 1)) return false;
+  if (camera.z < READABLE_Z) return false;
   const sx = camera.x + node.x * camera.z;
   const sy = camera.y + node.y * camera.z;
   const head = Math.min(node.h * camera.z, FRAMED_HEAD);
-  return sy >= 0 && sy + head <= vp.h && sx < vp.w && sx + node.w * camera.z > 0;
+  const across = Math.min(sx + node.w * camera.z, vp.w) - Math.max(sx, 0);
+  return sy >= 0 && sy + head <= vp.h && across >= Math.min(node.w * camera.z, FRAMED_HEAD);
 }
 
 const sameRect = (a: SchemeRect, b: SchemeRect) => a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
@@ -720,7 +731,12 @@ export function useSchemeCamera({
     const node = layout.byPath.get(aim.path) ?? taskRects?.get(aim.path);
     /* Not placed yet is not a failure: the request is still owed. */
     if (!node) return;
-    if (nodeIsFramed(node, cam, vp)) {
+    /* The FIRST aim is unconditional. An open asks for a readable framing of
+       that conversation, not merely for its rectangle to be somewhere in the
+       viewport, so returning to one from the overview scale still zooms in to
+       it — the guarantee `centerOn(node, 0.55)` has always carried. Only once
+       an aim has been taken does "already shown" complete the request. */
+    if (aim.at && nodeIsFramed(node, cam, vp)) {
       focusAim.current = null;
       return;
     }
@@ -730,12 +746,12 @@ export function useSchemeCamera({
     if (aim.at && sameRect(aim.at, node) && aim.cam && cameraMatchesFraming(cam, aim.cam)) return;
     const rect = viewportRef.current?.getBoundingClientRect();
     if (!rect || !(rect.width > 1) || !(rect.height > 1)) return;
-    const z = Math.min(MAX_Z, Math.max(cam.z, 0.55));
+    const z = Math.min(MAX_Z, Math.max(cam.z, READABLE_Z));
     aim.at = { x: node.x, y: node.y, w: node.w, h: node.h };
     aim.cam = alignX(centredCamera(node, z, { w: rect.width, h: rect.height }));
     aiming.current = true;
     try {
-      centerOn(node, 0.55);
+      centerOn(node, READABLE_Z);
     } finally {
       aiming.current = false;
     }

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -196,6 +196,47 @@ export function cameraShowsWorld(camera: Camera, world: SchemeRect, vp: { w: num
     && overlap(world.y, world.h, camera.y, vp.h) >= Math.min(EDGE_KEEP, world.h * camera.z);
 }
 
+/** Where the camera must sit for `node` to be framed: centred horizontally,
+    its head near the top so a tall pane starts readable instead of split. */
+export function centredCamera(node: SchemeRect, z: number, vp: { w: number; h: number }): Camera {
+  return {
+    z,
+    x: vp.w / 2 - (node.x + node.w / 2) * z,
+    y: Math.min(vp.h / 2 - node.y * z, vp.h * 0.08 - (node.y - 40) * z),
+  };
+}
+
+/** How much of a node's head must be on screen before an opened conversation
+    counts as shown: its title row and the first lines under it. */
+const FRAMED_HEAD = 120;
+
+/**
+ * Whether `node` is on screen and readable at this camera — the question a
+ * focus request actually asks, as opposed to "did a camera move happen".
+ * The head is what is judged: a pane taller than the viewport is framed when
+ * its top is inside it, and one pushed past an edge is not.
+ */
+export function nodeIsFramed(node: SchemeRect, camera: Camera, vp: { w: number; h: number }): boolean {
+  if (!(vp.w > 1) || !(vp.h > 1)) return false;
+  const sx = camera.x + node.x * camera.z;
+  const sy = camera.y + node.y * camera.z;
+  const head = Math.min(node.h * camera.z, FRAMED_HEAD);
+  return sy >= 0 && sy + head <= vp.h && sx < vp.w && sx + node.w * camera.z > 0;
+}
+
+const sameRect = (a: SchemeRect, b: SchemeRect) => a.x === b.x && a.y === b.y && a.w === b.w && a.h === b.h;
+
+/** A focus request the camera still owes the operator: the node it names, the
+    rectangle the last aim was taken against, and the camera that aim asked for.
+    Cleared when the node is framed, when the operator moves the camera, or when
+    a new request replaces it. */
+interface FocusAim {
+  path: string;
+  project: string;
+  at: SchemeRect | null;
+  cam: Camera | null;
+}
+
 /** The deadband used by repeated 0 to escalate from current work to all. */
 export function cameraMatchesFraming(camera: Camera, target: Camera): boolean {
   return Math.abs(camera.z - target.z) <= target.z * 0.01 && Math.abs(camera.x - target.x) <= 4 && Math.abs(camera.y - target.y) <= 4;
@@ -249,6 +290,13 @@ export function useSchemeCamera({
   /* An explicit framing change (fit, focus glide, jump, Return) re-baselines
      the selection anchor instead of being undone by it. */
   const framingRef = useRef(false);
+  /* The standing focus obligation, and the flag that tells the framings below
+     that the move they are being asked for IS that obligation's own aim. */
+  const focusAim = useRef<FocusAim | null>(null);
+  const aiming = useRef(false);
+  const dropFocusAim = useCallback(() => {
+    if (!aiming.current) focusAim.current = null;
+  }, []);
 
   useEffect(() => {
     latestCam.current = cam;
@@ -362,6 +410,9 @@ export function useSchemeCamera({
   const camQueue = useRef<((c: Camera) => Camera)[]>([]);
   const camRaf = useRef<number | null>(null);
   const queueCam = useCallback((fn: (c: Camera) => Camera) => {
+    /* Pan, wheel and pinch: the operator has taken the camera, so a focus
+       request still owed is dropped rather than pulling them back. */
+    dropFocusAim();
     camQueue.current.push(fn);
     if (camRaf.current != null) return;
     camRaf.current = requestAnimationFrame(() => {
@@ -370,7 +421,7 @@ export function useSchemeCamera({
       camQueue.current = [];
       setCam((c) => fns.reduce((acc, apply) => apply(acc), c));
     });
-  }, []);
+  }, [dropFocusAim]);
   useEffect(
     () => () => {
       if (camRaf.current != null) cancelAnimationFrame(camRaf.current);
@@ -428,13 +479,17 @@ export function useSchemeCamera({
   }, [layout.nodes.length, layout.drafts.length, layout.groups.length, taskRects, pipelineRects, world, alignX, lockX]);
 
   const glideTo = useCallback((next: Camera | ((c: Camera) => Camera)) => {
+    /* Every explicit framing but the focus aim itself — fit, jump, Return, a
+       task-panel row — is the operator deciding where to look, and ends any
+       focus request still owed. */
+    dropFocusAim();
     /* Reduced motion: skip the CSS transition — the move lands instantly. */
     if (!reducedMotion()) setGlide(true);
     framingRef.current = true;
     setCam(next);
     if (glideTimer.current) window.clearTimeout(glideTimer.current);
     glideTimer.current = window.setTimeout(() => setGlide(false), 500);
-  }, []);
+  }, [dropFocusAim]);
   useEffect(
     () => () => {
       if (glideTimer.current) window.clearTimeout(glideTimer.current);
@@ -492,14 +547,7 @@ export function useSchemeCamera({
     (node: SchemeRect, zMin: number) => {
       const rect = viewportRef.current?.getBoundingClientRect();
       if (!rect) return;
-      glideTo((c) => {
-        const z = Math.min(MAX_Z, Math.max(c.z, zMin));
-        return alignX({
-          z,
-          x: rect.width / 2 - (node.x + node.w / 2) * z,
-          y: Math.min(rect.height / 2 - node.y * z, rect.height * 0.08 - (node.y - 40) * z),
-        });
-      });
+      glideTo((c) => alignX(centredCamera(node, Math.min(MAX_Z, Math.max(c.z, zMin)), { w: rect.width, h: rect.height })));
     },
     [glideTo, alignX],
   );
@@ -623,19 +671,68 @@ export function useSchemeCamera({
     return () => window.clearTimeout(t);
   }, [cam, project, mapMode]);
 
-  /* An opened conversation glides into view once its node exists in the layout. */
+  /*
+   * An opened conversation is brought into view — and STAYS the camera's
+   * obligation until it actually is (#1625).
+   *
+   * The band projection is built for a camera it is built BEFORE: SchemeBoard
+   * must hand `layoutTaskBands` a zoom and a viewport width, and — the layout
+   * is an input to this hook, not an output of it — those can only be copies of
+   * this camera's own values, applied one commit late. A board that mounts with
+   * a focus already standing (the catalog open: the list unmounts, the board
+   * mounts, the request arrives with it) therefore offers the requested node a
+   * PROVISIONAL rectangle, projected at the initial 0.5 zoom and 1400px width,
+   * and on a tall stack of task bands that rectangle is thousands of world
+   * pixels away from where the node settles. Aiming at it once and calling the
+   * request handled left the operator's own conversation far outside the
+   * viewport, with nothing left to correct it: the saved-camera restore and the
+   * off-world re-fit both ran afterwards and framed something else entirely.
+   *
+   * So the request is an obligation rather than an event. It is discharged the
+   * moment the node is framed — after that a reflow moves the node freely and
+   * the camera stays where the operator left it — and it re-aims only while the
+   * node is NOT framed and either its rectangle or the camera has moved since
+   * the aim, so it answers the settling board without ever chasing a settled
+   * one. `glideTo` drops it, which is every explicit framing the operator can
+   * ask for; so does `queueCam`, which is every pan, wheel and pinch. Neither
+   * the highlight expiring nor a scanner poll can re-arm it — only a new focus
+   * VALUE can, and upstream only a new focus nonce produces one, which is what
+   * keeps this from being the standing follow `focusRequestEdge` removed.
+   */
   const focusHandled = useRef<string | null>(null);
   useEffect(() => {
-    if (!focus) {
-      focusHandled.current = null;
+    if (focus && focusHandled.current !== focus) {
+      focusHandled.current = focus;
+      focusAim.current = { path: focus, project, at: null, cam: null };
+    }
+    /* A repeated open of the same conversation must move the view again, so
+       the handled marker — not the obligation — clears when the request ends. */
+    if (!focus) focusHandled.current = null;
+    const aim = focusAim.current;
+    if (!aim || aim.project !== project) return;
+    const node = layout.byPath.get(aim.path) ?? taskRects?.get(aim.path);
+    /* Not placed yet is not a failure: the request is still owed. */
+    if (!node) return;
+    if (nodeIsFramed(node, cam, vp)) {
+      focusAim.current = null;
       return;
     }
-    if (focusHandled.current === focus) return;
-    const node = layout.byPath.get(focus) ?? taskRects?.get(focus);
-    if (!node) return;
-    focusHandled.current = focus;
-    centerOn(node, 0.55);
-  }, [focus, layout, taskRects, centerOn]);
+    /* Our own aim is already standing and the node is still not framed: there
+       is nothing further this rule can do, and repeating the move would only
+       fight whatever is holding the camera. */
+    if (aim.at && sameRect(aim.at, node) && aim.cam && cameraMatchesFraming(cam, aim.cam)) return;
+    const rect = viewportRef.current?.getBoundingClientRect();
+    if (!rect || !(rect.width > 1) || !(rect.height > 1)) return;
+    const z = Math.min(MAX_Z, Math.max(cam.z, 0.55));
+    aim.at = { x: node.x, y: node.y, w: node.w, h: node.h };
+    aim.cam = alignX(centredCamera(node, z, { w: rect.width, h: rect.height }));
+    aiming.current = true;
+    try {
+      centerOn(node, 0.55);
+    } finally {
+      aiming.current = false;
+    }
+  }, [focus, project, layout, taskRects, cam, vp, centerOn, alignX]);
 
   /* Wheel: plain — pan (shift turns it horizontal); ctrl/cmd (and trackpad
      pinch) — zoom at the cursor. In select mode a wheel over a scrollable

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -709,7 +709,14 @@ export function useSchemeCamera({
        the handled marker — not the obligation — clears when the request ends. */
     if (!focus) focusHandled.current = null;
     const aim = focusAim.current;
-    if (!aim || aim.project !== project) return;
+    if (!aim) return;
+    /* Another project is another board: a request made against the one the
+       operator left is not owed by the one they arrived at, and must not be
+       waiting for them when they come back. */
+    if (aim.project !== project) {
+      focusAim.current = null;
+      return;
+    }
     const node = layout.byPath.get(aim.path) ?? taskRects?.get(aim.path);
     /* Not placed yet is not a failure: the request is still owed. */
     if (!node) return;


### PR DESCRIPTION
Closes #1625.

## What the operator saw

Opening a historical agent from the desktop catalog changed the conversation hash, hydrated the transcript, admitted it as an isolated ephemeral manual node, and placed it in both the authored and the projected layout — and then left it outside the viewport, where it could not be read. Reopening one target left the camera at `{x:-8, y:-6438.3056, z:0.58}` while the requested node's projected rectangle was `{x:68.9655, y:9336.8966, w:1034.4828, h:1172.4138}`; a first open landed on the plain `{0, 0, 0.58}` framing with an unrelated band on screen.

## Cause, measured

The band projection is built for a camera it is built **before**. `SchemeBoard` has to hand `layoutTaskBands` a zoom and a viewport width, and because the layout is an input to `useSchemeCamera` rather than an output of it, those can only be copies of the camera's own values applied one commit late (initial `0.5` zoom, `1400px` width).

A catalog row click is precisely the case where that lag matters: the list unmounts and the board **mounts with the request already standing**. The requested node's first rectangle is therefore the provisional one, and on a deep stack of task bands it is thousands of world pixels from where the node settles. The aim was taken against it once and the request marked handled, so nothing remained to answer the relayout — and the saved-camera restore and the off-world re-fit then ran and framed something else.

Driving the reported board composition reproduces it deterministically: the requested node settles at world `y 9336.8966` while the camera stops **2601px short of it**, and a freshly loaded tab lands on `translate(0px, 0px) scale(0.58)` with **no node drawn at all** for the requested path. Both of those readings are taken from the running production build, not from a model of it.

## Fix

A focus request becomes an obligation rather than an event:

- the camera holds it until the node it names is actually **framed** — its head inside the viewport, with enough of it to read;
- it re-aims only while the node is not framed, and only when the node's rectangle or the camera has moved since the last aim, so it answers a settling board and never chases a settled one;
- it is **discharged** the moment the node is shown — a later reflow moves the node freely and the camera stays put;
- it is **dropped** by `queueCam` (every pan, wheel and pinch) and by `glideTo` (every explicit framing), so the operator always wins;
- neither the highlight expiring nor a scanner poll can re-arm it. Only a new focus value can, and upstream only a new nonce produces one — which is what keeps this from being the standing follow `focusRequestEdge` removed.

No timeout was changed, and no permanent camera follow was added. The saved-camera restore, the off-world recovery, task flags/history/associations and catalog page retention are untouched.

## Coverage

**Mounted board, the composition that failed** (`SchemeBoard.catalogFocus.dom.test.tsx`) — a completed pipeline folded into a band far down a stack of 15, the requested conversation admitted from the catalog:

| case | before | after |
| --- | --- | --- |
| board mounts with the request standing | fail | pass |
| repeat open after the operator panned away | fail | pass |
| pan respected through a later band reflow | fail | pass |
| no request → the saved camera is restored | pass | pass |

**Pure framing questions** (`useSchemeCamera.test.ts`): `centredCamera` frames what it was computed from; the reported rectangle under the reported camera is *not* framed; a pane taller than the viewport is judged by its head; an unmeasured viewport frames nothing, so a request stays owed.

**Rendered acceptance against the production build** (`scripts/capture-issue-1625-catalog-focus.ts`), in a real browser, on a synthetic home with its own `HOME`/XDG dirs/`TMPDIR`/state dir/provider homes. It seeds 260 conversations, 16 tasks and a finished two-stage pipeline, then pages the catalog to the archived row and clicks it — once from a board already on screen, once from a freshly loaded tab.

| reading | with the defect | with the fix |
| --- | --- | --- |
| open from a mounted board | shown, top 134.7 | shown, top 134.7 |
| open from a fresh tab (the catalog remount) | **no node at all**, camera `translate(0px, 0px)` | shown, top 134.7, own content rendered, native presentation |
| camera after a manual pan + 25s (2+ polls) | — | unchanged (`translate(-8px, -8704px)`) |
| red self-check: node pushed off screen | flagged | flagged |
| red self-check: node removed outright | flagged | flagged |

The board viewport in that run is `40..934`, so `top 134.7` is the requested conversation sitting near the top of the canvas with its title and body rendered inside it.

The suite is not run wholesale here: the broad pre-existing failures on this branch's merge base were re-checked file by file at `e552cd6e` and are base-identical (`SchemeBoard.lineage`, `SchemeBoard.pipelineRegions`, `SchemeBoard.pipelineComposition`, `SchemeBoard.stageOverlay`, `ProjectDashboard.selection`), unchanged by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
