### PR TITLE
Add native Codex queue transport adapter

### DIFF
--- a/docs/design/native-codex-queue-adapter.md
+++ b/docs/design/native-codex-queue-adapter.md
@@ -34,6 +34,11 @@ Malformed replies, lost acknowledgements, and unclassified RPC failures throw
 `NativeQueueUncertainError`. The caller must retain its original durable
 operation and payload without automatically repeating the mutation. Error
 causes can contain protocol data and must not be serialized to public surfaces.
+Disposal before transport invocation throws `NativeQueueNotSubmittedError` with
+`outcome: "not-submitted"`: the caller can safely reconsider submission through
+its existing durable workflow and a current adapter. This local outcome is
+distinct from protocol refusal. After transport invocation, disposal and lost
+acknowledgements preserve uncertainty. The adapter never retries either path.
 
 `read()` returns a copy of the last complete observation and its `stale` flag.
 `items: null` means there has been no complete observation. `items: []` means a

--- a/docs/design/native-codex-queue-adapter.md
+++ b/docs/design/native-codex-queue-adapter.md
@@ -1,0 +1,75 @@
+# Native Codex queue adapter
+
+Issue #1632 supplies the transport slice for #1629. Ordinary sends retain their
+default interrupt behavior when the parent integrates this adapter. This slice
+changes no running host, HTTP route, journal, composer, or voice code.
+
+`NativeCodexQueue` binds one native thread to one injected, already initialized
+RPC connection with experimental API negotiation enabled. Its handwritten boundary schemas follow Codex CLI 0.154.0's
+generated v2 queue and input schemas. The native desktop queue implementation
+bundled with app-server 0.153.4 informed coalesced refresh and separate server /
+client identity handling. No bundled implementation is copied here.
+
+The port implements `rpc(method, params, timeoutMs)`, matching the existing host
+call shape. It must correlate request IDs on that connection, unwrap `result`,
+honor the deadline, reject errors, and never retry mutations. Only a correlated
+JSON-RPC error envelope may become `NativeQueueProtocolRefusal`. The current
+host collapses errors to generic exceptions; the integrating stage must preserve
+that distinction at the envelope boundary. Generic errors remain uncertain.
+
+The adapter exposes `add`, `update`, `delete`, `reorder`, and `start` with native
+parameters. `update` takes the prior submission's server ID and client message
+ID plus replacement native input. It verifies both echoed identities. Input
+variants, text spans, media details, paths, URLs, and extra fields are retained.
+The integrating caller owns durable operation identity and prior payload
+snapshots, including attachment retention across editing and recovery.
+
+Every successful mutation returns `{ outcome: "acknowledged", result }`.
+Neither this acknowledgement nor an empty queue establishes delivery. Idle add
+and start can dispatch immediately; repeated `clientUserMessageId` values can
+create separate submissions. A delete result describes native queue removal
+only. A start result validates the turn envelope's ID, status, and items array;
+nested turn items are opaque and provide no canonical delivery proof here.
+Malformed replies, lost acknowledgements, and unclassified RPC failures throw
+`NativeQueueUncertainError`. The caller must retain its original durable
+operation and payload without automatically repeating the mutation. Error
+causes can contain protocol data and must not be serialized to public surfaces.
+
+`read()` returns a copy of the last complete observation and its `stale` flag.
+`items: null` means there has been no complete observation. `items: []` means a
+complete list was observed empty. `refresh()` coalesces concurrent readers and
+walks all pages in order. Defaults are 100 items requested per page, 20 pages,
+2,000 retained submissions, two refresh passes, and a ten-second total read
+deadline. Bounds are configurable. A still-unresolved wire read prevents a new
+read from accumulating behind its expired deadline.
+
+The host forwards notifications to `handleNotification(method, params)`.
+Matching `thread/queue/changed` notifications invalidate the snapshot and return
+`true`, allowing the caller to request a refresh when needed. Idle invalidation
+does no I/O. Notifications during a refresh trigger another bounded pass.
+Errors, missing completion cursors, repeated cursors or submission IDs,
+contradictory identities, pending mutations, and exhausted bounds retain the
+previous snapshot as stale and reject the refresh. Native lists have no thread
+ID or snapshot revision: request correlation and notification forwarding remain
+port responsibilities. The result records observed pages; native pagination
+offers no atomic snapshot guarantee.
+
+Use one adapter for a thread on its current connection. Dispose it on host or
+account replacement and forward no events from the old connection to the new
+adapter. Disposal fences late list results and unsent RPC work. Mutation
+acknowledgements already in flight retain their original thread identity.
+The integrating caller owns subscriptions, capability checks, recovery, and
+canonical settlement. No scheduler or parallel persistence system is added.
+
+Focused verification uses `src/lib/runtime/nativeCodexQueue.test.ts` under the
+Dockerfile's Bun 1.4.0 with lockfile dependencies. Isolate HOME, all three XDG
+roots, CODEX_HOME, CLAUDE_CONFIG_DIR, GEMINI_CLI_HOME, LLV_STATE_DIR, and a short
+TMPDIR; use an allowlisted environment. Set `NATIVE_CODEX_QUEUE_TEST_BINARY` to
+an explicitly selected absolute Codex 0.154.0 executable to enable the optional
+installed-binary fixture. It creates its own credential-free homes and loopback
+synthetic SSE backend, verifies real paginated reads and all mutation responses,
+and drops a successful add acknowledgement as a negative control. It retains
+scratch evidence outside the checkout and stops only its own fixture process.
+Without that variable the binary fixture is explicitly skipped. Hosted checks
+run their existing named suites; they do not automatically include this new
+test file. Parent integration must add its required ongoing CI coverage.

--- a/src/lib/runtime/nativeCodexQueue.test.ts
+++ b/src/lib/runtime/nativeCodexQueue.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, isAbsolute } from "node:path";
+import { createInterface } from "node:readline";
+import {
+  NativeCodexQueue, NativeQueueProtocolRefusal, NativeQueueUncertainError,
+  type NativeQueueRpcPort, type NativeQueueInput,
+} from "./nativeCodexQueue";
+
+const input: NativeQueueInput[] = [{ type: "text", text: "queued input", text_elements: [] }];
+const submission = (id = "submission-a", clientUserMessageId = "client-a") => ({
+  id, clientUserMessageId, input: structuredClone(input),
+});
+
+// Explicit opt-in: never discover a CLI/account or contact an external model.
+// The fixture retains its private scratch directory for inspection.
+const binary = process.env.NATIVE_CODEX_QUEUE_TEST_BINARY;
+test.skipIf(!binary)("installed Codex 0.154.0: adapter pagination and mutation acknowledgements", async () => {
+  if (!binary || !isAbsolute(binary)) throw new Error("An absolute fixture binary is required");
+  const base = mkdtempSync(join(tmpdir(), "nq-"));
+  const env: NodeJS.ProcessEnv & Record<string, string> = { PATH: "/usr/bin:/bin", LANG: "C.UTF-8", NODE_ENV: "test" };
+  for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "CODEX_HOME",
+    "CLAUDE_CONFIG_DIR", "GEMINI_CLI_HOME", "LLV_STATE_DIR", "TMPDIR"]) {
+    env[key] = join(base, key.toLowerCase());
+    mkdirSync(env[key]);
+  }
+  const cwd = join(base, "workspace");
+  mkdirSync(cwd);
+  expect(spawnSync(binary, ["--version"], { env, encoding: "utf8" }).stdout.trim()).toBe("codex-cli 0.154.0");
+  const backendStarted = deferred<void>();
+  const backend = createServer((request, response) => {
+    request.resume();
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.write('event: response.created\ndata: {"type":"response.created","response":{"id":"response_fixture"}}\n\n');
+    backendStarted.resolve();
+    // Hold this synthetic turn until the fixture explicitly interrupts it.
+  });
+  await new Promise<void>((resolve) => backend.listen(0, "127.0.0.1", resolve));
+  const address = backend.address();
+  if (!address || typeof address === "string") throw new Error("Fixture backend did not bind");
+  writeFileSync(join(env.CODEX_HOME, "config.toml"), `model = "fixture-model"
+model_provider = "fixture"
+approval_policy = "never"
+sandbox_mode = "read-only"
+web_search = "disabled"
+[model_providers.fixture]
+name = "Local queue fixture"
+base_url = "http://127.0.0.1:${address.port}/v1"
+wire_api = "responses"
+requires_openai_auth = false
+supports_websockets = false
+[analytics]
+enabled = false
+[features]
+apps = false
+plugins = false
+`);
+  const child = spawn(binary, ["app-server", "--stdio"], { cwd, env, stdio: ["pipe", "pipe", "ignore"] });
+  const pending = new Map<number, { resolve: (value: unknown) => void; reject: (reason: unknown) => void }>();
+  let serial = 0;
+  let adapter: NativeCodexQueue | undefined;
+  const completed = deferred<void>();
+  const lines = createInterface({ input: child.stdout });
+  lines.on("line", (line) => {
+    const message = JSON.parse(line);
+    if (typeof message.id === "number") {
+      const call = pending.get(message.id);
+      if (!call) return;
+      pending.delete(message.id);
+      if (message.error) call.reject(new NativeQueueProtocolRefusal(message.error.code, message.error.message));
+      else call.resolve(message.result);
+    } else {
+      adapter?.handleNotification(message.method, message.params);
+      if (message.method === "turn/completed") completed.resolve();
+    }
+  });
+  const failPending = () => { for (const call of pending.values()) call.reject(new Error("Fixture transport closed")); pending.clear(); };
+  child.on("error", failPending);
+  child.on("exit", failPending);
+  const calls: string[] = [];
+  const rpc: NativeQueueRpcPort["rpc"] = (method, params, timeoutMs) => new Promise((resolve, reject) => {
+    calls.push(method);
+    const requestId = ++serial;
+    const timer = setTimeout(() => { pending.delete(requestId); reject(new Error("Fixture RPC timeout")); }, timeoutMs);
+    pending.set(requestId, {
+      resolve: (value) => { clearTimeout(timer); resolve(value); },
+      reject: (reason) => { clearTimeout(timer); reject(reason); },
+    });
+    child.stdin.write(JSON.stringify({ id: requestId, method, params }) + "\n");
+  });
+  async function wait<T>(promise: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([promise, new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("Fixture event timeout")), 5000);
+      })]);
+    } finally { clearTimeout(timer); }
+  }
+  try {
+    await rpc("initialize", { clientInfo: { name: "queue_adapter_fixture", version: "1" }, capabilities: { experimentalApi: true } }, 5000);
+    child.stdin.write(JSON.stringify({ method: "initialized", params: {} }) + "\n");
+    const started = await rpc("thread/start", { cwd, model: "fixture-model", modelProvider: "fixture", approvalPolicy: "never", sandbox: "read-only" }, 5000) as { thread: { id: string } };
+    const threadId = started.thread.id;
+    adapter = new NativeCodexQueue({ rpc }, threadId, { pageSize: 1 });
+    const active = await rpc("turn/start", { threadId, input, clientUserMessageId: "active-client" }, 5000) as { turn: { id: string } };
+    await wait(backendStarted.promise);
+    const a = (await adapter.add("same-client", input)).result.queuedSubmission;
+    const b = (await adapter.add("same-client", input)).result.queuedSubmission;
+    expect(a.id).not.toBe(b.id);
+    expect(a.clientUserMessageId).toBe(b.clientUserMessageId);
+    const beforePages = calls.filter((method) => method === "thread/queue/list").length;
+    expect((await adapter.refresh()).items?.map((item) => item.id)).toEqual([a.id, b.id]);
+    // An add notification may arrive after its acknowledgement and invalidate
+    // the first pagination pass. Both passes remain bounded and complete.
+    const pageCalls = calls.filter((method) => method === "thread/queue/list").length - beforePages;
+    expect([2, 4]).toContain(pageCalls);
+    const edited: NativeQueueInput[] = [{ type: "text", text: "edited native input", text_elements: [] }];
+    expect((await adapter.update(a, edited)).result.queuedSubmission).toMatchObject({ id: a.id, clientUserMessageId: a.clientUserMessageId, input: edited });
+    expect((await adapter.reorder([b.id, a.id])).outcome).toBe("acknowledged");
+    expect((await adapter.refresh()).items?.map((item) => item.id)).toEqual([b.id, a.id]);
+    expect((await adapter.delete(b.id)).result.deleted).toBe(true);
+    expect((await adapter.delete(b.id)).result.deleted).toBe(false);
+    await expect(adapter.start(a.id)).rejects.toBeInstanceOf(NativeQueueProtocolRefusal);
+    await rpc("turn/interrupt", { threadId, turnId: active.turn.id }, 5000);
+    await wait(completed.promise);
+    const ack = await adapter.start(a.id);
+    expect(ack.outcome).toBe("acknowledged");
+    expect(ack.result.turn.id).toBeTruthy();
+    expect((await adapter.refresh()).items).toEqual([]);
+    // Empty native queue is still unrelated to durable delivery settlement.
+    expect(ack.outcome).toBe("acknowledged");
+    const lostAck = new NativeCodexQueue({ rpc: async (method, params, timeoutMs) => {
+      const result = await rpc(method, params, timeoutMs);
+      if (method === "thread/queue/add") throw new Error("Fixture dropped the successful acknowledgement");
+      return result;
+    } }, threadId, { pageSize: 1 });
+    const beforeAdds = calls.filter((method) => method === "thread/queue/add").length;
+    await expect(lostAck.add("lost-ack-client", input)).rejects.toBeInstanceOf(NativeQueueUncertainError);
+    expect(calls.filter((method) => method === "thread/queue/add").length - beforeAdds).toBe(1);
+    expect((await lostAck.refresh()).items?.filter((item) => item.clientUserMessageId === "lost-ack-client")).toHaveLength(1);
+    lostAck.dispose();
+  } finally {
+    adapter?.dispose();
+    child.stdin.end();
+    const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    const timer = setTimeout(() => child.kill("SIGTERM"), 1000);
+    try { if (child.exitCode === null) await wait(exited); }
+    finally { clearTimeout(timer); lines.close(); backend.closeAllConnections(); backend.close(); }
+  }
+}, 30_000);
+const page = (...data: ReturnType<typeof submission>[]) => ({ data, nextCursor: null });
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+function fixture(replies: Array<unknown | (() => unknown)> = [], options = {}) {
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const port: NativeQueueRpcPort = { rpc: async (method, params) => {
+    calls.push({ method, params: structuredClone(params) });
+    if (!replies.length) throw new Error("unexpected RPC");
+    const reply = replies.shift();
+    if (reply instanceof Error) throw reply;
+    return typeof reply === "function" ? reply() : reply;
+  } };
+  return { queue: new NativeCodexQueue(port, "thread-a", options), calls, replies };
+}
+
+describe("native queue reads", () => {
+  test("coalesces callers and commits all pages with opaque cursors in order", async () => {
+    const pending = deferred<unknown>();
+    const { queue, calls } = fixture([() => pending.promise, page(submission("submission-b"))]);
+    const first = queue.refresh();
+    const second = queue.refresh();
+    expect(first).toBe(second);
+    expect(queue.read()).toEqual({ threadId: "thread-a", items: null, stale: true });
+    pending.resolve({ data: [submission()], nextCursor: "opaque:2" });
+    expect((await first).items?.map((s) => s.id)).toEqual(["submission-a", "submission-b"]);
+    expect(calls).toEqual([
+      { method: "thread/queue/list", params: { threadId: "thread-a", cursor: null, limit: 100 } },
+      { method: "thread/queue/list", params: { threadId: "thread-a", cursor: "opaque:2", limit: 100 } },
+    ]);
+    expect(queue.read().stale).toBe(false);
+  });
+
+  const invalidPages = [
+    null, {}, { data: null }, { data: [] }, { data: [], nextCursor: 4 },
+    { data: [], nextCursor: "" }, { data: [], nextCursor: null, threadId: "thread-b" },
+    page({ ...submission(), id: "" }), page({ ...submission(), clientUserMessageId: "" }),
+    page({ ...submission(), input: [{ type: "image" }] } as never),
+    page({ ...submission(), threadId: "thread-b" } as never),
+    page(submission(), submission()),
+  ];
+  test.each(invalidPages)("malformed page cannot erase a complete snapshot: %j", async (bad) => {
+    const { queue } = fixture([page(submission()), bad]);
+    await queue.refresh();
+    await expect(queue.refresh()).rejects.toThrow();
+    expect(queue.read()).toEqual({ threadId: "thread-a", items: [submission()], stale: true });
+  });
+
+  test("partial results and RPC errors retain the last complete snapshot", async () => {
+    const { queue } = fixture([page(submission()), { data: [], nextCursor: "next" }, new Error("lost page")]);
+    await queue.refresh();
+    await expect(queue.refresh()).rejects.toThrow("lost page");
+    expect(queue.read().items).toEqual([submission()]);
+    expect(queue.read().stale).toBe(true);
+  });
+
+  test.each(["cursor", "duplicate", "pages", "items", "identity"])("rejects bounded/inconsistent pagination: %s", async (kind) => {
+    const next = { data: [submission("submission-b")], nextCursor: "next" };
+    const replies = kind === "identity" ? [page(submission("submission-a", "different-client"))]
+      : kind === "items" ? [page(submission(), submission("submission-b"))]
+      : [next, kind === "duplicate" ? page(submission("submission-b")) : { data: [], nextCursor: "next" }];
+    const { queue, calls } = fixture([page(submission()), ...replies], {
+      ...(kind === "pages" ? { maxPages: 1 } : {}), ...(kind === "items" ? { maxItems: 1 } : {}),
+    });
+    await queue.refresh();
+    await expect(queue.refresh()).rejects.toThrow();
+    expect(queue.read().items).toEqual([submission()]);
+    expect(queue.read().stale).toBe(true);
+    expect(calls.length).toBeLessThanOrEqual(3);
+  });
+
+  test("notifications invalidate only the bound thread and coalesce a fresh pass", async () => {
+    const pending = deferred<unknown>();
+    const started = deferred<void>();
+    const { queue, calls } = fixture([page(submission()), () => { started.resolve(); return pending.promise; }, page(submission("fresh"))]);
+    await queue.refresh();
+    expect(queue.handleNotification("thread/queue/changed", { threadId: "thread-b" })).toBe(false);
+    expect(queue.handleNotification("turn/started", { threadId: "thread-a" })).toBe(false);
+    expect(queue.handleNotification("thread/queue/changed", {})).toBe(false);
+    expect(queue.read().stale).toBe(false);
+    expect(queue.handleNotification("thread/queue/changed", { threadId: "thread-a" })).toBe(true);
+    expect(calls).toHaveLength(1);
+    const refresh = queue.refresh();
+    await started.promise;
+    for (let i = 0; i < 50; i++) queue.handleNotification("thread/queue/changed", { threadId: "thread-a" });
+    pending.resolve(page());
+    expect((await refresh).items?.[0].id).toBe("fresh");
+    expect(calls).toHaveLength(3);
+  });
+
+  test("invalidation storms stop at the refresh-pass bound", async () => {
+    const { queue, replies, calls } = fixture([page(submission())], { maxRefreshPasses: 2 });
+    await queue.refresh();
+    const changing = () => { queue.invalidate(); return page(); };
+    replies.push(changing, changing);
+    await expect(queue.refresh()).rejects.toThrow();
+    expect(calls).toHaveLength(3);
+    expect(queue.read()).toEqual({ threadId: "thread-a", items: [submission()], stale: true });
+  });
+
+  test("a hanging port is time bounded and cannot accumulate overlapping reads", async () => {
+    const pending = deferred<unknown>();
+    const { queue, calls, replies } = fixture([() => pending.promise], { timeoutMs: 10 });
+    await expect(queue.refresh()).rejects.toThrow();
+    await expect(queue.refresh()).rejects.toThrow();
+    expect(calls).toHaveLength(1);
+    pending.resolve(page(submission("late")));
+    await pending.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(queue.read().items).toBeNull();
+    replies.push(page(submission()));
+    await queue.refresh();
+    expect(queue.read().items).toEqual([submission()]);
+  });
+
+  test("snapshot copies cannot corrupt retained inputs or identity", async () => {
+    const { queue } = fixture([page(submission())]);
+    const snapshot = await queue.refresh();
+    snapshot.items![0].id = "changed";
+    snapshot.items![0].input.length = 0;
+    expect(queue.read().items).toEqual([submission()]);
+  });
+
+  test("a mutation between list request and response forces a complete new read", async () => {
+    const pending = deferred<unknown>();
+    const started = deferred<void>();
+    const { queue, calls } = fixture([
+      page(submission()), () => { started.resolve(); return pending.promise; },
+      { queuedSubmission: submission("submission-b") }, page(submission("submission-b")),
+    ]);
+    await queue.refresh();
+    const refreshing = queue.refresh();
+    await started.promise;
+    await queue.add("client-a", input);
+    pending.resolve(page());
+    expect((await refreshing).items).toEqual([submission("submission-b")]);
+    expect(calls).toHaveLength(4);
+  });
+
+  test("disposing during pagination preserves the stale snapshot and rejects late pages", async () => {
+    const pending = deferred<unknown>();
+    const started = deferred<void>();
+    const { queue } = fixture([page(submission()), () => { started.resolve(); return pending.promise; }]);
+    await queue.refresh();
+    const refreshing = queue.refresh();
+    await started.promise;
+    queue.dispose();
+    pending.resolve(page());
+    await expect(refreshing).rejects.toThrow("disposed");
+    expect(queue.read()).toEqual({ threadId: "thread-a", items: [submission()], stale: true });
+  });
+});
+
+describe("native queue mutations", () => {
+  test("preserves all native input variants and separate server/client identities through add and update", async () => {
+    const media: NativeQueueInput[] = [
+      { type: "text", text: "é", text_elements: [{ byteRange: { start: 0, end: 2 }, placeholder: null }] },
+      { type: "image", url: "data:image/png;base64,AA==", detail: "original" },
+      { type: "localImage", path: "fixtures/image.png", detail: null },
+      { type: "audio", url: "data:audio/wav;base64,AA==" },
+      { type: "localAudio", path: "fixtures/audio.wav" },
+      { type: "skill", name: "example", path: "fixtures/SKILL.md" },
+      { type: "mention", name: "document", path: "fixtures/document.md" },
+    ];
+    const queuedSubmission = { ...submission(), input: media };
+    const { queue, calls } = fixture([{ queuedSubmission }, { queuedSubmission }]);
+    expect(await queue.add("client-a", media)).toEqual({ outcome: "acknowledged", result: { queuedSubmission } });
+    expect(await queue.update(queuedSubmission, media)).toEqual({ outcome: "acknowledged", result: { queuedSubmission } });
+    expect(calls).toEqual([
+      { method: "thread/queue/add", params: { threadId: "thread-a", clientUserMessageId: "client-a", input: media } },
+      { method: "thread/queue/update", params: { threadId: "thread-a", queuedSubmissionId: "submission-a", input: media } },
+    ]);
+    expect(queue.read()).toEqual({ threadId: "thread-a", items: null, stale: true });
+  });
+
+  test("duplicate client IDs remain separate native submissions; empty queue does not settle either", async () => {
+    const { queue, calls } = fixture([{ queuedSubmission: submission() }, { queuedSubmission: submission("submission-b") }, page()]);
+    const first = await queue.add("client-a", input);
+    const second = await queue.add("client-a", input);
+    expect(first.result.queuedSubmission.id).not.toBe(second.result.queuedSubmission.id);
+    expect(first.outcome).toBe("acknowledged");
+    expect(second.outcome).toBe("acknowledged");
+    expect((await queue.refresh()).items).toEqual([]);
+    expect(calls).toHaveLength(3);
+  });
+
+  test("delete/reorder/start use native IDs, optional start selector, and native acknowledgements", async () => {
+    const turn = { id: "turn-a", status: "inProgress" as const, items: [], error: null };
+    const { queue, calls } = fixture([{ deleted: false }, {}, { turn }, { turn }]);
+    expect((await queue.delete("submission-a")).result).toEqual({ deleted: false });
+    expect((await queue.reorder(["submission-b", "submission-a"])).outcome).toBe("acknowledged");
+    expect((await queue.start("submission-a")).result).toEqual({ turn });
+    expect((await queue.start()).outcome).toBe("acknowledged");
+    expect(calls.map((c) => c.params)).toEqual([
+      { threadId: "thread-a", queuedSubmissionId: "submission-a" },
+      { threadId: "thread-a", queuedSubmissionIds: ["submission-b", "submission-a"] },
+      { threadId: "thread-a", queuedSubmissionId: "submission-a" }, { threadId: "thread-a" },
+    ]);
+  });
+
+  test.each(["add", "update", "delete", "reorder", "start"] as const)("lost %s acknowledgement is uncertain and never retried", async (method) => {
+    const { queue, calls } = fixture([new Error("connection lost after write")]);
+    const action = () => method === "add" ? queue.add("client-a", input)
+      : method === "update" ? queue.update(submission(), input)
+      : method === "delete" ? queue.delete("submission-a")
+      : method === "reorder" ? queue.reorder(["submission-a"]) : queue.start("submission-a");
+    const error = await action().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(NativeQueueUncertainError);
+    expect(error).toMatchObject({ outcome: "uncertain", method: `thread/queue/${method}`, threadId: "thread-a" });
+    expect(calls).toHaveLength(1);
+    expect(queue.read().stale).toBe(true);
+  });
+
+  test.each([
+    ["add", { queuedSubmission: submission("submission-a", "wrong-client") }],
+    ["update", { queuedSubmission: submission("wrong-server-id") }],
+    ["update", { queuedSubmission: submission("submission-a", "wrong-client") }],
+    ["delete", {}], ["delete", { deleted: "true" }], ["reorder", null],
+    ["reorder", { error: { code: -32602, message: "wrapped error" } }],
+    ["add", { threadId: "thread-b", queuedSubmission: submission() }],
+    ["start", { turn: { id: "turn-a", status: "inProgress", items: [], threadId: "thread-b" } }],
+    ["start", { turn: { id: "", status: "inProgress", items: [] } }],
+    ["start", { turn: { id: "turn-a", status: "invented", items: [] } }],
+    ["start", { turn: { id: "turn-a", status: "inProgress" } }],
+  ])("malformed or mismatched %s acknowledgement is uncertain", async (method, reply) => {
+    const { queue } = fixture([reply]);
+    const action = method === "add" ? queue.add("client-a", input)
+      : method === "update" ? queue.update(submission(), input)
+      : method === "delete" ? queue.delete("submission-a")
+      : method === "reorder" ? queue.reorder([]) : queue.start();
+    await expect(action).rejects.toBeInstanceOf(NativeQueueUncertainError);
+  });
+
+  test("only an explicit protocol refusal is classified as refused", async () => {
+    const refusal = new NativeQueueProtocolRefusal(-32602, "queue is empty");
+    const { queue, calls } = fixture([refusal, Object.assign(new Error("socket"), { code: -32602 })]);
+    await expect(queue.start()).rejects.toBe(refusal);
+    await expect(queue.start()).rejects.toBeInstanceOf(NativeQueueUncertainError);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("timeout remains uncertain after a late acknowledgement", async () => {
+    const pending = deferred<unknown>();
+    const { queue, calls } = fixture([() => pending.promise], { timeoutMs: 10 });
+    const error = await queue.add("client-a", input).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(NativeQueueUncertainError);
+    pending.resolve({ queuedSubmission: submission() });
+    await pending.promise;
+    expect(queue.read().items).toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("an unresolved wire mutation keeps reads stale beyond the caller deadline", async () => {
+    const pending = deferred<unknown>();
+    const { queue, calls, replies } = fixture([page(submission()), () => pending.promise], { timeoutMs: 10 });
+    await queue.refresh();
+    await expect(queue.add("client-a", input)).rejects.toBeInstanceOf(NativeQueueUncertainError);
+    await expect(queue.refresh()).rejects.toThrow("mutation is still pending");
+    expect(calls).toHaveLength(2);
+    pending.resolve({ queuedSubmission: submission("submission-b") });
+    await pending.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(queue.read().stale).toBe(true);
+    replies.push(page(submission("submission-b")));
+    expect((await queue.refresh()).items).toEqual([submission("submission-b")]);
+  });
+
+  test("an in-flight mutation prevents a read from claiming a fresh queue", async () => {
+    const pending = deferred<unknown>();
+    const { queue, replies } = fixture([page(submission()), () => pending.promise]);
+    await queue.refresh();
+    const adding = queue.add("client-a", input);
+    await expect(queue.refresh()).rejects.toThrow();
+    expect(queue.read()).toEqual({ threadId: "thread-a", items: [submission()], stale: true });
+    pending.resolve({ queuedSubmission: submission("submission-b") });
+    await adding;
+    replies.push(page(submission("submission-b")));
+    expect((await queue.refresh()).stale).toBe(false);
+  });
+
+  test("local validation and disposal cannot send mutations", async () => {
+    const { queue, calls } = fixture();
+    await expect(queue.add("", input)).rejects.toThrow();
+    await expect(queue.update(submission(), [{ type: "audio" }] as never)).rejects.toThrow();
+    await expect(queue.reorder(["duplicate", "duplicate"])).rejects.toThrow();
+    queue.dispose();
+    await expect(queue.start()).rejects.toThrow();
+    await expect(queue.refresh()).rejects.toThrow();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("disposal before the RPC microtask prevents an unsent mutation", async () => {
+    const { queue, calls } = fixture([{ queuedSubmission: submission() }]);
+    const adding = queue.add("client-a", input);
+    queue.dispose();
+    await expect(adding).rejects.toThrow();
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/lib/runtime/nativeCodexQueue.test.ts
+++ b/src/lib/runtime/nativeCodexQueue.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { join, isAbsolute } from "node:path";
 import { createInterface } from "node:readline";
 import {
-  NativeCodexQueue, NativeQueueProtocolRefusal, NativeQueueUncertainError,
+  NativeCodexQueue, NativeQueueProtocolRefusal, NativeQueueUncertainError, NativeQueueNotSubmittedError,
   type NativeQueueRpcPort, type NativeQueueInput,
 } from "./nativeCodexQueue";
 
@@ -440,7 +440,7 @@ describe("native queue mutations", () => {
     await expect(queue.update(submission(), [{ type: "audio" }] as never)).rejects.toThrow();
     await expect(queue.reorder(["duplicate", "duplicate"])).rejects.toThrow();
     queue.dispose();
-    await expect(queue.start()).rejects.toThrow();
+    await expect(queue.start()).rejects.toBeInstanceOf(NativeQueueNotSubmittedError);
     await expect(queue.refresh()).rejects.toThrow();
     expect(calls).toHaveLength(0);
   });
@@ -449,7 +449,31 @@ describe("native queue mutations", () => {
     const { queue, calls } = fixture([{ queuedSubmission: submission() }]);
     const adding = queue.add("client-a", input);
     queue.dispose();
-    await expect(adding).rejects.toThrow();
+    const error = await adding.catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(NativeQueueNotSubmittedError);
+    expect(error).toMatchObject({ outcome: "not-submitted", method: "thread/queue/add", threadId: "thread-a" });
     expect(calls).toHaveLength(0);
+  });
+
+  test("disposal after transport invocation leaves a lost acknowledgement uncertain", async () => {
+    const pending = deferred<unknown>();
+    const started = deferred<void>();
+    const { queue, calls } = fixture([() => { started.resolve(); return pending.promise; }]);
+    const adding = queue.add("client-a", input);
+    await started.promise;
+    queue.dispose();
+    pending.reject(new Error("connection lost after write"));
+    await expect(adding).rejects.toBeInstanceOf(NativeQueueUncertainError);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("a synchronous transport exception cannot claim local non-submission", async () => {
+    let calls = 0;
+    const queue = new NativeCodexQueue({ rpc: () => {
+      calls++;
+      throw new NativeQueueNotSubmittedError("thread/queue/add", "thread-a");
+    } }, "thread-a");
+    await expect(queue.add("client-a", input)).rejects.toBeInstanceOf(NativeQueueUncertainError);
+    expect(calls).toBe(1);
   });
 });

--- a/src/lib/runtime/nativeCodexQueue.ts
+++ b/src/lib/runtime/nativeCodexQueue.ts
@@ -1,0 +1,259 @@
+import { z } from "zod";
+
+// Handwritten boundary schemas from Codex 0.154.0's generated v2 queue schemas.
+// Keep optional fields optional and preserve extra fields and attachment bytes.
+const id = z.string().min(1);
+const detail = z.enum(["auto", "low", "high", "original"]).nullable().optional();
+const inputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text"), text: z.string(), text_elements: z.array(z.object({
+    byteRange: z.object({ start: z.number().int().nonnegative(), end: z.number().int().nonnegative() }).passthrough(),
+    placeholder: z.string().nullable().optional(),
+  }).passthrough()).optional() }).passthrough(),
+  z.object({ type: z.literal("image"), url: z.string(), detail }).passthrough(),
+  z.object({ type: z.literal("localImage"), path: z.string(), detail }).passthrough(),
+  z.object({ type: z.literal("audio"), url: z.string() }).passthrough(),
+  z.object({ type: z.literal("localAudio"), path: z.string() }).passthrough(),
+  z.object({ type: z.literal("skill"), name: z.string(), path: z.string() }).passthrough(),
+  z.object({ type: z.literal("mention"), name: z.string(), path: z.string() }).passthrough(),
+]);
+const submissionSchema = z.object({ id, clientUserMessageId: id, input: z.array(inputSchema) }).passthrough();
+const listSchema = z.object({
+  data: z.array(submissionSchema),
+  // Native emits explicit null on the last page. Missing completion evidence
+  // must not clear a previously populated cache, even though the schema permits omission.
+  nextCursor: id.nullable(),
+}).passthrough();
+const submissionResponse = z.object({ queuedSubmission: submissionSchema }).passthrough();
+const startResponse = z.object({ turn: z.object({
+  id, status: z.enum(["completed", "interrupted", "failed", "inProgress"]), items: z.array(z.unknown()),
+}).passthrough() }).passthrough();
+
+export type NativeQueueInput = z.infer<typeof inputSchema>;
+export type NativeQueuedSubmission = z.infer<typeof submissionSchema>;
+export type NativeQueueAcknowledgement<T> = { outcome: "acknowledged"; result: T };
+export type NativeQueueSnapshot = {
+  threadId: string;
+  /** null means no complete read has succeeded; [] is a complete empty observation. */
+  items: NativeQueuedSubmission[] | null;
+  stale: boolean;
+};
+
+export interface NativeQueueRpcPort {
+  /**
+   * Existing host-style RPC: correlate replies to request IDs on one connection,
+   * unwrap result, and reject errors. Never retry a mutation. Honor timeoutMs
+   * and discard late responses. Map genuine JSON-RPC error envelopes to
+   * NativeQueueProtocolRefusal; unclassified exceptions remain uncertain.
+   */
+  rpc(method: string, params: Record<string, unknown>, timeoutMs: number): Promise<unknown>;
+}
+
+/** Construct only for an authoritative error envelope correlated by the port. */
+export class NativeQueueProtocolRefusal extends Error {
+  readonly outcome = "refused";
+  constructor(readonly code: number, message: string) {
+    super(message);
+    this.name = "NativeQueueProtocolRefusal";
+  }
+}
+
+/** The caller retains its durable operation and payload; this grants no retry. */
+export class NativeQueueUncertainError extends Error {
+  readonly outcome = "uncertain";
+  constructor(readonly method: string, readonly threadId: string, readonly cause: unknown) {
+    super("Native queue mutation outcome is uncertain");
+    this.name = "NativeQueueUncertainError";
+  }
+}
+
+type Limits = { pageSize: number; maxPages: number; maxItems: number; maxRefreshPasses: number; timeoutMs: number };
+
+/**
+ * One thread on one RPC connection. Replace the adapter on host/account change.
+ * No scheduler, persistence, automatic mutation retry, or delivery settlement.
+ */
+export class NativeCodexQueue {
+  private readonly limits: Limits;
+  private items: NativeQueuedSubmission[] | null = null;
+  private stale = true;
+  private revision = 0;
+  private disposed = false;
+  private mutations = 0;
+  private refreshPromise: Promise<NativeQueueSnapshot> | null = null;
+  // Keep an unresolved wire read fenced even if our own deadline expired.
+  private wireRead: Promise<unknown> | null = null;
+
+  constructor(private readonly port: NativeQueueRpcPort, readonly threadId: string, limits: Partial<Limits> = {}) {
+    id.parse(threadId);
+    this.limits = { pageSize: 100, maxPages: 20, maxItems: 2000, maxRefreshPasses: 2, timeoutMs: 10_000, ...limits };
+    for (const value of Object.values(this.limits)) {
+      if (!Number.isSafeInteger(value) || value <= 0 || value > 2_147_483_647) throw new Error("Invalid native queue bound");
+    }
+  }
+
+  read(): NativeQueueSnapshot {
+    return { threadId: this.threadId, items: structuredClone(this.items), stale: this.stale };
+  }
+
+  invalidate(): void {
+    this.revision++;
+    this.stale = true;
+  }
+
+  /** The integrating host forwards notifications; this does no unsolicited I/O. */
+  handleNotification(method: string, params: unknown): boolean {
+    if (this.disposed || method !== "thread/queue/changed" || !params || typeof params !== "object"
+      || !("threadId" in params) || params.threadId !== this.threadId) return false;
+    this.invalidate();
+    return true;
+  }
+
+  refresh(): Promise<NativeQueueSnapshot> {
+    if (this.disposed) return Promise.reject(new Error("Native queue adapter is disposed"));
+    if (this.refreshPromise) return this.refreshPromise;
+    this.stale = true;
+    // Defer work so even a synchronous notification from the port sees the latch.
+    this.refreshPromise = Promise.resolve().then(() => this.readAllPages()).finally(() => { this.refreshPromise = null; });
+    return this.refreshPromise;
+  }
+
+  private async readAllPages(): Promise<NativeQueueSnapshot> {
+    const deadline = Date.now() + this.limits.timeoutMs;
+    for (let pass = 0; pass < this.limits.maxRefreshPasses; pass++) {
+      this.assertOpen();
+      if (this.mutations) throw new Error("Native queue mutation is still pending");
+      const revision = this.revision;
+      const data: NativeQueuedSubmission[] = [];
+      const seenIds = new Set<string>();
+      const seenCursors = new Set<string>();
+      const previous = new Map(this.items?.map((item) => [item.id, item.clientUserMessageId]));
+      let cursor: string | null = null;
+      for (let page = 0; page < this.limits.maxPages; page++) {
+        if (this.wireRead) throw new Error("Previous native queue read has not settled");
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) throw new Error("Native queue refresh deadline exceeded");
+        const wire = Promise.resolve().then(() => {
+          this.assertOpen();
+          return this.port.rpc("thread/queue/list", { threadId: this.threadId, cursor, limit: this.limits.pageSize }, remaining);
+        });
+        this.wireRead = wire;
+        const clear = () => { if (this.wireRead === wire) this.wireRead = null; };
+        void wire.then(clear, clear);
+        const response = listSchema.parse(await this.withDeadline(wire, remaining));
+        this.assertOpen();
+        this.checkThread(response);
+        if (data.length + response.data.length > this.limits.maxItems) throw new Error("Native queue item bound exceeded");
+        for (const item of response.data) {
+          this.checkThread(item);
+          if (seenIds.has(item.id)) throw new Error("Duplicate native submission identity");
+          if (previous.has(item.id) && previous.get(item.id) !== item.clientUserMessageId) throw new Error("Native submission identity changed");
+          seenIds.add(item.id);
+          data.push(item);
+        }
+        cursor = response.nextCursor;
+        if (cursor === null) {
+          if (this.mutations) throw new Error("Native queue mutation is still pending");
+          if (revision !== this.revision) break;
+          this.items = structuredClone(data);
+          this.stale = false;
+          return this.read();
+        }
+        if (seenCursors.has(cursor)) throw new Error("Native queue cursor repeated");
+        seenCursors.add(cursor);
+        if (page + 1 === this.limits.maxPages) throw new Error("Native queue page bound exceeded");
+      }
+    }
+    throw new Error("Native queue changed during every bounded refresh pass");
+  }
+
+  async add(clientUserMessageId: string, input: NativeQueueInput[]) {
+    id.parse(clientUserMessageId);
+    return this.mutate("add", { clientUserMessageId, input: z.array(inputSchema).parse(input) }, (value) => {
+      const result = submissionResponse.parse(value);
+      this.checkThread(result.queuedSubmission);
+      if (result.queuedSubmission.clientUserMessageId !== clientUserMessageId) throw new Error("Native client message identity mismatch");
+      return result;
+    });
+  }
+
+  /** Pass the prior server AND client identity. Updating preserves the client ID. */
+  async update(identity: Pick<NativeQueuedSubmission, "id" | "clientUserMessageId">, input: NativeQueueInput[]) {
+    const queuedSubmissionId = id.parse(identity.id);
+    const clientUserMessageId = id.parse(identity.clientUserMessageId);
+    return this.mutate("update", { queuedSubmissionId, input: z.array(inputSchema).parse(input) }, (value) => {
+      const result = submissionResponse.parse(value);
+      this.checkThread(result.queuedSubmission);
+      if (result.queuedSubmission.id !== queuedSubmissionId || result.queuedSubmission.clientUserMessageId !== clientUserMessageId) {
+        throw new Error("Native submission identity mismatch");
+      }
+      return result;
+    });
+  }
+
+  async delete(queuedSubmissionId: string) {
+    return this.mutate("delete", { queuedSubmissionId: id.parse(queuedSubmissionId) },
+      (value) => z.object({ deleted: z.boolean() }).passthrough().parse(value));
+  }
+
+  async reorder(queuedSubmissionIds: string[]) {
+    const ids = z.array(id).parse(queuedSubmissionIds);
+    if (new Set(ids).size !== ids.length) throw new Error("Duplicate native submission identity");
+    return this.mutate("reorder", { queuedSubmissionIds: ids }, (value) => z.object({}).strict().parse(value));
+  }
+
+  async start(queuedSubmissionId?: string | null) {
+    return this.mutate("start", queuedSubmissionId === undefined ? {} : { queuedSubmissionId: id.nullable().parse(queuedSubmissionId) },
+      (value) => {
+        const result = startResponse.parse(value);
+        this.checkThread(result.turn);
+        return result;
+      });
+  }
+
+  private async mutate<T>(action: string, params: Record<string, unknown>, parse: (value: unknown) => T): Promise<NativeQueueAcknowledgement<T>> {
+    this.assertOpen();
+    const method = `thread/queue/${action}`;
+    this.mutations++;
+    this.invalidate();
+    const wire = Promise.resolve().then(() => {
+      this.assertOpen();
+      return this.port.rpc(method, { ...params, threadId: this.threadId }, this.limits.timeoutMs);
+    });
+    // A caller deadline does not end the wire operation. Fence reads until the
+    // port settles it, and invalidate again even when its acknowledgement is late.
+    const settled = () => { this.mutations--; this.invalidate(); };
+    void wire.then(settled, settled);
+    try {
+      const value = await this.withDeadline(wire, this.limits.timeoutMs);
+      this.checkThread(value);
+      return { outcome: "acknowledged", result: parse(value) };
+    } catch (cause) {
+      if (cause instanceof NativeQueueProtocolRefusal) throw cause;
+      throw new NativeQueueUncertainError(method, this.threadId, cause);
+    }
+  }
+
+  private checkThread(value: unknown): void {
+    // Queue replies have no thread field in v2. Correlation belongs to the port;
+    // reject a contradictory field if a transport/protocol extension supplies one.
+    if (value && typeof value === "object" && "threadId" in value && value.threadId !== this.threadId) {
+      throw new Error("Native queue thread identity mismatch");
+    }
+  }
+
+  private withDeadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Native queue RPC deadline exceeded")), timeoutMs);
+      promise.then((value) => { clearTimeout(timer); resolve(value); }, (error) => { clearTimeout(timer); reject(error); });
+    });
+  }
+
+  private assertOpen(): void {
+    if (this.disposed) throw new Error("Native queue adapter is disposed");
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.invalidate();
+  }
+}

--- a/src/lib/runtime/nativeCodexQueue.ts
+++ b/src/lib/runtime/nativeCodexQueue.ts
@@ -57,6 +57,15 @@ export class NativeQueueProtocolRefusal extends Error {
   }
 }
 
+/** Local disposal prevented this mutation from ever reaching the RPC port. */
+export class NativeQueueNotSubmittedError extends Error {
+  readonly outcome = "not-submitted";
+  constructor(readonly method: string, readonly threadId: string) {
+    super("Native queue mutation was not submitted: adapter is disposed");
+    this.name = "NativeQueueNotSubmittedError";
+  }
+}
+
 /** The caller retains its durable operation and payload; this grants no retry. */
 export class NativeQueueUncertainError extends Error {
   readonly outcome = "uncertain";
@@ -211,12 +220,14 @@ export class NativeCodexQueue {
   }
 
   private async mutate<T>(action: string, params: Record<string, unknown>, parse: (value: unknown) => T): Promise<NativeQueueAcknowledgement<T>> {
-    this.assertOpen();
     const method = `thread/queue/${action}`;
+    if (this.disposed) throw new NativeQueueNotSubmittedError(method, this.threadId);
+    let transportInvoked = false;
     this.mutations++;
     this.invalidate();
     const wire = Promise.resolve().then(() => {
-      this.assertOpen();
+      if (this.disposed) throw new NativeQueueNotSubmittedError(method, this.threadId);
+      transportInvoked = true;
       return this.port.rpc(method, { ...params, threadId: this.threadId }, this.limits.timeoutMs);
     });
     // A caller deadline does not end the wire operation. Fence reads until the
@@ -228,6 +239,7 @@ export class NativeCodexQueue {
       this.checkThread(value);
       return { outcome: "acknowledged", result: parse(value) };
     } catch (cause) {
+      if (!transportInvoked && cause instanceof NativeQueueNotSubmittedError) throw cause;
       if (cause instanceof NativeQueueProtocolRefusal) throw cause;
       throw new NativeQueueUncertainError(method, this.threadId, cause);
     }


### PR DESCRIPTION
Adds the native Codex queue transport adapter needed by #1629. It supports list/add/update/delete/reorder/start while keeping mutation acknowledgements separate from delivery and preserving uncertain outcomes after lost responses.

Closes #1632. Parent host/UI/journal integration remains owed, including default interrupt, capability negotiation, request-error classification, notification forwarding, operation recovery, and canonical delivery settlement. Existing host, HTTP, journal, composer, and voice files are untouched.

The adapter binds one thread to an injected RPC connection. It preserves native input/media and server/client identities, coalesces bounded pagination, and retains stale snapshots after incomplete or contradictory reads. Notifications invalidate state without scheduling sends. Native update remains available for edits. Disposal before invoking the RPC port returns a typed `not-submitted` outcome; failures after transport invocation preserve uncertainty.

Validation:

- Bun 1.4.0 with frozen lockfile dependencies and isolated home/config/cache/data/provider/state/temp roots.
- 54 focused tests / 164 assertions, including an opt-in Codex 0.154.0 fixture using a credential-free loopback synthetic backend. Real pagination and every mutation response pass. Dropping a successful add acknowledgement returns uncertainty without retrying.
- Four private negative controls detect missing completion, lost invalidation, lost uncertainty classification, and lost client-identity validation.
- Freshly generated experimental CLI schemas match all 13 audited queue schemas.
- TypeScript checking and the full-diff publication gate pass.
- ESLint is unavailable: its React plugin crashes with `contextOrFilename.getFilename is not a function` on both the new module and an unchanged baseline file.

The current hosted workflows run their existing named suites; the new focused test is verified locally. Parent integration must add its ongoing CI coverage. This PR is ready for the pipeline's independent review. No merge, deployment, or production runtime changes were performed.
