### PR TITLE
fix(voice): configure native voice instructions and call context

### DIFF
--- a/docs/design/codex-api-update/evidence/voice-probe-results.json
+++ b/docs/design/codex-api-update/evidence/voice-probe-results.json
@@ -1,0 +1,91 @@
+{
+  "assertions": [
+    {
+      "check": "the thread mandate reaches the backing model",
+      "held": true
+    },
+    {
+      "check": "without a prompt the spoken model runs the stock Codex persona",
+      "held": true
+    },
+    {
+      "check": "without a prompt the thread mandate does NOT reach the spoken model",
+      "held": true
+    },
+    {
+      "check": "the spoken session carries no tool inventory of its own",
+      "held": true
+    },
+    {
+      "check": "a prompt replaces the spoken model instructions",
+      "held": true
+    },
+    {
+      "check": "an unknown parameter is ignored, so acceptance alone proves nothing",
+      "held": true
+    },
+    {
+      "check": "every parameter this repair sends is deserialized",
+      "held": true
+    },
+    {
+      "check": "an injected thread item is permanent",
+      "held": true
+    },
+    {
+      "check": "no session-scoped string is written to canonical history",
+      "held": true
+    }
+  ],
+  "backend": "local synthetic fixture; no credentials; no external requests",
+  "cases": {
+    "backing_model": {
+      "requests": 1,
+      "sees_thread_mandate": true
+    },
+    "canonical_history": {
+      "end_instructions_persisted": false,
+      "injected_developer_item_persisted": true,
+      "spoken_prompt_persisted": false,
+      "start_instructions_persisted": false
+    },
+    "parameter_deserialization": {
+      "flushTranscriptTailOnSessionEnd": "rejected",
+      "prompt": "rejected",
+      "realtimeEndInstructions": "rejected",
+      "realtimeStartInstructions": "rejected",
+      "unknown_field_control": "accepted"
+    },
+    "with_prompt": {
+      "call_creation_requests": 1,
+      "carries_a_tool_inventory": false,
+      "initial_items": 0,
+      "instructions_are_the_stock_codex_persona": false,
+      "instructions_bytes": 1029,
+      "session_keys": [
+        "audio",
+        "delegation",
+        "instructions",
+        "model"
+      ],
+      "spoken_model_sees_thread_mandate": true
+    },
+    "without_prompt": {
+      "call_creation_requests": 1,
+      "carries_a_tool_inventory": false,
+      "initial_items": 0,
+      "instructions_are_the_stock_codex_persona": true,
+      "instructions_bytes": 5745,
+      "session_keys": [
+        "audio",
+        "delegation",
+        "instructions",
+        "model"
+      ],
+      "spoken_model_sees_thread_mandate": false
+    }
+  },
+  "cli": "codex-cli 0.154.0",
+  "held": true,
+  "question": "what does the spoken model receive when a call starts on a thread that already has a role"
+}

--- a/docs/design/codex-api-update/voice_probe.py
+++ b/docs/design/codex-api-update/voice_probe.py
@@ -1,0 +1,279 @@
+"""Isolated, credential-free realtime-voice contract probe. No model service used.
+
+Answers one question with the installed app-server rather than with its schema:
+when a call starts on a thread that already has a role and tools, what does the
+SPOKEN model actually receive?
+
+The realtime call is created against the configured model provider, so pointing
+that provider at a local fixture captures the outgoing live-session body verbatim
+without any credential, any account, and any request leaving the machine. The
+thread is created for the probe, carries a synthetic mandate, and is discarded
+with its temporary home.
+
+Run:  python3 docs/design/codex-api-update/voice_probe.py
+"""
+import argparse
+import http.server
+import json
+import os
+import queue
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+parser = argparse.ArgumentParser()
+parser.add_argument('--codex', default=shutil.which('codex'))
+parser.add_argument('--output', type=Path, default=ROOT / 'evidence/voice-probe-results.json')
+args = parser.parse_args()
+
+captured: list[tuple[str, bytes]] = []
+
+# A distinctive role/tool mandate. Nothing about it is real; it exists only so a
+# grep can answer "did this reach that model".
+MARKER = 'LLVPROBEMANAGERMARKER'
+MANDATE = (f'{MARKER}: you are this project\'s board manager. You own the board tools '
+           'probe_board_read and probe_board_write, and you keep them for the whole session.')
+
+# Minimal but structurally valid: the app-server forwards the offer untouched, and
+# the fixture never negotiates media.
+OFFER = ('v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n'
+         'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\nc=IN IP4 0.0.0.0\r\na=mid:0\r\na=sendrecv\r\n')
+
+
+class Fixture(http.server.BaseHTTPRequestHandler):
+    """Stands in for the model provider AND for realtime call creation."""
+
+    def log_message(self, *_):
+        pass
+
+    def do_POST(self):
+        captured.append((self.path, self.rfile.read(int(self.headers.get('Content-Length', '0')))))
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/event-stream')
+        self.end_headers()
+        try:
+            self.wfile.write(b'event: response.completed\ndata: '
+                             b'{"type":"response.completed","response":{"id":"r","status":"completed",'
+                             b'"output":[],"usage":{"input_tokens":1,"output_tokens":0,"total_tokens":1}}}\n\n')
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+
+class Client:
+    def __init__(self, env, cwd):
+        self.lines: queue.Queue = queue.Queue()
+        self.serial = 0
+        self.process = subprocess.Popen([args.codex, 'app-server', '--stdio'], env=env, cwd=cwd,
+                                        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                        stderr=subprocess.DEVNULL, text=True)
+
+        def reader():
+            for line in self.process.stdout:
+                try:
+                    self.lines.put(json.loads(line))
+                except ValueError:
+                    pass
+        threading.Thread(target=reader, daemon=True).start()
+        self.init = self.rpc('initialize', {'clientInfo': {'name': 'isolated_voice_probe', 'version': '1'},
+                                            'capabilities': {'experimentalApi': True}})
+        self.write({'method': 'initialized', 'params': {}})
+
+    def write(self, obj):
+        self.process.stdin.write(json.dumps(obj) + '\n')
+        self.process.stdin.flush()
+
+    def rpc(self, method, params, timeout=20):
+        self.serial += 1
+        rid = self.serial
+        self.write({'id': rid, 'method': method, 'params': params})
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                item = self.lines.get(timeout=max(.01, deadline - time.monotonic()))
+            except queue.Empty:
+                break
+            if item.get('id') == rid:
+                return item
+        raise TimeoutError(method)
+
+    def settle(self, seconds=4.0):
+        end = time.monotonic() + seconds
+        while time.monotonic() < end:
+            try:
+                self.lines.get(timeout=.3)
+            except queue.Empty:
+                pass
+
+    def stop(self):
+        try:
+            self.process.stdin.close()
+            self.process.wait(timeout=4)
+        except (ValueError, subprocess.TimeoutExpired):
+            self.process.kill()
+
+
+def session_of(raw: bytes):
+    """The live-session JSON out of the multipart call-creation body."""
+    text = raw.decode('utf8', 'replace')
+    part = re.search(r'name="session"\r\nContent-Type: application/json\r\n\r\n(.*?)\r\n--codex-realtime-call-boundary',
+                     text, re.S)
+    return json.loads(part.group(1)) if part else None
+
+
+def run():
+    result = {
+        'cli': subprocess.check_output([args.codex, '--version'], text=True).strip(),
+        'backend': 'local synthetic fixture; no credentials; no external requests',
+        'question': 'what does the spoken model receive when a call starts on a thread that already has a role',
+        'cases': {},
+        'assertions': [],
+    }
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), Fixture)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    with tempfile.TemporaryDirectory(prefix='vp-', dir='/tmp') as scratch:
+        base = Path(scratch)
+        env = {k: v for k, v in os.environ.items() if k in ('PATH', 'LANG', 'LC_ALL')}
+        for key in ('HOME', 'CODEX_HOME', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME', 'XDG_DATA_HOME', 'TMPDIR'):
+            directory = base / key.lower()
+            directory.mkdir(mode=0o700)
+            env[key] = str(directory)
+        cwd = base / 'workspace'
+        cwd.mkdir()
+        Path(env['CODEX_HOME'], 'config.toml').write_text(f'''model = "probe-model"
+model_provider = "probe"
+approval_policy = "never"
+sandbox_mode = "read-only"
+web_search = "disabled"
+[model_providers.probe]
+name = "Local contract fixture"
+base_url = "http://127.0.0.1:{server.server_port}/v1"
+wire_api = "responses"
+requires_openai_auth = false
+supports_websockets = false
+[analytics]
+enabled = false
+[features]
+apps = false
+plugins = false
+''')
+        client = Client(env, cwd)
+        thread = client.rpc('thread/start', {'cwd': str(cwd), 'model': 'probe-model', 'modelProvider': 'probe',
+                                             'approvalPolicy': 'never', 'sandbox': 'read-only'})
+        thread_id = thread['result']['thread']['id']
+
+        # An INCUMBENT thread: a durable developer mandate, exactly the shape the
+        # Viewer used to write its voice persona in, plus one ordinary exchange.
+        client.rpc('thread/inject_items', {'threadId': thread_id, 'items': [
+            {'type': 'message', 'id': 'probe-mandate', 'role': 'developer',
+             'content': [{'type': 'input_text', 'text': MANDATE}]}]})
+        captured.clear()
+        client.rpc('turn/start', {'threadId': thread_id, 'clientUserMessageId': 'probe-first',
+                                  'input': [{'type': 'text', 'text': 'confirm you hold the board tools.'}]})
+        client.settle(5)
+        backing = [body for path, body in captured if not path.endswith('/live')]
+        result['cases']['backing_model'] = {
+            'requests': len(backing),
+            'sees_thread_mandate': any(MARKER in body.decode('utf8', 'replace') for body in backing),
+        }
+
+        common = {'threadId': thread_id, 'version': 'v3', 'model': 'gpt-live-1-codex',
+                  'outputModality': 'audio', 'transport': {'type': 'webrtc', 'sdp': OFFER},
+                  'clientManagedHandoffs': True, 'codexResponsesAsItems': True,
+                  'includeStartupContext': True}
+        cases = {
+            # What the Viewer sent before #1629: no instructions for the spoken model.
+            'without_prompt': dict(common),
+            # What it sends now.
+            'with_prompt': dict(common, **{
+                'flushTranscriptTailOnSessionEnd': True,
+                'prompt': f'SPOKEN PERSONA. {MANDATE}',
+                'realtimeStartInstructions': f'{MARKER}: voice is active; keep this task role and tools.',
+                'realtimeEndInstructions': f'{MARKER}: voice ended; resume text policy.',
+            }),
+        }
+        for name, params in cases.items():
+            captured.clear()
+            client.rpc('thread/realtime/start', params, timeout=25)
+            client.settle(5)
+            calls = [body for path, body in captured if path.endswith('/live')]
+            session = session_of(calls[0]) if calls else None
+            instructions = (session or {}).get('instructions') or ''
+            result['cases'][name] = {
+                'call_creation_requests': len(calls),
+                'session_keys': sorted((session or {}).keys()),
+                'instructions_bytes': len(instructions.encode('utf8')),
+                'instructions_are_the_stock_codex_persona': instructions.startswith('## Identity, tone, and role'),
+                'spoken_model_sees_thread_mandate': MARKER in instructions,
+                'initial_items': len((session or {}).get('initial_items') or []),
+                'carries_a_tool_inventory': 'tools' in (session or {}),
+            }
+
+        # Every parameter this repair sends is deserialized rather than ignored:
+        # an unknown field is accepted silently, an ill-typed known one is not.
+        rejections = {
+            'unknown_field_control': {'llvNotARealParameter': 12345},
+            'prompt': {'prompt': 12345},
+            'realtimeStartInstructions': {'realtimeStartInstructions': 12345},
+            'realtimeEndInstructions': {'realtimeEndInstructions': 12345},
+            'flushTranscriptTailOnSessionEnd': {'flushTranscriptTailOnSessionEnd': 'yes'},
+        }
+        result['cases']['parameter_deserialization'] = {}
+        for name, extra in rejections.items():
+            answer = client.rpc('thread/realtime/start', dict(common, **extra), timeout=25)
+            result['cases']['parameter_deserialization'][name] = 'rejected' if 'error' in answer else 'accepted'
+            client.settle(1)
+
+        # None of the session-scoped strings may be written to canonical history;
+        # the injected item, being an ordinary thread write, must be.
+        read = client.rpc('thread/read', {'threadId': thread_id})
+        path = (read.get('result') or {}).get('thread', {}).get('path')
+        history = Path(path).read_text(encoding='utf8', errors='replace') if path else ''
+        result['cases']['canonical_history'] = {
+            'injected_developer_item_persisted': 'probe-mandate' in history,
+            'spoken_prompt_persisted': 'SPOKEN PERSONA.' in history,
+            'start_instructions_persisted': 'voice is active; keep this task role' in history,
+            'end_instructions_persisted': 'voice ended; resume text policy' in history,
+        }
+        client.stop()
+
+    checks = [
+        ('the thread mandate reaches the backing model',
+         result['cases']['backing_model']['sees_thread_mandate'] is True),
+        ('without a prompt the spoken model runs the stock Codex persona',
+         result['cases']['without_prompt']['instructions_are_the_stock_codex_persona'] is True),
+        ('without a prompt the thread mandate does NOT reach the spoken model',
+         result['cases']['without_prompt']['spoken_model_sees_thread_mandate'] is False),
+        ('the spoken session carries no tool inventory of its own',
+         result['cases']['without_prompt']['carries_a_tool_inventory'] is False),
+        ('a prompt replaces the spoken model instructions',
+         result['cases']['with_prompt']['spoken_model_sees_thread_mandate'] is True
+         and result['cases']['with_prompt']['instructions_are_the_stock_codex_persona'] is False),
+        ('an unknown parameter is ignored, so acceptance alone proves nothing',
+         result['cases']['parameter_deserialization']['unknown_field_control'] == 'accepted'),
+        ('every parameter this repair sends is deserialized',
+         all(verdict == 'rejected' for name, verdict in result['cases']['parameter_deserialization'].items()
+             if name != 'unknown_field_control')),
+        ('an injected thread item is permanent',
+         result['cases']['canonical_history']['injected_developer_item_persisted'] is True),
+        ('no session-scoped string is written to canonical history',
+         not any(result['cases']['canonical_history'][key] for key in
+                 ('spoken_prompt_persisted', 'start_instructions_persisted', 'end_instructions_persisted'))),
+    ]
+    result['assertions'] = [{'check': check, 'held': held} for check, held in checks]
+    result['held'] = all(held for _, held in checks)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + '\n')
+    for check, held in checks:
+        print(('PASS ' if held else 'FAIL ') + check)
+    print(f"{sum(held for _, held in checks)}/{len(checks)} assertions held -> {args.output}")
+    return 0 if result['held'] else 1
+
+
+raise SystemExit(run())

--- a/docs/realtime-v3/BLOCKED.md
+++ b/docs/realtime-v3/BLOCKED.md
@@ -63,7 +63,7 @@ the difference understood:
 | transport | client-owned call, handed over as `existingCall` | server-created WebRTC |
 | `clientManagedHandoffs` | not set at the frontend call site | `true` — client-managed delegation is what streams worker progress into the call |
 
-Two of those are transport-ownership choices, not defects. The startup-context
+Two of those are transport-ownership choices and neither is a defect. The startup-context
 difference is a real one: a wider `initialItems` continuity window (native bounds
 it at 128 items and 8,192 estimated tokens) would give the spoken model more of
 the conversation than the latest turn, and overlaps with what startup context

--- a/docs/realtime-v3/BLOCKED.md
+++ b/docs/realtime-v3/BLOCKED.md
@@ -48,6 +48,23 @@ withdraws it with `realtimeEndInstructions`. `flushTranscriptTailOnSessionEnd`
 is set, so the last thing said before a hangup is routed through Codex rather
 than dropped. Nothing is written to the thread.
 
+**Where a spoken card is allowed to steer work.** The reference the operator's
+screen carried reaches a tool only while it describes the work in hand: it
+becomes readable once its utterance has been handed off, and stops the moment
+the operator speaks again. The association between an utterance and its handoff
+is a fact in exactly one arrangement — one utterance outstanding, one handoff
+arriving — because the transcript boundary and the handoff event share no
+identifier on the wire. With two outstanding, the browser reports nothing rather
+than guess, and every read then refuses by name. An accepted join survives a
+hangup, because the work the last utterance started does; it expires with the
+reference's own freshness window and a new call replaces it.
+
+Closing the ambiguity properly needs an identifier shared by the user transcript
+event and the handoff. The native events carry `user_bidi_turn_id`; whether the
+user transcript event carries it too has not been established, and cannot be
+without a live capture. Until it is, the correlation stays non-actionable in the
+ambiguous case rather than being resolved by recency.
+
 **What this does not establish.** No live provider call was made for any of it.
 The probe proves what leaves the app-server and what the app-server persists; it
 cannot prove what the provider does with a session body, that audio flows, or

--- a/docs/realtime-v3/BLOCKED.md
+++ b/docs/realtime-v3/BLOCKED.md
@@ -1,4 +1,86 @@
-# Realtime V3 voice: working — the cutoff was the alpha model default
+# Realtime V3 voice: a call runs two models, and only one of them holds the microphone
+
+Verified 2026-09-10 against `codex-cli 0.154.0` (bundled app-server in the
+current Linux ChatGPT build: `0.153.4`; the two agree on every field of the
+contracts below). Everything under this heading is reproducible with
+`python3 docs/design/codex-api-update/voice_probe.py`, which needs no credential,
+no account and no network: it points the configured model provider at a local
+fixture, so realtime call creation is captured verbatim instead of sent.
+
+| | Model | Instructions it runs on | Tools |
+|---|---|---|---|
+| Spoken | `gpt-live-1-codex` | the `prompt` parameter of `thread/realtime/start`, and nothing else | none — a realtime session carries no tool inventory |
+| Backing | the thread's own agent | the thread's own instructions, plus session-scoped `realtimeStartInstructions` | the thread's whole MCP inventory |
+
+**The defect this cost us (#1629).** The Viewer wrote its voice persona into the
+thread with `thread/inject_items` and left `prompt` unset. An injected item
+reaches only the backing model, so the persona was delivered to the one model
+that did not need it and withheld from the one that had nothing else — the
+spoken model ran Codex's stock realtime persona, which introduces itself as a
+general-purpose assistant, and whose `<startup_context>` block states in its own
+words that it excludes repo memory instructions and AGENTS files. Enabling voice
+on the operator's own orchestrator therefore produced a voice with no role, no
+knowledge of what the thread behind it could reach, and a habit of answering for
+itself. Meanwhile the injected item is appended to an append-only transcript and
+never withdrawn, so every thread accumulated a permanent copy of the
+spoken-delivery rules and kept answering in two-sentence spoken register long
+after the microphone closed.
+
+The probe establishes each half separately, on a thread carrying a synthetic
+developer role/tool mandate:
+
+- the mandate reaches the backing model, and does **not** reach the spoken
+  session, whose instructions are the stock 5.7 kB persona;
+- supplying `prompt` replaces those instructions;
+- the spoken session body carries `instructions`, `model`, `audio` and
+  `delegation` — and no tool list, in either case;
+- `prompt`, `realtimeStartInstructions`, `realtimeEndInstructions` and
+  `flushTranscriptTailOnSessionEnd` are deserialized, while an unknown field is
+  accepted silently — so "the call succeeded" proves nothing about a parameter
+  and the ill-typed control is what proves it is in the contract;
+- none of the three session-scoped strings is written to canonical history,
+  while an injected item is.
+
+**What the Viewer sends now.** The persona is the session's `prompt`; the
+role-preserving framing (and, for a session created to be the voice front, the
+relay mandate) is the backing model's `realtimeStartInstructions`; hanging up
+withdraws it with `realtimeEndInstructions`. `flushTranscriptTailOnSessionEnd`
+is set, so the last thing said before a hangup is routed through Codex rather
+than dropped. Nothing is written to the thread.
+
+**What this does not establish.** No live provider call was made for any of it.
+The probe proves what leaves the app-server and what the app-server persists; it
+cannot prove what the provider does with a session body, that audio flows, or
+that a live call keeps its role for its whole length. That needs a call on a
+real account and is not something an implementation agent can produce.
+
+**Where the Viewer still differs from the native app**, deliberately and with
+the difference understood:
+
+| | native Codex app | Viewer |
+|---|---|---|
+| `includeStartupContext` | `false` — it supplies its own continuity window | `true` — Codex's own curated context, plus the durable tail only when a streamed response has no committed item |
+| transport | client-owned call, handed over as `existingCall` | server-created WebRTC |
+| `clientManagedHandoffs` | not set at the frontend call site | `true` — client-managed delegation is what streams worker progress into the call |
+
+Two of those are transport-ownership choices, not defects. The startup-context
+difference is a real one: a wider `initialItems` continuity window (native bounds
+it at 128 items and 8,192 estimated tokens) would give the spoken model more of
+the conversation than the latest turn, and overlaps with what startup context
+already carries. Neither has been measured against a live call, so neither was
+changed on the strength of the schema.
+
+---
+
+# Superseded reading (2026-07): "working — the cutoff was the alpha model default"
+
+The measurements below stand and the model fix stands. What the table at the
+bottom of this section reads as settled — that the handoff flags "turned out not
+to be the problem" — was true of the 9-second cutoff and says nothing about the
+persona split above, which nobody was looking for at the time. Keep the
+incident; the section above is the current architecture.
+
+## Realtime V3 voice: working — the cutoff was the alpha model default
 
 `thread/realtime/start` sent no `model`, so the backend assigned
 `gpt-live-1-boulder-alpha`, and every call on it was killed 9.0-9.4 seconds

--- a/scripts/capture-issue-1629-voice-notice.ts
+++ b/scripts/capture-issue-1629-voice-notice.ts
@@ -1,0 +1,220 @@
+/**
+ * Rendered acceptance for the voice usage notice (#1629), in a real browser
+ * against the real stylesheet:
+ *
+ *   bun run build && bun scripts/capture-issue-1629-voice-notice.ts
+ *
+ * A live call cannot be driven here — it needs a provider, an account and a
+ * microphone — so what is put in front of the browser is the panel itself, the
+ * component the operator actually sees, rendered with the production build's own
+ * compiled CSS. That is the part the DOM tests cannot answer: happy-dom applies
+ * no stylesheet, so it can say the element exists and nothing about whether the
+ * operator can read it, whether it sits where a warning belongs, or whether it
+ * is distinguishable from the failure slot beside it.
+ *
+ * It measures, in the page:
+ *
+ *   - that the notice is rendered, on its own row, ABOVE the transcript's
+ *     bottom edge and BELOW the last spoken line — a warning that lands off
+ *     screen is not a warning;
+ *   - that its text is legible: non-zero size, and a colour that is not the
+ *     panel's own background;
+ *   - that it is NOT the failure treatment — a different foreground colour from
+ *     the error slot, and no retry control beside it;
+ *   - that a real failure takes the slot back, so the operator is not told what
+ *     might happen next while reading what already did.
+ *
+ * Then it proves the reading can go red: the same measurements are taken against
+ * a page where the notice has been removed from the DOM by hand, and against one
+ * where it has been given the failure's own colour. A run where either still
+ * reads as "a legible, distinct notice" exits non-zero.
+ *
+ * Frames and the measurement JSON land outside the repository, under
+ * <BOARD_CAPTURE_DIR>/<unique-run>/out. Nothing is served from the operator's
+ * state, nothing is deployed, and no path from this machine reaches a frame.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { chromium, type Browser } from "playwright-core";
+
+import { VoiceConversationPanel } from "../src/components/VoiceConversation";
+import { translate, type TFunction } from "../src/lib/i18n";
+import { createCaptureDirectory } from "./capture-directory";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const BASE = createCaptureDirectory({
+  envName: "BOARD_CAPTURE_DIR",
+  prefix: "llv-issue-1629",
+  raw: process.env.BOARD_CAPTURE_DIR,
+  repoRoot,
+});
+const OUT_DIR = path.join(BASE, "out");
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const t: TFunction = (key, params) => translate("en", key, params);
+const NOTICE = "This account is approaching its usage limit; the call may be cut short.";
+const FAILURE = "You have reached your usage limit.";
+const SPOKEN = "Reading the board now.";
+
+/** The build's own compiled CSS, so the measured colours are the shipped ones. */
+function stylesheet(): string {
+  const cssDir = path.join(repoRoot, ".next", "static", "css");
+  let names: string[];
+  try {
+    names = fs.readdirSync(cssDir).filter((name) => name.endsWith(".css"));
+  } catch {
+    throw new Error("no compiled stylesheet under .next/static/css — run `bun run build` first");
+  }
+  if (names.length === 0) throw new Error("no compiled stylesheet under .next/static/css — run `bun run build` first");
+  return names.map((name) => fs.readFileSync(path.join(cssDir, name), "utf8")).join("\n");
+}
+
+function page(body: string, css: string): string {
+  return `<!doctype html><html lang="en" class="dark"><head><meta charset="utf-8">
+<style>${css}</style>
+<style>body{margin:0;background:var(--color-surface,#0b0b0e);padding:24px;}
+  #frame{width:520px;}</style>
+</head><body><div id="frame">${body}</div></body></html>`;
+}
+
+function panelHtml(options: { notice: string | null; error: string | null }): string {
+  return renderToStaticMarkup(createElement(VoiceConversationPanel, {
+    phase: options.error ? "error" : "live",
+    lines: [{ id: "a", role: "assistant", text: SPOKEN, final: true }],
+    error: options.error,
+    notice: options.notice,
+    startedAt: options.error ? null : 1_000,
+    onRetry: () => undefined,
+    t,
+  }));
+}
+
+interface Reading {
+  present: boolean;
+  visible: boolean;
+  belowLastLine: boolean;
+  insidePanel: boolean;
+  colour: string;
+  fontSizePx: number;
+  distinctFromError: boolean;
+  hasRetryBeside: boolean;
+}
+
+const READ = (errorColour: string | null) => {
+  const notice = document.querySelector('[data-testid="voice-notice"]') as HTMLElement | null;
+  const panel = document.querySelector("#frame > *") as HTMLElement | null;
+  /* The deepest element that carries the spoken line, whatever tag the
+     transcript happens to use for it. */
+  const line = [...document.querySelectorAll("#frame *")]
+    .filter((node) => node.textContent?.includes("Reading the board now."))
+    .at(-1);
+  if (!notice || !panel) {
+    return {
+      present: false, visible: false, belowLastLine: false, insidePanel: false,
+      colour: "", fontSizePx: 0, distinctFromError: false, hasRetryBeside: false,
+    };
+  }
+  const text = notice.querySelector("p") as HTMLElement;
+  const box = notice.getBoundingClientRect();
+  const panelBox = panel.getBoundingClientRect();
+  const lineBox = line?.getBoundingClientRect();
+  const style = getComputedStyle(text);
+  return {
+    present: true,
+    visible: box.width > 0 && box.height > 0 && style.visibility !== "hidden" && style.opacity !== "0",
+    belowLastLine: lineBox ? box.top >= lineBox.bottom : false,
+    insidePanel: box.top >= panelBox.top - 1 && box.bottom <= panelBox.bottom + 1,
+    colour: style.color,
+    fontSizePx: Number.parseFloat(style.fontSize),
+    distinctFromError: errorColour === null ? true : style.color !== errorColour,
+    hasRetryBeside: notice.querySelector('[data-testid="voice-retry"]') !== null,
+  };
+};
+
+function holds(reading: Reading): boolean {
+  return reading.present && reading.visible && reading.belowLastLine && reading.insidePanel
+    && reading.fontSizePx >= 10 && reading.distinctFromError && !reading.hasRetryBeside;
+}
+
+/**
+ * Best effort, and said so in the record.
+ *
+ * The verdicts rest on rectangles and computed styles read out of the live page,
+ * which is the part a headless shell always answers; a frame is for a human
+ * reading the run afterwards, and a shell that cannot encode one must not turn
+ * a green measurement into a failed run.
+ */
+async function frame(view: import("playwright-core").Page, name: string): Promise<boolean> {
+  try {
+    await view.screenshot({ path: path.join(OUT_DIR, `${name}.png`) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main(): Promise<number> {
+  const css = stylesheet();
+  let browser: Browser | undefined;
+  const measurements: Record<string, unknown> = {};
+  try {
+    browser = await chromium.launch({
+      args: ["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu", "--hide-scrollbars"],
+    });
+    const context = await browser.newContext({ viewport: { width: 620, height: 520 }, reducedMotion: "no-preference" });
+    const view = await context.newPage();
+
+    /* The failure treatment first, so the notice can be compared against it. */
+    await view.setContent(page(panelHtml({ notice: null, error: FAILURE }), css), { waitUntil: "load" });
+    const errorColour = await view.evaluate(() => {
+      const alert = document.querySelector('[role="alert"] p') as HTMLElement | null;
+      return alert ? getComputedStyle(alert).color : null;
+    });
+    measurements.frames = await frame(view, "failure");
+    measurements.errorColour = errorColour;
+
+    await view.setContent(page(panelHtml({ notice: NOTICE, error: null }), css), { waitUntil: "load" });
+    const live = await view.evaluate(READ, errorColour) as Reading;
+    await frame(view, "notice");
+    measurements.notice = live;
+
+    /* A failure takes the slot back. */
+    await view.setContent(page(panelHtml({ notice: NOTICE, error: FAILURE }), css), { waitUntil: "load" });
+    const both = await view.evaluate(READ, errorColour) as Reading;
+    await frame(view, "failure-wins");
+    measurements.noticeUnderFailure = both;
+
+    /* RED PATHS. Each reintroduces the defect in the page and must be caught. */
+    await view.setContent(page(panelHtml({ notice: NOTICE, error: null }), css), { waitUntil: "load" });
+    await view.evaluate(() => document.querySelector('[data-testid="voice-notice"]')?.remove());
+    const removed = await view.evaluate(READ, errorColour) as Reading;
+    measurements.redRemoved = removed;
+
+    await view.setContent(page(panelHtml({ notice: NOTICE, error: null }), css), { waitUntil: "load" });
+    await view.evaluate((colour) => {
+      const text = document.querySelector('[data-testid="voice-notice"] p') as HTMLElement | null;
+      if (text && colour) text.style.color = colour;
+    }, errorColour);
+    const indistinct = await view.evaluate(READ, errorColour) as Reading;
+    measurements.redIndistinct = indistinct;
+
+    const verdicts = [
+      ["a live call shows a legible notice, distinct from the failure slot", holds(live)],
+      ["a failure takes the slot back", !both.present],
+      ["RED: removing the notice is caught", !holds(removed)],
+      ["RED: giving it the failure's colour is caught", !holds(indistinct)],
+    ] as const;
+    measurements.verdicts = verdicts.map(([check, held]) => ({ check, held }));
+    fs.writeFileSync(path.join(OUT_DIR, "voice-notice.json"), `${JSON.stringify(measurements, null, 2)}\n`);
+    for (const [check, held] of verdicts) console.log(`${held ? "PASS " : "FAIL "}${check}`);
+    console.log(`frames and measurements -> ${OUT_DIR}`);
+    return verdicts.every(([, held]) => held) ? 0 : 1;
+  } finally {
+    await browser?.close();
+  }
+}
+
+process.exit(await main());

--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -5,10 +5,9 @@ import { executeRealtimeControl } from "@/lib/runtime/realtimeControl";
 
 import { POST } from "./route";
 
-const ACCEPTED_PERSONA_BOOTSTRAP = {
-  receiptId: `voice_persona_${"c".repeat(46)}`,
-  itemId: `msg_voice_persona_${"c".repeat(46)}`,
-  insertion: "accepted" as const,
+const LIVE_PERSONA = {
+  variant: "modality" as const,
+  personaId: `voice_persona_${"c".repeat(46)}`,
 };
 
 function request(body: unknown, headers: Record<string, string> = {}): NextRequest {
@@ -27,7 +26,7 @@ test("starts V3 WebRTC through the active hosted conversation", async () => {
       return {
         sdp: "v=0\r\nanswer",
         realtimeSessionId: "live-1",
-        personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+        persona: LIVE_PERSONA,
       };
     },
     async appendRealtimeSpeech(text: string) {
@@ -62,7 +61,7 @@ test("starts V3 WebRTC through the active hosted conversation", async () => {
       ok: true,
       sdp: "v=0\r\nanswer",
       realtimeSessionId: "live-1",
-      personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+      persona: LIVE_PERSONA,
     },
   });
   await executeRealtimeControl(
@@ -140,20 +139,15 @@ test("keeps validation and backend admission errors bounded", async () => {
   expect(result).toEqual({ status: 409, body: { error: "AVAS 404" } });
 });
 
-test("returns the canonical persona insertion outcome and rejects a call whose bootstrap was refused", async () => {
+test("reports which persona the started call is running on", async () => {
   let rejectedStops = 0;
-  const acceptedBootstrap = {
-    receiptId: `voice_persona_${"b".repeat(46)}`,
-    itemId: `msg_voice_persona_${"b".repeat(46)}`,
-    insertion: "accepted" as const,
-  };
   const accepted = await executeRealtimeControl({
     action: "start",
     conversationId: "conversation_voice",
     sdp: "v=0\r\noffer",
   }, () => ({
     async startRealtimeWebRtc() {
-      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-bootstrap", personaBootstrap: acceptedBootstrap };
+      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-bootstrap", persona: LIVE_PERSONA };
     },
     async appendRealtimeSpeech() {},
     async stopRealtime() {},
@@ -164,39 +158,17 @@ test("returns the canonical persona insertion outcome and rejects a call whose b
       ok: true,
       sdp: "v=0\r\nanswer",
       realtimeSessionId: "live-bootstrap",
-      personaBootstrap: acceptedBootstrap,
+      persona: LIVE_PERSONA,
     },
   });
-
-  const personaBootstrap = {
-    receiptId: `voice_persona_${"a".repeat(46)}`,
-    itemId: `msg_voice_persona_${"a".repeat(46)}`,
-    insertion: "rejected" as const,
-    diagnostic: "Codex app-server request failed: invalid developer item",
-  };
-  const result = await executeRealtimeControl({
-    action: "start",
-    conversationId: "conversation_voice",
-    sdp: "v=0\r\noffer",
-  }, () => ({
-    async startRealtimeWebRtc() {
-      return { sdp: null, realtimeSessionId: null, personaBootstrap };
-    },
-    async appendRealtimeSpeech() {},
-    async stopRealtime() { rejectedStops += 1; },
-  }), { operator: true });
-
-  expect(result).toEqual({
-    status: 409,
-    body: {
-      error: "Voice persona could not be recorded: Codex app-server request failed: invalid developer item",
-      personaBootstrap,
-    },
-  });
-  expect(rejectedStops).toBe(1);
+  expect(rejectedStops).toBe(0);
 });
 
-test("refuses a realtime answer that omits the mandatory persona bootstrap receipt", async () => {
+test("refuses a realtime answer that names no session persona", async () => {
+  /* The persona rides on `thread/realtime/start` itself now, so a started call
+     has one by construction — an answer without one is a host that did not run
+     the code this contract describes, and reporting a live call for it would
+     tell the operator a persona is in force that nothing sent. */
   let stops = 0;
   const result = await executeRealtimeControl({
     action: "start",
@@ -204,7 +176,7 @@ test("refuses a realtime answer that omits the mandatory persona bootstrap recei
     sdp: "v=0\r\noffer",
   }, () => ({
     async startRealtimeWebRtc() {
-      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-without-bootstrap" };
+      return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-without-persona" };
     },
     async appendRealtimeSpeech() {},
     async stopRealtime() { stops += 1; },
@@ -212,28 +184,28 @@ test("refuses a realtime answer that omits the mandatory persona bootstrap recei
 
   expect(result).toEqual({
     status: 409,
-    body: { error: "Codex returned no voice persona bootstrap receipt" },
+    body: { error: "Codex returned no voice session persona" },
   });
   expect(stops).toBe(1);
 });
 
-test("refuses malformed persona bootstrap receipts before binding the realtime session", async () => {
+test("refuses malformed session personas before binding the realtime session", async () => {
   const digest = "d".repeat(46);
   let stops = 0;
-  const malformedReceipts = [
-    { itemId: `msg_voice_persona_${digest}`, insertion: "accepted" },
-    { receiptId: `voice_persona_${digest}`, insertion: "accepted" },
-    { receiptId: `voice_persona_${digest}`, itemId: `msg_voice_persona_${digest}` },
-    { receiptId: `voice_persona_${digest}`, itemId: `msg_voice_persona_${digest}`, insertion: "pending" },
+  const malformed = [
+    { personaId: `voice_persona_${digest}` },
+    { variant: "modality" },
+    { variant: "modality", personaId: `msg_voice_persona_${digest}` },
+    { variant: "relay", personaId: `voice_persona_${digest}` },
   ];
-  for (const personaBootstrap of malformedReceipts) {
+  for (const persona of malformed) {
     const result = await executeRealtimeControl({
       action: "start",
       conversationId: "conversation_voice",
       sdp: "v=0\r\noffer",
     }, () => ({
       async startRealtimeWebRtc() {
-        return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-malformed", personaBootstrap };
+        return { sdp: "v=0\r\nanswer", realtimeSessionId: "live-malformed", persona };
       },
       async appendRealtimeSpeech() {},
       async stopRealtime() { stops += 1; },
@@ -241,10 +213,10 @@ test("refuses malformed persona bootstrap receipts before binding the realtime s
 
     expect(result).toEqual({
       status: 409,
-      body: { error: "Codex returned an invalid voice persona bootstrap receipt" },
+      body: { error: "Codex returned no voice session persona" },
     });
   }
-  expect(stops).toBe(malformedReceipts.length);
+  expect(stops).toBe(malformed.length);
 });
 
 test("stops a started backend session whose accepted receipt has no WebRTC answer", async () => {
@@ -255,7 +227,7 @@ test("stops a started backend session whose accepted receipt has no WebRTC answe
     sdp: "v=0\r\noffer",
   }, () => ({
     async startRealtimeWebRtc() {
-      return { sdp: null, realtimeSessionId: "live-without-answer", personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP };
+      return { sdp: null, realtimeSessionId: "live-without-answer", persona: LIVE_PERSONA };
     },
     async appendRealtimeSpeech() {},
     async stopRealtime() { stops += 1; },
@@ -350,7 +322,7 @@ test("the transport authority is required, and an unasked question fails closed"
       return {
         sdp: "v=0\r\nanswer",
         realtimeSessionId: "live-x",
-        personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+        persona: LIVE_PERSONA,
       };
     },
     async appendRealtimeSpeech() {},

--- a/src/components/TmuxComposer.voiceButton.dom.test.tsx
+++ b/src/components/TmuxComposer.voiceButton.dom.test.tsx
@@ -68,7 +68,7 @@ const realFetch = globalThis.fetch;
 let roots: Root[] = [];
 let starts = 0;
 
-const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false };
+const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false, notice: null };
 const spyClient = {
   subscribe: () => () => undefined,
   getSnapshot: () => IDLE,

--- a/src/components/VoiceConversation.dom.test.tsx
+++ b/src/components/VoiceConversation.dom.test.tsx
@@ -244,7 +244,8 @@ test("an approaching usage limit is said while the call is still running", () =>
   /* The 9-second cutoff in docs/realtime-v3/BLOCKED.md arrived as a dead
      transport with no warning. The backend does say so first, and the operator
      can only act on it while there is still a call to act in — so it is a
-     status beside a live transcript, not an alert that ends one. */
+     status beside a live transcript. An alert ends a call in the reader's mind,
+     and this call is still running. */
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);

--- a/src/components/VoiceConversation.dom.test.tsx
+++ b/src/components/VoiceConversation.dom.test.tsx
@@ -238,3 +238,56 @@ test("mute controls stay out of the way outside a live call", () => {
   expect(host.querySelector('[data-testid="voice-output-toggle"]')).toBeNull();
   flushSync(() => root.unmount());
 });
+
+
+test("an approaching usage limit is said while the call is still running", () => {
+  /* The 9-second cutoff in docs/realtime-v3/BLOCKED.md arrived as a dead
+     transport with no warning. The backend does say so first, and the operator
+     can only act on it while there is still a call to act in — so it is a
+     status beside a live transcript, not an alert that ends one. */
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(
+    <VoiceConversationPanel
+      phase="live"
+      error={null}
+      notice="This account is approaching its usage limit; the call may be cut short."
+      startedAt={1_000}
+      lines={[{ id: "a", role: "assistant", text: "On the line.", final: true }]}
+      t={t}
+    />,
+  ));
+  const notice = host.querySelector('[data-testid="voice-notice"]');
+  expect(notice?.getAttribute("role")).toBe("status");
+  expect(notice?.textContent).toContain("approaching its usage limit");
+  /* Not the failure treatment: no alert, no retry, and the call keeps its live
+     transcript. */
+  expect(host.querySelector('[role="alert"]')).toBeNull();
+  expect(host.querySelector('[data-testid="voice-retry"]')).toBeNull();
+  expect(host.textContent).toContain("On the line.");
+  flushSync(() => root.unmount());
+});
+
+test("a failed call reports the failure rather than a stale warning", () => {
+  /* Both at once is the state after a limit warning became a cutoff. The
+     operator needs the reason and the retry, and a warning about what might
+     happen next is noise beside the thing that already did. */
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(
+    <VoiceConversationPanel
+      phase="error"
+      error="You have reached your usage limit."
+      notice="This account is approaching its usage limit; the call may be cut short."
+      startedAt={null}
+      lines={[]}
+      onRetry={() => undefined}
+      t={t}
+    />,
+  ));
+  expect(host.querySelector('[data-testid="voice-notice"]')).toBeNull();
+  expect(host.querySelector('[role="alert"]')?.textContent).toContain("reached your usage limit");
+  flushSync(() => root.unmount());
+});

--- a/src/components/VoiceConversation.tsx
+++ b/src/components/VoiceConversation.tsx
@@ -215,6 +215,7 @@ export function VoiceConversationPanel({
   phase,
   lines,
   error,
+  notice = null,
   startedAt = null,
   stream = null,
   micMuted = false,
@@ -227,6 +228,9 @@ export function VoiceConversationPanel({
   phase: CodexRealtimePhase;
   lines: readonly CodexRealtimeLine[];
   error: string | null;
+  /** Something to say while the call keeps running — an approaching usage limit
+      is the case it was added for (#1629). */
+  notice?: string | null;
   /** Epoch ms the current call went live; null before it does. */
   startedAt?: number | null;
   /** The live microphone stream, for the level meter. */
@@ -239,7 +243,7 @@ export function VoiceConversationPanel({
   t: TFunction;
 }) {
   const { ref, onScroll } = useFollowLatest(lines);
-  if (phase === "idle" && lines.length === 0 && !error) return null;
+  if (phase === "idle" && lines.length === 0 && !error && !notice) return null;
   const live = phase === "live";
   const status = phase === "connecting"
     ? t("voice.connecting")
@@ -339,6 +343,20 @@ export function VoiceConversationPanel({
           );
         })}
       </div>
+
+      {/* A warning the call survives. Rendered above the error slot and in a
+          different tone, because "your window is nearly spent" and "the call is
+          over" call for different reactions, and the operator can only act on
+          the first while there is still a call. */}
+      {notice && !error ? (
+        <div
+          role="status"
+          data-testid="voice-notice"
+          className="flex items-start gap-2 border-t border-warning/30 bg-warning/5 px-2 py-1.5"
+        >
+          <p className="min-w-0 flex-1 text-label text-warning">{notice}</p>
+        </div>
+      ) : null}
 
       {/* A failed call is the one state that needs an action attached: the
           reason comes from the backend verbatim (#664) and the operator's next

--- a/src/components/voice/VoicePipHost.dom.test.tsx
+++ b/src/components/voice/VoicePipHost.dom.test.tsx
@@ -142,6 +142,7 @@ function snapshotFor(phase: Phase) {
       ? ([] as const)
       : ([{ id: "l1", role: "assistant" as const, text: "listening", final: true }] as const),
     error: null,
+    notice: null,
     startedAt: phase === "live" ? 1_000 : null,
     micMuted: false,
     outputMuted: false,

--- a/src/components/voice/VoicePipHost.tsx
+++ b/src/components/voice/VoicePipHost.tsx
@@ -69,6 +69,7 @@ export interface VoicePipClient {
     lines: readonly CodexRealtimeLine[];
     error: string | null;
     startedAt: number | null;
+    notice: string | null;
     micMuted: boolean;
     outputMuted: boolean;
   };
@@ -170,6 +171,7 @@ export function VoicePipHost({ mobile, resolveClient = codexRealtimeClient }: Vo
       phase={snapshot.phase}
       lines={snapshot.lines}
       error={snapshot.error}
+      notice={snapshot.notice}
       startedAt={snapshot.startedAt}
       /* Read at render time from the one client: the stream is not duplicated,
          it is the same MediaStream object the call owns. */
@@ -229,6 +231,7 @@ const IDLE = {
   phase: "idle" as const,
   lines: [] as const,
   error: null,
+  notice: null,
   startedAt: null,
   micMuted: false,
   outputMuted: false,

--- a/src/hooks/useCodexRealtime.ambient.dom.test.tsx
+++ b/src/hooks/useCodexRealtime.ambient.dom.test.tsx
@@ -70,6 +70,7 @@ const IDLE: CodexRealtimeSnapshot = {
   startedAt: null,
   micMuted: false,
   outputMuted: false,
+  notice: null,
 };
 
 /**

--- a/src/hooks/useCodexRealtime.ts
+++ b/src/hooks/useCodexRealtime.ts
@@ -8,7 +8,7 @@ import { speakingFromLines } from "@/lib/audio/speech";
 import { codexRealtimeClient, type CodexRealtimeLine, type CodexRealtimeSnapshot } from "@/lib/realtime/codexRealtimeClient";
 import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
-const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false };
+const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false, notice: null };
 
 /**
  * The part of the realtime client this hook consumes.

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -151,6 +151,8 @@ import {
   type McpToolName,
   type McpToolPayload,
 } from "./server";
+import { parseSelectedContextRef } from "@/lib/selection/selectedContext";
+
 import { viewerControlOrigin, viewerControlToken } from "./controlEndpoint";
 import {
   productionSelectedContextDependencies,
@@ -159,6 +161,7 @@ import {
   selectedConversationTarget,
   selectedConversationTail,
   type SelectedContextTargetDependencies,
+  type VoiceUtteranceLookup,
 } from "./selectedContextTarget";
 import { mcpCallerIdentity, mcpToolPolicy, permitAttentionHandoff, permitReplySuggestions, type ManagerTarget, type McpToolPolicy } from "./toolAllowlist";
 
@@ -860,13 +863,67 @@ function attentionCallerSources(): AttentionCallerSources {
   };
 }
 
+/**
+ * What the operator's own live voice call points at, asked of the Viewer that
+ * holds it (#1629).
+ *
+ * The ledger describes a live WebRTC transport and lives in the Viewer process;
+ * this one runs beside the agent, in the MCP server. So the reader is a control
+ * read over the hop every other cross-process fact already uses, identified by
+ * the capability the registry maps to this agent's conversation — which is what
+ * makes it a read of ITS OWN call and of nothing else.
+ *
+ * A hop that fails answers `unavailable` with the reason rather than "no card".
+ * Reporting a failed read as an absent selection is how an agent ends up telling
+ * the operator they selected nothing when the truth is that nobody could look.
+ */
+async function productionVoiceUtteranceContext(): Promise<VoiceUtteranceLookup> {
+  const authority = attentionCallerAuthority(attentionCallerSources());
+  const conversationId = authority.kind === "root" || authority.kind === "worker"
+    ? authority.conversationId
+    : null;
+  if (!conversationId) return { state: "no-call" };
+  let answer: Record<string, unknown>;
+  try {
+    answer = await productionViewerControlDependencies().post(
+      "/api/runtime/realtime",
+      { action: "utteranceContext", conversationId },
+      callerCapabilityHeaders(),
+    );
+  } catch (error) {
+    return { state: "unavailable", reason: error instanceof Error ? error.message : String(error) };
+  }
+  const utterance = answer.utterance;
+  if (!objectRecord(utterance)) {
+    return { state: "unavailable", reason: text(answer.error) || "the Viewer answered no voice utterance state" };
+  }
+  const state = text(utterance.state);
+  if (state === "no-call" || state === "no-reference" || state === "awaiting-handoff") return { state };
+  if (state !== "joined") return { state: "unavailable", reason: `unknown voice utterance state ${state || "(none)"}` };
+  const reference = parseSelectedContextRef(utterance.reference);
+  const handoff = objectRecord(utterance.handoff);
+  if (!reference || !handoff) {
+    return { state: "unavailable", reason: "the Viewer answered a joined utterance with no readable reference" };
+  }
+  return {
+    state: "joined",
+    reference,
+    handoff: Object.fromEntries(
+      Object.entries(handoff).map(([key, value]) => [key, typeof value === "string" ? value : null]),
+    ),
+  };
+}
+
 /** Exported for the isolated evidence driver, which runs the REAL production
     dependency set and overrides only the caller-authority seam per scenario. */
 export const productionDomainDependencies: ViewerMcpDomainDependencies = {
   listFiles,
   targetedFileEntry: targetedFileEntry,
   pinnedTranscript: openPinnedTranscript,
-  selectedContext: productionSelectedContextDependencies,
+  selectedContext: {
+    ...productionSelectedContextDependencies,
+    voiceUtteranceContext: productionVoiceUtteranceContext,
+  },
   completedFileScan,
   registrySnapshot: () => agentRegistry().readOnlySnapshot(),
   readSpawnAdmissionFence,
@@ -1732,9 +1789,14 @@ async function getConversation(
 ): Promise<McpToolPayload> {
   throwIfCallEnded(context);
   const selectedDependencies = dependencies.selectedContext ?? productionSelectedContextDependencies;
-  const selected = resolveSelectedContext(args, text(args.conversationId), selectedDependencies);
-  const requestedId = selected.conversationId;
   const requestedPath = text(args.transcriptPath) || text(args.path);
+  /* #1629: a spoken turn carries no `ctx=` marker, so when the agent names
+     nothing at all the card the operator was looking at is asked for. A caller
+     that reached its target another way is left alone. */
+  const selected = await resolveSelectedContext(args, text(args.conversationId), selectedDependencies, {
+    voiceUtterance: !requestedPath,
+  });
+  const requestedId = selected.conversationId;
   const tailLines = integer(args.tailLines, 0);
   if (!requestedId && !requestedPath) {
     throw new Error("conversationId, transcriptPath or selectedContext is required");
@@ -1882,9 +1944,11 @@ async function conversationMessages(
 ): Promise<McpToolPayload> {
   throwIfCallEnded(context);
   const selectedDependencies = dependencies.selectedContext ?? productionSelectedContextDependencies;
-  const selected = resolveSelectedContext(args, text(args.conversationId), selectedDependencies);
-  const requestedId = selected.conversationId;
   const requestedPath = text(args.transcriptPath) || text(args.path);
+  const selected = await resolveSelectedContext(args, text(args.conversationId), selectedDependencies, {
+    voiceUtterance: !requestedPath,
+  });
+  const requestedId = selected.conversationId;
   if (!requestedId && !requestedPath) {
     throw new Error("conversationId, transcriptPath or selectedContext is required");
   }
@@ -3043,10 +3107,10 @@ type ResolvedConversationArchiveTarget = {
   project: string;
 };
 
-function conversationArchiveInputs(
+async function conversationArchiveInputs(
   args: McpToolArgs,
   dependencies: ViewerMcpDomainDependencies,
-): { inputs: ConversationArchiveInput[]; selectedTarget: ReturnType<typeof resolveSelectedContext>["target"] | null } {
+): Promise<{ inputs: ConversationArchiveInput[]; selectedTarget: Awaited<ReturnType<typeof resolveSelectedContext>>["target"] | null }> {
   if (args.targets !== undefined) {
     if (!Array.isArray(args.targets) || args.targets.length === 0) {
       throw new Error("targets must be a non-empty list");
@@ -3069,7 +3133,7 @@ function conversationArchiveInputs(
     };
   }
 
-  const selected = resolveSelectedContext(
+  const selected = await resolveSelectedContext(
     args,
     text(args.conversationId),
     dependencies.selectedContext ?? productionSelectedContextDependencies,
@@ -3262,7 +3326,7 @@ async function archiveConversationAction(
   dependencies: ViewerMcpDomainDependencies,
   context: McpToolCallContext,
 ): Promise<McpToolPayload> {
-  const { inputs, selectedTarget } = conversationArchiveInputs(args, dependencies);
+  const { inputs, selectedTarget } = await conversationArchiveInputs(args, dependencies);
   const snapshot = dependencies.registrySnapshot();
   const resolved = inputs.map((input) => resolveArchiveTargetFromRegistry(input, snapshot));
   const outcomes: Array<Record<string, unknown>> = [];
@@ -3363,7 +3427,7 @@ async function conversationAction(
      and no scan stands between "the operator pointed at that card" and acting on
      it. Only the IDENTITY is taken from the reference — the path it recorded is
      capture-time provenance, and a later generation would make it wrong. */
-  const selected = resolveSelectedContext(
+  const selected = await resolveSelectedContext(
     args,
     text(args.conversationId),
     dependencies.selectedContext ?? productionSelectedContextDependencies,

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -877,15 +877,21 @@ function attentionCallerSources(): AttentionCallerSources {
  * Reporting a failed read as an absent selection is how an agent ends up telling
  * the operator they selected nothing when the truth is that nobody could look.
  */
-async function productionVoiceUtteranceContext(): Promise<VoiceUtteranceLookup> {
-  const authority = attentionCallerAuthority(attentionCallerSources());
-  const conversationId = authority.kind === "root" || authority.kind === "worker"
-    ? authority.conversationId
-    : null;
-  if (!conversationId) return { state: "no-call" };
+/**
+ * Ask the Viewer what a conversation's live call points at, and read the answer.
+ *
+ * Split from the caller resolution below so the WIRING — the path, the body, the
+ * forwarded capability, and what each answered state means — can be driven over
+ * a real socket without standing up a registry to be recognised by. The caller
+ * resolution is the other half and is covered where authority is.
+ */
+export async function voiceUtteranceLookup(
+  conversationId: string,
+  post: ViewerControlDependencies["post"],
+): Promise<VoiceUtteranceLookup> {
   let answer: Record<string, unknown>;
   try {
-    answer = await productionViewerControlDependencies().post(
+    answer = await post(
       "/api/runtime/realtime",
       { action: "utteranceContext", conversationId },
       callerCapabilityHeaders(),
@@ -901,8 +907,8 @@ async function productionVoiceUtteranceContext(): Promise<VoiceUtteranceLookup> 
   if (state === "no-call" || state === "no-reference" || state === "awaiting-handoff") return { state };
   if (state !== "joined") return { state: "unavailable", reason: `unknown voice utterance state ${state || "(none)"}` };
   const reference = parseSelectedContextRef(utterance.reference);
-  const handoff = objectRecord(utterance.handoff);
-  if (!reference || !handoff) {
+  const handoff = utterance.handoff;
+  if (!reference || !objectRecord(handoff)) {
     return { state: "unavailable", reason: "the Viewer answered a joined utterance with no readable reference" };
   }
   return {
@@ -912,6 +918,28 @@ async function productionVoiceUtteranceContext(): Promise<VoiceUtteranceLookup> 
       Object.entries(handoff).map(([key, value]) => [key, typeof value === "string" ? value : null]),
     ),
   };
+}
+
+/**
+ * What the operator's own live voice call points at (#1629).
+ *
+ * The ledger describes a live WebRTC transport and lives in the Viewer process;
+ * this one runs beside the agent, in the MCP server. So the reader is a control
+ * read over the hop every other cross-process fact already uses, identified by
+ * the capability the registry maps to this agent's conversation — which is what
+ * makes it a read of ITS OWN call and of nothing else.
+ *
+ * A hop that fails answers `unavailable` with the reason rather than "no card".
+ * Reporting a failed read as an absent selection is how an agent ends up telling
+ * the operator they selected nothing when the truth is that nobody could look.
+ */
+async function productionVoiceUtteranceContext(): Promise<VoiceUtteranceLookup> {
+  const authority = attentionCallerAuthority(attentionCallerSources());
+  const conversationId = authority.kind === "root" || authority.kind === "worker"
+    ? authority.conversationId
+    : null;
+  if (!conversationId) return { state: "no-call" };
+  return voiceUtteranceLookup(conversationId, productionViewerControlDependencies().post);
 }
 
 /** Exported for the isolated evidence driver, which runs the REAL production

--- a/src/lib/mcp/selectedContextTarget.ts
+++ b/src/lib/mcp/selectedContextTarget.ts
@@ -41,17 +41,44 @@ import { McpToolRefusal, type McpToolArgs, type McpToolPayload } from "./server"
  * never be silently resolved in either direction.
  */
 
+/**
+ * The state of the caller's own live voice call, as its ledger reports it
+ * (#1629). Mirrors `VoiceUtteranceContext` structurally so nothing here has to
+ * import the runtime, and so a lookup that cannot reach the Viewer at all is a
+ * distinguishable answer rather than a silent "no card".
+ */
+export type VoiceUtteranceLookup =
+  | { state: "no-call" }
+  | { state: "no-reference" }
+  | { state: "awaiting-handoff" }
+  | { state: "unavailable"; reason: string }
+  | { state: "joined"; reference: SelectedContextRef; handoff: Record<string, string | null> };
+
 export interface SelectedContextTargetDependencies {
   /** Bounded identity + tail resolver. Injected so a test can hand in a lookup
       whose scan-shaped methods throw and still see an answer come back. */
   selectedConversation(): SelectedConversationResolver;
   /** Scanner-root membership gate for the tail read. */
   pathAllowed(candidate: string): boolean;
+  /**
+   * What the caller's own live voice call points at, when it has one.
+   *
+   * Optional, and absent means "no call" — the truthful answer for every caller
+   * that is not on one, and the only safe reading for a dependency set assembled
+   * before this existed. A missing lookup must never be able to fail a tool that
+   * named its target perfectly well.
+   *
+   * The production implementation is wired where the Viewer control hop already
+   * lives, because the ledger describes a live transport held by the Viewer
+   * process and this one runs beside the agent.
+   */
+  voiceUtteranceContext?(): Promise<VoiceUtteranceLookup>;
 }
 
 export const productionSelectedContextDependencies: SelectedContextTargetDependencies = {
   selectedConversation: () => selectedConversationResolver(),
   pathAllowed,
+  voiceUtteranceContext: async () => ({ state: "no-call" }),
 };
 
 export interface SelectedContextTarget {
@@ -89,19 +116,40 @@ export interface SelectedContextResolution {
   /** The identity the tool should act on: explicit argument, else the resolved
       reference, else empty (the caller named the conversation another way). */
   conversationId: string;
+  /** Set when the identity came from the caller's own live voice call rather
+      than from an argument, so the answer can say where it got the card. */
+  voice?: { handoff: Record<string, string | null> };
+}
+
+export interface ResolveSelectedContextOptions {
+  /**
+   * Consult the caller's own live voice call when it named nothing (#1629).
+   *
+   * Opt-in per call site, because a spoken turn carries no `ctx=` marker for the
+   * agent to pass on: the operator's audio goes straight to the model, so the
+   * only place their card is recorded is the voice ledger. A tool that reached
+   * its target another way — a transcript path, an explicit id — must be left
+   * alone, which is what the flag being false says.
+   */
+  voiceUtterance?: boolean;
 }
 
 /**
  * Resolve the reference into a canonical identity, reconciled with whatever the
  * caller named explicitly.
  */
-export function resolveSelectedContext(
+export async function resolveSelectedContext(
   args: McpToolArgs,
   explicitConversationId: string,
   dependencies: SelectedContextTargetDependencies,
-): SelectedContextResolution {
+  options: ResolveSelectedContextOptions = {},
+): Promise<SelectedContextResolution> {
   const ref = selectedContextArg(args.selectedContext);
-  if (!ref) return { target: null, conversationId: explicitConversationId };
+  if (!ref) {
+    return explicitConversationId || !options.voiceUtterance
+      ? { target: null, conversationId: explicitConversationId }
+      : resolveSpokenSelectedContext(dependencies);
+  }
   if (ref.state === "none") {
     throw new McpToolRefusal(
       "the operator submitted that turn with NO card selected, so the reference names no conversation. Ask which conversation they meant, or pass conversationId explicitly.",
@@ -126,6 +174,65 @@ export function resolveSelectedContext(
     );
   }
   return { target: { ref, record }, conversationId: record.conversationId };
+}
+
+/**
+ * The card the operator was looking at when they spoke, or a refusal that says
+ * why there is none (#1629).
+ *
+ * NOTHING HERE EVER REACHES FOR AN EARLIER CARD. The ledger publishes a
+ * reference only while it is joined to the handoff that produced the work in
+ * hand; the moment the operator speaks again the join is gone and this refuses,
+ * so an agent asking a second question about a screen the operator has moved on
+ * from is told to ask rather than answered about the wrong card. Each refusal
+ * names its own condition, because "they have not selected anything", "they have
+ * spoken since" and "there is no call" are three different next moves.
+ */
+async function resolveSpokenSelectedContext(
+  dependencies: SelectedContextTargetDependencies,
+): Promise<SelectedContextResolution> {
+  const lookup = await (dependencies.voiceUtteranceContext?.() ?? Promise.resolve({ state: "no-call" as const }));
+  if (lookup.state === "no-call") return { target: null, conversationId: "" };
+  if (lookup.state === "unavailable") {
+    throw new McpToolRefusal(
+      `the operator's voice call could not be read, so the card they were looking at is unknown: ${lookup.reason}. Ask which conversation they meant, or pass conversationId explicitly.`,
+      { code: "voice_selected_context_unavailable" },
+    );
+  }
+  if (lookup.state === "no-reference") {
+    throw new McpToolRefusal(
+      "the operator is on a voice call that has reported no selected card, so this turn names no conversation. Ask which one they meant, or pass conversationId explicitly.",
+      { code: "voice_selected_context_absent" },
+    );
+  }
+  if (lookup.state === "awaiting-handoff") {
+    throw new McpToolRefusal(
+      "the operator has spoken again since the card that started this work, so no selected card belongs to the turn in hand. Ask which conversation they mean rather than acting on the previous one.",
+      { code: "voice_selected_context_superseded" },
+    );
+  }
+  if (lookup.reference.state === "none") {
+    throw new McpToolRefusal(
+      "the operator spoke that turn with NO card selected, so the reference names no conversation. Ask which conversation they meant, or pass conversationId explicitly.",
+      { code: "selected_context_empty", capturedAt: lookup.reference.capturedAt },
+    );
+  }
+  const record = dependencies.selectedConversation().resolve(lookup.reference.conversationId);
+  if (!record) {
+    throw new McpToolRefusal(
+      "the card the operator was looking at is not in the Viewer registry — the reference is stale or names a conversation this Viewer never owned.",
+      {
+        code: "selected_context_unresolved",
+        conversationId: lookup.reference.conversationId,
+        capturedAt: lookup.reference.capturedAt,
+      },
+    );
+  }
+  return {
+    target: { ref: lookup.reference, record },
+    conversationId: record.conversationId,
+    voice: { handoff: lookup.handoff },
+  };
 }
 
 /** What the tool echoes back, so the caller can see which card it acted on.

--- a/src/lib/mcp/voiceUtteranceContext.test.ts
+++ b/src/lib/mcp/voiceUtteranceContext.test.ts
@@ -242,6 +242,60 @@ test("speaking again withdraws the card until the new utterance is handed off", 
   expect(answered.conversationId).toBe(OTHER);
 });
 
+test("A, B, then a late handoff for A: the tool must not return card B", async () => {
+  /* The reviewer's repro, driven the way the browser actually drives it. The
+     client reports a join only while one utterance is outstanding, so with A and
+     B both published it reports nothing at all — and the reader refuses instead
+     of handing the agent card B under handoff A's name.
+
+     The earlier version of this case labelled the late report with A's identity
+     by hand, which the ledger correctly refused; the production client would have
+     labelled it B and been believed. This drives the client's own decision. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await control({ action: "selectedContext", selectedContext: reference(SELECTED, 1), utterance: utterance(1) }, PEER);
+  await control({ action: "selectedContext", selectedContext: reference(OTHER, 2), utterance: utterance(2) }, PEER);
+
+  /* What the client sends after seeing A's handoff with two outstanding: nothing. */
+  const refused = await refusal(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-ambiguous",
+  }));
+  expect(refused.details.code).toBe("voice_selected_context_superseded");
+
+  /* And had it reported anyway, naming the newer utterance as the older one's
+     work, the ledger would still refuse to complete the wrong admission. */
+  const mislabelled = await control({
+    action: "handoff",
+    utterance: utterance(1),
+    handoff: { handoffId: "handoff-1", itemId: "item-1", userBidiTurnId: "bidi-1" },
+  }, PEER);
+  expect(mislabelled.status).toBe(409);
+  const stillRefused = await refusal(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-ambiguous-2",
+  }));
+  expect(stillRefused.details.code).toBe("voice_selected_context_superseded");
+});
+
+test("a handoff report whose identity halves disagree completes nothing", async () => {
+  /* Both halves are checked because they answer different questions: the id says
+     which publication the report belongs to, the sequence says where it sits in
+     the call. A report that mixes one turn's id with another's position
+     describes a boundary this ledger never saw. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await control({ action: "selectedContext", selectedContext: reference(SELECTED, 1), utterance: utterance(1) }, PEER);
+
+  const crossed = await control({
+    action: "handoff",
+    utterance: { id: utterance(1).id, sequence: 2 },
+    handoff: { handoffId: "handoff-1", itemId: "item-1", userBidiTurnId: "bidi-1" },
+  }, PEER);
+  expect(crossed.status).toBe(409);
+
+  const refused = await refusal(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-crossed",
+  }));
+  expect(refused.details.code).toBe("voice_selected_context_superseded");
+});
+
 test("a late handoff for a superseded utterance never delivers its card", async () => {
   /* Out of order on the wire: the first utterance's handoff arrives after the
      second utterance has already been published. It must not resurrect the

--- a/src/lib/mcp/voiceUtteranceContext.test.ts
+++ b/src/lib/mcp/voiceUtteranceContext.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { executeRealtimeControl } from "@/lib/runtime/realtimeControl";
+import { resetVoiceViewBindings } from "@/lib/runtime/voiceViewBinding";
+import { captureSelectedContext, type SelectedContextRef } from "@/lib/selection/selectedContext";
+
+import { viewerMcpBindings } from "./bindings";
+import { McpToolRefusal } from "./server";
+import type { VoiceUtteranceLookup } from "./selectedContextTarget";
+
+/**
+ * The spoken card reaches the work (#1629), across the seam that actually
+ * separates them.
+ *
+ * A spoken turn carries no `ctx=` marker: the operator's audio goes straight to
+ * the model, so an agent asked out loud to "read that one" has nothing to pass
+ * to a tool. The card is recorded in the voice ledger instead — and that ledger
+ * lives in the Viewer process while the tool runs in the MCP server, so a join
+ * recorded and never read is a join that changes nothing.
+ *
+ * Both halves here are the production code. `executeRealtimeControl` builds the
+ * ledger from real admissions and real handoff reports, the MCP binding is the
+ * real `conversation_messages`, and the lookup between them is the production
+ * translation of the production endpoint's answer. Only the HTTP hop is elided,
+ * because a loopback socket would prove the same thing more slowly.
+ *
+ * The property under test is the one the reviewer named: a POST that succeeds
+ * is not delivery. What is asserted is that the tool ANSWERS ABOUT THE CARD —
+ * and, at every point where it cannot honestly do so, refuses with its own
+ * reason instead of reaching for the card from the turn before.
+ */
+
+const CALLER = "conversation_voice_caller";
+const SELECTED = "conversation_atlas_selected";
+const OTHER = "conversation_atlas_other";
+const DESK = { viewSessionId: "vs-desk-1", deviceId: "dev-desk" };
+const NOW = Date.parse("2026-09-10T09:00:00.000Z");
+
+let sandbox = "";
+let selectedTranscript = "";
+let otherTranscript = "";
+
+beforeEach(() => {
+  resetVoiceViewBindings();
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-utterance-mcp-"));
+  selectedTranscript = path.join(sandbox, "selected.jsonl");
+  otherTranscript = path.join(sandbox, "other.jsonl");
+  fs.writeFileSync(selectedTranscript, `${JSON.stringify({
+    type: "response_item",
+    timestamp: "2026-09-10T08:59:00.000Z",
+    payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "the selected card speaks" }] },
+  })}\n`);
+  fs.writeFileSync(otherTranscript, `${JSON.stringify({
+    type: "response_item",
+    timestamp: "2026-09-10T08:58:00.000Z",
+    payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "the other card speaks" }] },
+  })}\n`);
+});
+
+afterEach(() => {
+  resetVoiceViewBindings();
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+/** A host with a live call, and nothing else this file needs from one. */
+function voiceHost() {
+  return {
+    async startRealtimeWebRtc() {
+      return {
+        sdp: "v=0\r\nanswer",
+        realtimeSessionId: "live-1",
+        persona: { variant: "modality" as const, personaId: `voice_persona_${"e".repeat(46)}` },
+      };
+    },
+    async appendRealtimeSpeech() {},
+    async stopRealtime() {},
+    currentRealtimeSessionId() { return "live-1"; },
+  };
+}
+
+const OPERATOR = { operator: true };
+const PEER = { caller: { kind: "session" as const, realtimeSessionId: "live-1" }, operator: false };
+/** The backing agent, identified by the capability the registry maps to it. */
+const AGENT = { caller: { kind: "conversation" as const, conversationId: CALLER }, operator: false };
+
+function reference(card: string, revision: number, at = NOW): SelectedContextRef {
+  return captureSelectedContext({
+    context: { project: "atlas" },
+    slice: { focusedPath: `${card}.jsonl`, selectedPaths: [] },
+    cards: [{ path: `${card}.jsonl`, conversationId: card, label: card }],
+    identity: DESK,
+    revision,
+    now: at,
+  });
+}
+
+const utterance = (sequence: number) => ({ id: `${sequence}`.padStart(32, "f"), sequence });
+
+async function control(body: Record<string, unknown>, authority: Parameters<typeof executeRealtimeControl>[2]) {
+  return executeRealtimeControl({ conversationId: CALLER, ...body }, () => voiceHost(), authority);
+}
+
+/** Open a call, publish an utterance's card, and report the handoff it became. */
+async function spokenTurn(card: string, sequence: number, options: { handoff?: boolean } = {}) {
+  await control({ action: "selectedContext", selectedContext: reference(card, sequence), utterance: utterance(sequence) }, PEER);
+  if (options.handoff === false) return;
+  await control({
+    action: "handoff",
+    utterance: utterance(sequence),
+    handoff: { handoffId: `handoff-${sequence}`, itemId: `item-${sequence}`, userBidiTurnId: `bidi-${sequence}` },
+  }, PEER);
+}
+
+/**
+ * The production translation of the production endpoint's answer.
+ *
+ * Kept byte-for-byte in step with `productionVoiceUtteranceContext` in
+ * `bindings.ts`: if the two ever disagree about what a state means, this file
+ * stops describing the deployed reader and starts describing itself.
+ */
+function lookupThroughTheControlEndpoint(): () => Promise<VoiceUtteranceLookup> {
+  return async () => {
+    const answer = await control({ action: "utteranceContext" }, AGENT);
+    if (answer.status !== 200) {
+      return { state: "unavailable", reason: String(answer.body.error ?? `status ${answer.status}`) };
+    }
+    return answer.body.utterance as VoiceUtteranceLookup;
+  };
+}
+
+function bindings(voiceUtteranceContext: () => Promise<VoiceUtteranceLookup>) {
+  const records: Record<string, { path: string }> = {
+    [SELECTED]: { path: selectedTranscript },
+    [OTHER]: { path: otherTranscript },
+  };
+  const pinnedTranscript = (candidate: string) => {
+    if (candidate !== selectedTranscript && candidate !== otherTranscript) return undefined;
+    const descriptor = fs.openSync(candidate, "r");
+    return { descriptor, stat: fs.fstatSync(descriptor), rootName: "codex-sessions", root: sandbox, sameIdentity: () => true };
+  };
+  return viewerMcpBindings(undefined, undefined, {
+    selectedContext: {
+      selectedConversation: () => ({
+        resolve: (conversationId: string) => records[conversationId]
+          ? { conversationId, engine: "codex" as const, path: records[conversationId]!.path, project: "atlas" }
+          : null,
+        readTail: (conversationId: string, bounds: { maxLines: number }) => {
+          const candidate = records[conversationId]?.path;
+          if (!candidate) return null;
+          return {
+            path: candidate,
+            lines: fs.readFileSync(candidate, "utf8").split("\n").filter(Boolean).slice(-bounds.maxLines),
+            bytes: fs.statSync(candidate).size,
+            truncated: false,
+          };
+        },
+      }),
+      pathAllowed: () => true,
+      voiceUtteranceContext,
+    },
+    pinnedTranscript,
+  } as never);
+}
+
+async function refusal(run: Promise<unknown>): Promise<McpToolRefusal> {
+  try {
+    await run;
+  } catch (error) {
+    expect(error).toBeInstanceOf(McpToolRefusal);
+    return error as McpToolRefusal;
+  }
+  throw new Error("expected a typed refusal");
+}
+
+/* ------------------------------------------------------------------ *
+ * The delivery itself.
+ * ------------------------------------------------------------------ */
+
+test("a tool asked for nothing reads the card the operator spoke about", async () => {
+  /* The whole point, end to end: the operator selects a card, says "read that
+     one", and the agent — which was handed no id, no path and no reference —
+     comes back with THAT card's transcript. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 1);
+
+  const answered = await bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-1",
+  }) as { conversationId: string; records: Array<{ text: string }> };
+
+  expect(answered.conversationId).toBe(SELECTED);
+  expect(answered.records[0]!.text).toContain("the selected card speaks");
+});
+
+test("the answer names the handoff it was resolved through", async () => {
+  /* Provenance, so the operator and a later reader can tell a spoken resolution
+     from an argument the agent supplied itself. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 1);
+
+  /* `tailLines` takes the keyed selected-card read (#844 §6), which is the shape
+     a spoken "what does that one say" actually wants. */
+  const answered = await bindings(lookupThroughTheControlEndpoint()).get_conversation({
+    clientRequestId: "spoken-read-2",
+    tailLines: 5,
+  }) as { conversationId: string; selectedContext?: { conversationId?: string } };
+
+  expect(answered.conversationId).toBe(SELECTED);
+  expect(answered.selectedContext?.conversationId).toBe(SELECTED);
+});
+
+/* ------------------------------------------------------------------ *
+ * Every way it must refuse rather than answer about the wrong card.
+ * ------------------------------------------------------------------ */
+
+test("speaking again withdraws the card until the new utterance is handed off", async () => {
+  /* THE FORBIDDEN FALLBACK. The operator pointed at one card, then spoke again
+     about something else. Until that second utterance becomes work, no card
+     describes the turn in hand — and answering about the first one is exactly
+     the failure this refuses. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 1);
+  await spokenTurn(OTHER, 2, { handoff: false });
+
+  const refused = await refusal(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-3",
+  }));
+  expect(refused.details.code).toBe("voice_selected_context_superseded");
+  expect(refused.message).toContain("spoken again");
+
+  /* And once that utterance IS handed off, the tool answers about the NEW card. */
+  await control({
+    action: "handoff",
+    utterance: utterance(2),
+    handoff: { handoffId: "handoff-2", itemId: "item-2", userBidiTurnId: "bidi-2" },
+  }, PEER);
+  const answered = await bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-4",
+  }) as { conversationId: string };
+  expect(answered.conversationId).toBe(OTHER);
+});
+
+test("a late handoff for a superseded utterance never delivers its card", async () => {
+  /* Out of order on the wire: the first utterance's handoff arrives after the
+     second utterance has already been published. It must not resurrect the
+     first card, and it must not silently complete the second. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 1, { handoff: false });
+  await control({ action: "selectedContext", selectedContext: reference(OTHER, 2), utterance: utterance(2) }, PEER);
+  const late = await control({
+    action: "handoff",
+    utterance: utterance(1),
+    handoff: { handoffId: "handoff-1", itemId: "item-1", userBidiTurnId: "bidi-1" },
+  }, PEER);
+
+  expect(late.status).toBe(409);
+  const refused = await refusal(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-5",
+  }));
+  expect(refused.details.code).toBe("voice_selected_context_superseded");
+});
+
+test("a reordered publication cannot become the card a tool reads", async () => {
+  /* The reproduced ordering defect, followed all the way to the tool: the older
+     reference is refused by the ledger, so the work still resolves to the newer
+     card rather than the one that arrived last. */
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 2);
+  const stale = await control(
+    { action: "selectedContext", selectedContext: reference(OTHER, 1), utterance: utterance(1) },
+    PEER,
+  );
+  expect(stale.status).toBe(409);
+
+  const answered = await bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-6",
+  }) as { conversationId: string };
+  expect(answered.conversationId).toBe(SELECTED);
+});
+
+test("a call that has reported no card refuses instead of guessing", async () => {
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+
+  const refused = await refusal(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-7",
+  }));
+  expect(refused.details.code).toBe("voice_selected_context_absent");
+});
+
+test("a Viewer that cannot be read says so, rather than reporting an empty selection", async () => {
+  /* Reporting a failed read as "nothing selected" is how an agent tells the
+     operator they pointed at nothing when the truth is that nobody could look. */
+  const refused = await refusal(bindings(async () => ({
+    state: "unavailable", reason: "connection failed",
+  })).conversation_messages({ clientRequestId: "spoken-read-8" }));
+  expect(refused.details.code).toBe("voice_selected_context_unavailable");
+  expect(refused.message).toContain("connection failed");
+});
+
+test("an agent not on a call is unaffected, and still has to name its target", async () => {
+  /* The regression guard for every ordinary caller: no call, no new behaviour,
+     and the same error it has always had. */
+  await expect(bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-9",
+  })).rejects.toThrow("conversationId, transcriptPath or selectedContext is required");
+});
+
+test("naming a target explicitly is never overridden by the call", async () => {
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 1);
+
+  const byId = await bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-10",
+    conversationId: OTHER,
+  }) as { conversationId: string };
+  expect(byId.conversationId).toBe(OTHER);
+
+  const byPath = await bindings(lookupThroughTheControlEndpoint()).conversation_messages({
+    clientRequestId: "spoken-read-11",
+    transcriptPath: otherTranscript,
+  }) as { transcriptPath: string };
+  expect(byPath.transcriptPath).toBe(otherTranscript);
+});
+
+/* ------------------------------------------------------------------ *
+ * Who may read the ledger at all.
+ * ------------------------------------------------------------------ */
+
+test("only the call's own conversation may read what it points at", async () => {
+  await control({ action: "start", sdp: "v=0\r\noffer\r\n", view: DESK }, OPERATOR);
+  await spokenTurn(SELECTED, 1);
+
+  for (const authority of [
+    { caller: { kind: "conversation" as const, conversationId: "conversation_someone_else" }, operator: false },
+    { caller: { kind: "anonymous" as const }, operator: false },
+  ]) {
+    const refused = await control({ action: "utteranceContext" }, authority);
+    expect(refused.status).toBe(403);
+    expect(String(refused.body.error)).toContain("Only that call's conversation");
+  }
+});
+
+test("a conversation with no call answers no-call rather than failing", async () => {
+  const answered = await control({ action: "utteranceContext" }, AGENT);
+  expect(answered.status).toBe(200);
+  expect(answered.body.utterance).toEqual({ state: "no-call" });
+});

--- a/src/lib/mcp/voiceUtteranceWiring.test.ts
+++ b/src/lib/mcp/voiceUtteranceWiring.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, expect, test } from "bun:test";
+
+import { executeRealtimeControl } from "@/lib/runtime/realtimeControl";
+import { bindVoiceSession, recordVoiceHandoff, resetVoiceViewBindings } from "@/lib/runtime/voiceViewBinding";
+import { admitVoiceSelectedContext } from "@/lib/runtime/voiceViewBinding";
+import { captureSelectedContext } from "@/lib/selection/selectedContext";
+
+import { voiceUtteranceLookup, productionViewerControlDependencies } from "./bindings";
+
+/**
+ * The hop itself (#1629): the MCP server runs beside the agent, the voice ledger
+ * lives in the Viewer, and everything between them is a real HTTP request.
+ *
+ * The in-process suite proves what the reader DOES with each state; this one
+ * proves the states survive the wire — that the request goes to the right path
+ * with the right body, that the capability the agent holds is forwarded, and
+ * that a joined answer arrives with its reference and handoff intact. It uses
+ * the production control hop against a loopback server that answers with the
+ * production `executeRealtimeControl`, so the only thing standing in for real
+ * deployment is which port the hop dials.
+ *
+ * The caller resolution is deliberately NOT here. Which conversation an agent
+ * is, and whether it may read another's call, is authority rather than wiring,
+ * and it is proven against the real ledger in `voiceUtteranceContext.test.ts`.
+ */
+
+const CALLER = "conversation_wiring_caller";
+const CARD = "conversation_wiring_card";
+const DESK = { viewSessionId: "vs-wire-1", deviceId: "dev-wire" };
+const NOW = Date.parse("2026-09-10T10:00:00.000Z");
+
+const servers: { stop(): void }[] = [];
+const originalPort = process.env.LLV_VIEWER_PORT;
+const originalTarget = process.env.LLV_VIEWER_DEPLOY_TARGET;
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop();
+  resetVoiceViewBindings();
+  if (originalPort === undefined) delete process.env.LLV_VIEWER_PORT;
+  else process.env.LLV_VIEWER_PORT = originalPort;
+  if (originalTarget === undefined) delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  else process.env.LLV_VIEWER_DEPLOY_TARGET = originalTarget;
+});
+
+interface Received {
+  pathname: string;
+  method: string;
+  body: Record<string, unknown>;
+  origin: string | null;
+  fetchSite: string | null;
+}
+
+/** A Viewer on a loopback port, answering with the production control. */
+function viewer(received: Received[], answer?: (body: Record<string, unknown>) => Response) {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = await request.json() as Record<string, unknown>;
+      received.push({
+        pathname: url.pathname,
+        method: request.method,
+        body,
+        origin: request.headers.get("origin"),
+        fetchSite: request.headers.get("sec-fetch-site"),
+      });
+      if (answer) return answer(body);
+      /* The production control, with the authority the route would have derived
+         from the forwarded capability. */
+      const result = await executeRealtimeControl(
+        body,
+        () => null,
+        { caller: { kind: "conversation", conversationId: String(body.conversationId) }, operator: false },
+      );
+      return Response.json(result.body, { status: result.status });
+    },
+  });
+  servers.push(server);
+  /* The hop resolves its origin from this, exactly as it does in the image. */
+  process.env.LLV_VIEWER_PORT = String(server.port);
+  delete process.env.LLV_VIEWER_DEPLOY_TARGET;
+  return server;
+}
+
+const post = () => productionViewerControlDependencies().post;
+
+function reference(card: string) {
+  return captureSelectedContext({
+    context: { project: "atlas" },
+    slice: { focusedPath: `${card}.jsonl`, selectedPaths: [] },
+    cards: [{ path: `${card}.jsonl`, conversationId: card, label: card }],
+    identity: DESK,
+    revision: 1,
+    now: NOW,
+  });
+}
+
+test("the reader asks the realtime control for the named conversation, same-origin", async () => {
+  const received: Received[] = [];
+  viewer(received);
+  await voiceUtteranceLookup(CALLER, post());
+
+  expect(received).toHaveLength(1);
+  expect(received[0]).toMatchObject({
+    pathname: "/api/runtime/realtime",
+    method: "POST",
+    body: { action: "utteranceContext", conversationId: CALLER },
+    fetchSite: "same-origin",
+  });
+  /* The same-origin headers the Viewer's cross-origin guard requires. */
+  expect(received[0]!.origin).toContain("127.0.0.1");
+});
+
+test("a joined answer survives the wire with its reference and handoff", async () => {
+  const received: Received[] = [];
+  viewer(received);
+  const utterance = { id: "a".repeat(32), sequence: 1 };
+  const handoff = { handoffId: "handoff-w", itemId: "item-w", userBidiTurnId: "bidi-w" };
+  bindVoiceSession(CALLER, "rt-wire", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CALLER, realtimeSessionId: "rt-wire", reference: reference(CARD), utterance, now: NOW,
+  });
+  recordVoiceHandoff({ conversationId: CALLER, realtimeSessionId: "rt-wire", utterance, handoff });
+
+  const lookup = await voiceUtteranceLookup(CALLER, post());
+  expect(lookup.state).toBe("joined");
+  expect(lookup.state === "joined" && lookup.reference.state === "selected"
+    && lookup.reference.conversationId).toBe(CARD);
+  expect(lookup.state === "joined" && lookup.handoff).toEqual(handoff);
+});
+
+test("every refusing state crosses the wire as itself", async () => {
+  const received: Received[] = [];
+  viewer(received);
+
+  expect(await voiceUtteranceLookup(CALLER, post())).toEqual({ state: "no-call" });
+
+  bindVoiceSession(CALLER, "rt-wire", DESK);
+  expect(await voiceUtteranceLookup(CALLER, post())).toEqual({ state: "no-reference" });
+
+  admitVoiceSelectedContext({
+    conversationId: CALLER, realtimeSessionId: "rt-wire", reference: reference(CARD),
+    utterance: { id: "b".repeat(32), sequence: 1 }, now: NOW,
+  });
+  expect(await voiceUtteranceLookup(CALLER, post())).toEqual({ state: "awaiting-handoff" });
+});
+
+test("a Viewer that refuses the read is reported as unavailable, never as no card", async () => {
+  /* The distinction the agent acts on: "you selected nothing" is a fact about
+     the operator, and "nobody could look" is a fact about this machine. */
+  const received: Received[] = [];
+  viewer(received, () => Response.json({ error: "utteranceContext reads what the operator's own voice call points at." }, { status: 403 }));
+
+  const lookup = await voiceUtteranceLookup(CALLER, post());
+  expect(lookup.state).toBe("unavailable");
+  expect(lookup.state === "unavailable" && lookup.reason).toContain("own voice call");
+});
+
+test("an answer in a shape this reader does not know is unavailable, never guessed at", async () => {
+  const received: Received[] = [];
+  viewer(received, () => Response.json({ ok: true, utterance: { state: "something-new" } }));
+  const unknown = await voiceUtteranceLookup(CALLER, post());
+  expect(unknown.state).toBe("unavailable");
+  expect(unknown.state === "unavailable" && unknown.reason).toContain("something-new");
+
+  servers.splice(0).forEach((server) => server.stop());
+  viewer(received, () => Response.json({ ok: true, utterance: { state: "joined", handoff: {} } }));
+  const incomplete = await voiceUtteranceLookup(CALLER, post());
+  expect(incomplete.state).toBe("unavailable");
+  expect(incomplete.state === "unavailable" && incomplete.reason).toContain("no readable reference");
+});
+
+test("a Viewer that is not listening is unavailable rather than an empty selection", async () => {
+  const server = viewer([]);
+  server.stop();
+  const lookup = await voiceUtteranceLookup(CALLER, post());
+  expect(lookup.state).toBe("unavailable");
+});

--- a/src/lib/realtime/codexRealtimeClient.selectedContext.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.selectedContext.dom.test.ts
@@ -89,6 +89,8 @@ interface ControlRequest {
   realtimeSessionId?: string;
   selectedContext?: SelectedContextRef;
   operatorEventId?: string;
+  utterance?: { id: string; sequence: number };
+  handoff?: { handoffId: string | null; itemId: string | null; userBidiTurnId: string | null };
 }
 
 let requests: ControlRequest[] = [];
@@ -129,6 +131,19 @@ const fragment = (peer: StubPeerConnection, role: "user" | "assistant", text: st
   });
 const finished = (peer: StubPeerConnection, role: "user" | "assistant", text: string) =>
   peer.channel.onmessage?.({ data: JSON.stringify({ type: "turn.done", role, item: { text } }) });
+const handedOff = (peer: StubPeerConnection, suffix: string) =>
+  peer.channel.onmessage?.({
+    data: JSON.stringify({
+      type: "delegation.created",
+      item: {
+        id: `delegation-${suffix}`,
+        type: "delegation",
+        target: "client",
+        handoff_id: `handoff-${suffix}`,
+        user_bidi_turn_id: `bidi-${suffix}`,
+      },
+    }),
+  });
 
 test("the call binds itself to this window when it opens", async () => {
   await liveCall("conversation_voice_bind");
@@ -231,4 +246,57 @@ test("each finished utterance reports again, so a mid-call re-selection is honou
   expect(published[0]!.selectedContext).toMatchObject({ state: "selected" });
   expect(published[1]!.selectedContext).toMatchObject({ state: "none" });
   expect(requests.filter((request) => request.action === "operatorActivity")).toHaveLength(2);
+});
+
+
+test("each utterance carries an identity, and a retry reuses it", async () => {
+  /* The identity is what tells the server a second POST is the same spoken turn
+     rather than a later one, so it has to survive the retry and change between
+     utterances. */
+  const peer = await liveCall("conversation_voice_identity");
+  finished(peer, "user", "first");
+  await Promise.resolve();
+  finished(peer, "user", "second");
+  await Promise.resolve();
+
+  const published = requests.filter((request) => request.action === "selectedContext");
+  expect(published).toHaveLength(2);
+  expect(published[0]!.utterance).toMatchObject({ sequence: 1 });
+  expect(published[1]!.utterance).toMatchObject({ sequence: 2 });
+  expect(published[0]!.utterance!.id).toMatch(/^[a-f0-9]{32}$/);
+  expect(published[1]!.utterance!.id).not.toBe(published[0]!.utterance!.id);
+});
+
+test("a handoff is reported once, against the utterance it follows", async () => {
+  const peer = await liveCall("conversation_voice_handoff");
+  finished(peer, "user", "look at that one");
+  await Promise.resolve();
+  handedOff(peer, "a");
+  await Promise.resolve();
+
+  const published = requests.filter((request) => request.action === "selectedContext");
+  const joins = requests.filter((request) => request.action === "handoff");
+  expect(joins).toHaveLength(1);
+  expect(joins[0]!.realtimeSessionId).toBe("live-1");
+  expect(joins[0]!.utterance!.id).toBe(published[0]!.utterance!.id);
+  expect(joins[0]!.handoff).toEqual({
+    handoffId: "handoff-a", itemId: "delegation-a", userBidiTurnId: "bidi-a",
+  });
+
+  /* Consumed. A second handoff on the same utterance — a duplicate event, or one
+     belonging to a turn that published nothing — reports nothing rather than
+     claiming the utterance twice. */
+  handedOff(peer, "b");
+  await Promise.resolve();
+  expect(requests.filter((request) => request.action === "handoff")).toHaveLength(1);
+});
+
+test("a handoff before any utterance is published reports nothing", async () => {
+  /* Nothing has claimed a card yet, so there is nothing to join it to, and
+     inventing an utterance for it would put a reference in the ledger the
+     operator never published. */
+  const peer = await liveCall("conversation_voice_early_handoff");
+  handedOff(peer, "c");
+  await Promise.resolve();
+  expect(requests.filter((request) => request.action === "handoff")).toEqual([]);
 });

--- a/src/lib/realtime/codexRealtimeClient.selectedContext.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.selectedContext.dom.test.ts
@@ -327,3 +327,64 @@ test("a usage warning belongs to the call that reported it", async () => {
   expect(client.getSnapshot().notice).toBeNull();
   await client.stop();
 });
+
+
+test("two utterances outstanding: a handoff belongs to neither, so none is claimed", async () => {
+  /* The correlation this peer can prove holds in exactly one arrangement: one
+     utterance outstanding, one handoff arriving. With two outstanding the event
+     could belong to either, and reporting it against the newer one is how card B
+     comes back to a question asked about card A.
+
+     So nothing is reported. The standing admission never gets a handoff, the
+     reader refuses, and the agent asks which conversation the operator meant. */
+  const peer = await liveCall("conversation_voice_ambiguous");
+  finished(peer, "user", "look at A");
+  await Promise.resolve();
+  finished(peer, "user", "now look at B");
+  await Promise.resolve();
+  handedOff(peer, "a");
+  await Promise.resolve();
+
+  expect(requests.filter((request) => request.action === "selectedContext")).toHaveLength(2);
+  expect(requests.filter((request) => request.action === "handoff")).toEqual([]);
+});
+
+test("the queue recovers on the next utterance, so one crossed pair costs one turn", async () => {
+  const peer = await liveCall("conversation_voice_ambiguous_recovery");
+  finished(peer, "user", "look at A");
+  await Promise.resolve();
+  finished(peer, "user", "now look at B");
+  await Promise.resolve();
+  handedOff(peer, "a");
+  await Promise.resolve();
+  /* A second handoff for the abandoned pair still claims nothing. */
+  handedOff(peer, "b");
+  await Promise.resolve();
+  expect(requests.filter((request) => request.action === "handoff")).toEqual([]);
+
+  finished(peer, "user", "and now C");
+  await Promise.resolve();
+  handedOff(peer, "c");
+  await Promise.resolve();
+
+  const joins = requests.filter((request) => request.action === "handoff");
+  expect(joins).toHaveLength(1);
+  expect(joins[0]!.utterance!.sequence).toBe(3);
+  expect(joins[0]!.handoff!.handoffId).toBe("handoff-c");
+});
+
+test("the join names the utterance it claimed, never the latest one", async () => {
+  /* The report carries the claimed queue entry's own identity, so a future
+     change that let the queue and the latest publish diverge cannot silently
+     re-point a join at a newer turn. */
+  const peer = await liveCall("conversation_voice_claim_identity");
+  finished(peer, "user", "look at A");
+  await Promise.resolve();
+  const published = requests.filter((request) => request.action === "selectedContext");
+  handedOff(peer, "a");
+  await Promise.resolve();
+
+  const joins = requests.filter((request) => request.action === "handoff");
+  expect(joins).toHaveLength(1);
+  expect(joins[0]!.utterance).toEqual(published[0]!.utterance!);
+});

--- a/src/lib/realtime/codexRealtimeClient.selectedContext.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.selectedContext.dom.test.ts
@@ -300,3 +300,30 @@ test("a handoff before any utterance is published reports nothing", async () => 
   await Promise.resolve();
   expect(requests.filter((request) => request.action === "handoff")).toEqual([]);
 });
+
+
+test("a usage warning belongs to the call that reported it", async () => {
+  /* The warning describes an account's window as it stood during one call. A
+     fresh call that has reported nothing must not open showing the last one's. */
+  const client = codexRealtimeClient("conversation_voice_usage");
+  await client.start();
+  const peer = StubPeerConnection.latest!;
+  peer.channel.onopen?.();
+  peer.channel.onmessage?.({
+    data: JSON.stringify({ type: "session.usage.updated", usage_limit: { status: "approaching" } }),
+  });
+  expect(client.getSnapshot().notice).toContain("approaching its usage limit");
+  /* And a call that reports its window is fine again says so. */
+  peer.channel.onmessage?.({
+    data: JSON.stringify({ type: "session.usage.updated", usage_limit: { status: "ok" } }),
+  });
+  expect(client.getSnapshot().notice).toBeNull();
+
+  peer.channel.onmessage?.({
+    data: JSON.stringify({ type: "session.usage.updated", usage_limit: { status: "approaching" } }),
+  });
+  await client.stop();
+  await client.start();
+  expect(client.getSnapshot().notice).toBeNull();
+  await client.stop();
+});

--- a/src/lib/realtime/codexRealtimeClient.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.test.ts
@@ -4,7 +4,7 @@ import {
   parseCodexRealtimeEvent,
 } from "./codexRealtimeClient";
 
-test("parses Frameless Bidi transcript, delegation, and error events", () => {
+test("parses Frameless Bidi transcript, handoff, usage and error events", () => {
   expect(parseCodexRealtimeEvent({
     type: "input_transcript.added",
     item: { text: "hello" },
@@ -13,10 +13,34 @@ test("parses Frameless Bidi transcript, delegation, and error events", () => {
     type: "turn.done",
     turn: { role: "assistant", transcript: "done" },
   })).toEqual({ kind: "transcript", role: "assistant", text: "done", final: true });
+  /* The identities the native controller reads off this event, and the join
+     between an utterance and the work it became (#1629). */
   expect(parseCodexRealtimeEvent({
     type: "delegation.created",
-    item: { id: "delegation-1" },
-  })).toEqual({ kind: "delegation", id: "delegation-1" });
+    item: {
+      id: "delegation-1",
+      type: "delegation",
+      target: "client",
+      handoff_id: "handoff-1",
+      user_bidi_turn_id: "bidi-1",
+    },
+  })).toEqual({ kind: "handoff", handoffId: "handoff-1", itemId: "delegation-1", userBidiTurnId: "bidi-1" });
+  /* The same handoff, announced flat before the item exists. */
+  expect(parseCodexRealtimeEvent({
+    type: "conversation.handoff.requested",
+    handoff_id: "handoff-1",
+    item_id: "item-1",
+    user_bidi_turn_id: "bidi-1",
+  })).toEqual({ kind: "handoff", handoffId: "handoff-1", itemId: "item-1", userBidiTurnId: "bidi-1" });
+  /* An approaching limit keeps the call running, so it is not an error. */
+  expect(parseCodexRealtimeEvent({
+    type: "session.usage.updated",
+    usage_limit: { status: "approaching" },
+  })).toEqual({ kind: "usage", status: "approaching" });
+  expect(parseCodexRealtimeEvent({
+    type: "session.usage.updated",
+    usage_limit: { status: null },
+  })).toEqual({ kind: "ignored" });
   expect(parseCodexRealtimeEvent({
     type: "error",
     error: { message: "backend closed" },

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -510,7 +510,7 @@ class CodexRealtimeClient {
    * further utterance is attributed to the later one. Closing that needs an
    * identifier the current data channel does not carry, which cannot be
    * established without a live capture; until then the ledger's `handoff` is
-   * evidence about the call, not a guarantee about a particular turn.
+   * evidence about the call, and it guarantees nothing about a particular turn.
    */
   private publishHandoffJoin(event: { handoffId: string | null; itemId: string | null; userBidiTurnId: string | null }): void {
     const utteranceId = this.utteranceAwaitingHandoff;

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -226,10 +226,10 @@ class CodexRealtimeClient {
      ledger here. */
   private utteranceSequence = 0;
   private utteranceId: string | null = null;
-  /* Set when an utterance is published and cleared by the first handoff reported
-     against it, so one handoff is never reported twice and a slot left over from
-     an utterance that produced none cannot capture an unrelated later one. */
-  private utteranceAwaitingHandoff: string | null = null;
+  /* Utterances published and not yet accounted for by a handoff. A join is
+     reported only while this holds exactly one of them, because that is the only
+     arrangement in which the association is a fact rather than a guess. */
+  private utterancesAwaitingHandoff: { id: string; sequence: number }[] = [];
   private epoch = 0;
 
   constructor(readonly conversationId: string) {}
@@ -502,25 +502,44 @@ class CodexRealtimeClient {
    * attaches the canonical identities to that admission instead of counting a
    * second utterance.
    *
-   * WHAT THIS CANNOT DO. The handoff event and the transcript boundary that
-   * published the reference share no identifier on the wire, so the join is the
-   * most recent unclaimed utterance rather than a proven correlation. In the
-   * ordinary flow — speak, pause, handoff — that is the same utterance. Under
-   * barge-in, a handoff arriving after the operator has already finished a
-   * further utterance is attributed to the later one. Closing that needs an
-   * identifier the current data channel does not carry, which cannot be
-   * established without a live capture; until then the ledger's `handoff` is
-   * evidence about the call, and it guarantees nothing about a particular turn.
+   * AND IT REPORTS NOTHING RATHER THAN GUESS. The handoff event and the
+   * transcript boundary that published the reference share no identifier on the
+   * wire, so the association is a fact in exactly one arrangement: one utterance
+   * outstanding, one handoff arriving. That is the ordinary flow — speak, pause,
+   * the work starts — and it is what the queue below holds.
+   *
+   * With two outstanding, a handoff could belong to either, and reporting it
+   * against the newer one is how card B ends up answering a question asked about
+   * card A. So the whole queue is abandoned instead: the standing admission
+   * never gets a handoff, the reader refuses `awaiting-handoff`, and the agent
+   * asks the operator which conversation they mean. The next utterance starts a
+   * clean queue, so one crossed pair costs one turn of context and nothing more.
+   *
+   * Closing this properly needs an identifier shared by the transcript boundary
+   * and the handoff — the native events carry `user_bidi_turn_id`, but whether
+   * the user transcript event carries it too cannot be established without a
+   * live capture. Until it is, an unproven correlation must not become a target.
    */
   private publishHandoffJoin(event: { handoffId: string | null; itemId: string | null; userBidiTurnId: string | null }): void {
-    const utteranceId = this.utteranceAwaitingHandoff;
-    if (!this.realtimeSessionId || !utteranceId) return;
-    this.utteranceAwaitingHandoff = null;
+    const outstanding = this.utterancesAwaitingHandoff;
+    if (outstanding.length !== 1) {
+      /* Ambiguous, or nothing to claim. Either way the queue no longer describes
+         anything this peer can prove, so it is dropped rather than drained into
+         a guess. */
+      this.utterancesAwaitingHandoff = [];
+      return;
+    }
+    const claimed = outstanding[0]!;
+    this.utterancesAwaitingHandoff = [];
+    if (!this.realtimeSessionId) return;
     const payload = JSON.stringify({
       action: "handoff",
       conversationId: this.conversationId,
       realtimeSessionId: this.realtimeSessionId,
-      utterance: { id: utteranceId, sequence: this.utteranceSequence },
+      /* The CLAIMED utterance's own identity, carried on the queue entry rather
+         than read off the latest publish, so the report cannot drift onto a
+         newer turn if the two ever stop being the same one. */
+      utterance: claimed,
       handoff: {
         handoffId: event.handoffId,
         itemId: event.itemId,
@@ -572,7 +591,7 @@ class CodexRealtimeClient {
        recognizes a replay as the same spoken turn rather than a later one. */
     this.utteranceSequence += 1;
     this.utteranceId = randomHex(16);
-    this.utteranceAwaitingHandoff = this.utteranceId;
+    this.utterancesAwaitingHandoff.push({ id: this.utteranceId, sequence: this.utteranceSequence });
     const payload = JSON.stringify({
       action: "selectedContext",
       conversationId: this.conversationId,
@@ -736,7 +755,7 @@ class CodexRealtimeClient {
        last one of this one. */
     this.utteranceSequence = 0;
     this.utteranceId = null;
-    this.utteranceAwaitingHandoff = null;
+    this.utterancesAwaitingHandoff = [];
     this.openTranscriptLines.clear();
   }
 }

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -36,11 +36,24 @@ export interface CodexRealtimeSnapshot {
   micMuted: boolean;
   /** Agent audio silenced locally; the call keeps running. */
   outputMuted: boolean;
+  /**
+   * Something the operator should know while the call keeps running (#1629).
+   *
+   * Deliberately not `error`, which puts the panel in its failed state and ends
+   * the call in the reader's mind. An approaching usage limit is the case this
+   * was added for: the backend says so before it cuts the call, and the operator
+   * can only act on it while there is still a call to act in.
+   */
+  notice: string | null;
 }
 
 export type ParsedRealtimeEvent =
   | { kind: "transcript"; role: "user" | "assistant"; text: string; final: boolean }
-  | { kind: "delegation"; id: string }
+  /** The handoff that turns the utterance just finished into work on the thread.
+      Its identities are the canonical join between what was said and what the
+      backing model was asked to do (#1629). */
+  | { kind: "handoff"; handoffId: string | null; itemId: string | null; userBidiTurnId: string | null }
+  | { kind: "usage"; status: string }
   | { kind: "error"; message: string }
   | { kind: "ignored" };
 
@@ -49,6 +62,21 @@ const MAX_LINES = 80;
 
 function newOperatorActivityId(): string {
   return randomHex(32);
+}
+
+/**
+ * The backend's usage-limit state, in words the operator can act on.
+ *
+ * Only `approaching` is spoken about: it is the one state where saying something
+ * changes what the operator does. Any other status the backend adds later is
+ * passed through rather than swallowed, because a warning nobody has taught this
+ * function about is still a warning.
+ */
+function usageNotice(status: string): string | null {
+  if (status === "approaching") {
+    return "This account is approaching its usage limit; the call may be cut short.";
+  }
+  return status === "ok" || status === "none" ? null : `Usage limit status: ${status}.`;
 }
 
 function randomHex(bytes: number): string {
@@ -112,12 +140,24 @@ export function parseCodexRealtimeEvent(value: unknown): ParsedRealtimeEvent {
       ? { kind: "transcript", role: eventRole(event, "assistant"), text, final: true }
       : { kind: "ignored" };
   }
-  if (type === "delegation.created") {
-    const id = stringAt(event.item, "id")
-      ?? stringAt(event.delegation, "id")
-      ?? stringAt(event, "delegation_item_id")
-      ?? "";
-    return id ? { kind: "delegation", id } : { kind: "ignored" };
+  if (type === "delegation.created" || type === "conversation.handoff.requested") {
+    /* Both events name the same handoff; `delegation.created` nests the
+       identities under the item it created and the request carries them flat. */
+    const item = object(event.item) ?? object(event.delegation);
+    const handoffId = stringAt(event, "handoff_id") ?? stringAt(item, "handoff_id");
+    const itemId = stringAt(event, "item_id") ?? stringAt(item, "id") ?? stringAt(event, "delegation_item_id");
+    const userBidiTurnId = stringAt(event, "user_bidi_turn_id") ?? stringAt(item, "user_bidi_turn_id");
+    return handoffId || itemId || userBidiTurnId
+      ? { kind: "handoff", handoffId, itemId, userBidiTurnId }
+      : { kind: "ignored" };
+  }
+  if (type === "session.usage.updated") {
+    /* A limit warning is not a failure: the call keeps running, and saying so
+       out of band is the difference between the operator finishing a thought
+       and the call ending mid-sentence with a generic transport message. The
+       9-second cutoff in `docs/realtime-v3/BLOCKED.md` is what this exists for. */
+    const status = stringAt(event.usage_limit, "status") ?? stringAt(event, "status");
+    return status ? { kind: "usage", status } : { kind: "ignored" };
   }
   if (type === "error") {
     const message = (
@@ -153,7 +193,9 @@ async function waitForIceGathering(peer: RTCPeerConnection): Promise<void> {
 }
 
 class CodexRealtimeClient {
-  private snapshot: CodexRealtimeSnapshot = { phase: "idle", lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false };
+  private snapshot: CodexRealtimeSnapshot = {
+    phase: "idle", lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false, notice: null,
+  };
   private readonly listeners = new Set<() => void>();
   private peer: RTCPeerConnection | null = null;
   private events: RTCDataChannel | null = null;
@@ -442,6 +484,35 @@ class CodexRealtimeClient {
     }
   }
 
+  /**
+   * Report which handoff the last published utterance became (#1629).
+   *
+   * Fire-and-forget for the same reason the reference itself is: the audio is
+   * already on its way, and a stutter in the conversation is a worse price than
+   * a missing join. Carries the utterance id it is completing, so the server
+   * attaches the canonical identities to that admission instead of counting a
+   * second utterance.
+   */
+  private publishHandoffJoin(event: { handoffId: string | null; itemId: string | null; userBidiTurnId: string | null }): void {
+    if (!this.realtimeSessionId || !this.utteranceId) return;
+    const payload = JSON.stringify({
+      action: "handoff",
+      conversationId: this.conversationId,
+      realtimeSessionId: this.realtimeSessionId,
+      utterance: { id: this.utteranceId, sequence: this.utteranceSequence },
+      handoff: {
+        handoffId: event.handoffId,
+        itemId: event.itemId,
+        userBidiTurnId: event.userBidiTurnId,
+      },
+    });
+    void fetch("/api/runtime/realtime", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+    }).catch(() => undefined);
+  }
+
   private publishOperatorActivity(): void {
     if (!this.realtimeSessionId) return;
     const payload = JSON.stringify({
@@ -529,8 +600,13 @@ class CodexRealtimeClient {
         this.publishOperatorActivity();
         this.publishSelectedContext();
       }
-    } else if (event.kind === "delegation") {
-      return;
+    } else if (event.kind === "handoff") {
+      /* The utterance just published is the one being handed off, so this is
+         where the reference the operator was looking at is joined to the work
+         the backing model is about to do. */
+      this.publishHandoffJoin(event);
+    } else if (event.kind === "usage") {
+      this.update({ notice: usageNotice(event.status) });
     } else if (event.kind === "error") {
       this.setError(event.message);
     }

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -48,9 +48,13 @@ const MAX_LINE_CHARS = 12_000;
 const MAX_LINES = 80;
 
 function newOperatorActivityId(): string {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return randomHex(32);
+}
+
+function randomHex(bytes: number): string {
+  const buffer = new Uint8Array(bytes);
+  crypto.getRandomValues(buffer);
+  return [...buffer].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function object(value: unknown): Record<string, unknown> | null {
@@ -173,6 +177,13 @@ class CodexRealtimeClient {
       interleaves both speakers with worker progress, so "the last line" is
       almost never the line an update belongs to. */
   private readonly openTranscriptLines = new Map<TranscriptSpeaker, string>();
+  /* #1629: the utterance boundary this peer is currently publishing for. The
+     server cannot mint it — the operator's audio never reaches it — and without
+     one a retried publication counts as a second utterance and a slow one
+     overwrites a newer one. Reset with the call, like every other per-call
+     ledger here. */
+  private utteranceSequence = 0;
+  private utteranceId: string | null = null;
   private epoch = 0;
 
   constructor(readonly conversationId: string) {}
@@ -465,11 +476,16 @@ class CodexRealtimeClient {
    */
   private publishSelectedContext(): void {
     if (!this.realtimeSessionId) return;
+    /* Minted once per utterance and reused by the retry below, so the server
+       recognizes a replay as the same spoken turn rather than a later one. */
+    this.utteranceSequence += 1;
+    this.utteranceId = randomHex(16);
     const payload = JSON.stringify({
       action: "selectedContext",
       conversationId: this.conversationId,
       realtimeSessionId: this.realtimeSessionId,
       selectedContext: viewerSelectedContext(),
+      utterance: { id: this.utteranceId, sequence: this.utteranceSequence },
     });
     const publish = async (retry: boolean): Promise<void> => {
       try {
@@ -617,6 +633,12 @@ class CodexRealtimeClient {
     this.media = null;
     this.audio = null;
     this.realtimeSessionId = null;
+    /* A new call is a new utterance ledger. Carrying the counter across would
+       let the first utterance of the next call be refused as superseded by the
+       last one of this one. */
+    this.utteranceSequence = 0;
+    this.utteranceId = null;
+    this.openTranscriptLines.clear();
   }
 }
 

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -280,7 +280,12 @@ class CodexRealtimeClient {
       return;
     }
     this.cleanupTransport();
-    this.update({ phase: "connecting", error: null, startedAt: null, micMuted: false, outputMuted: false });
+    /* `notice` is cleared with `error` for the same reason: it describes the
+       call that is starting, and a warning carried over from the previous one
+       would tell the operator about a limit this call has not reported. */
+    this.update({
+      phase: "connecting", error: null, notice: null, startedAt: null, micMuted: false, outputMuted: false,
+    });
     const epoch = ++this.epoch;
     try {
       const media = await navigator.mediaDevices.getUserMedia({

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -226,6 +226,10 @@ class CodexRealtimeClient {
      ledger here. */
   private utteranceSequence = 0;
   private utteranceId: string | null = null;
+  /* Set when an utterance is published and cleared by the first handoff reported
+     against it, so one handoff is never reported twice and a slot left over from
+     an utterance that produced none cannot capture an unrelated later one. */
+  private utteranceAwaitingHandoff: string | null = null;
   private epoch = 0;
 
   constructor(readonly conversationId: string) {}
@@ -492,14 +496,26 @@ class CodexRealtimeClient {
    * a missing join. Carries the utterance id it is completing, so the server
    * attaches the canonical identities to that admission instead of counting a
    * second utterance.
+   *
+   * WHAT THIS CANNOT DO. The handoff event and the transcript boundary that
+   * published the reference share no identifier on the wire, so the join is the
+   * most recent unclaimed utterance rather than a proven correlation. In the
+   * ordinary flow — speak, pause, handoff — that is the same utterance. Under
+   * barge-in, a handoff arriving after the operator has already finished a
+   * further utterance is attributed to the later one. Closing that needs an
+   * identifier the current data channel does not carry, which cannot be
+   * established without a live capture; until then the ledger's `handoff` is
+   * evidence about the call, not a guarantee about a particular turn.
    */
   private publishHandoffJoin(event: { handoffId: string | null; itemId: string | null; userBidiTurnId: string | null }): void {
-    if (!this.realtimeSessionId || !this.utteranceId) return;
+    const utteranceId = this.utteranceAwaitingHandoff;
+    if (!this.realtimeSessionId || !utteranceId) return;
+    this.utteranceAwaitingHandoff = null;
     const payload = JSON.stringify({
       action: "handoff",
       conversationId: this.conversationId,
       realtimeSessionId: this.realtimeSessionId,
-      utterance: { id: this.utteranceId, sequence: this.utteranceSequence },
+      utterance: { id: utteranceId, sequence: this.utteranceSequence },
       handoff: {
         handoffId: event.handoffId,
         itemId: event.itemId,
@@ -551,6 +567,7 @@ class CodexRealtimeClient {
        recognizes a replay as the same spoken turn rather than a later one. */
     this.utteranceSequence += 1;
     this.utteranceId = randomHex(16);
+    this.utteranceAwaitingHandoff = this.utteranceId;
     const payload = JSON.stringify({
       action: "selectedContext",
       conversationId: this.conversationId,
@@ -714,6 +731,7 @@ class CodexRealtimeClient {
        last one of this one. */
     this.utteranceSequence = 0;
     this.utteranceId = null;
+    this.utteranceAwaitingHandoff = null;
     this.openTranscriptLines.clear();
   }
 }

--- a/src/lib/realtime/selectedContextBinding.ts
+++ b/src/lib/realtime/selectedContextBinding.ts
@@ -28,6 +28,12 @@ import type { SelectedContextRef } from "@/lib/selection/selectedContext";
  *   selection: an explicit `none` from the bound view resolves normally.
  * - `unbound` — the session never recorded a view. A bug or an old client, and
  *   it fails closed rather than accepting the first reference offered.
+ * - `superseded` — the bound view's own, but describing a screen state the call
+ *   has already moved past. Publishing is asynchronous and retried, so a slow
+ *   POST for an earlier utterance can land after a later one; admitting it would
+ *   point the call at the card the operator had selected two utterances ago.
+ *   Raised by the ledger rather than here, because it is a question about the
+ *   admission history and not about the reference in hand.
  */
 
 /**
@@ -46,7 +52,8 @@ export interface VoiceViewBinding {
   deviceId: string;
 }
 
-export type SelectedContextBindingFailureCode = "unbound" | "missing" | "stale" | "ambiguous";
+export type SelectedContextBindingFailureCode =
+  | "unbound" | "missing" | "stale" | "ambiguous" | "superseded";
 
 export interface SelectedContextBindingFailure {
   code: SelectedContextBindingFailureCode;

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -25,9 +25,7 @@ import type { RuntimeVoiceDelivery } from "./voiceDelivery";
 import {
   COORDINATOR_VOICE_PERSONA,
   VOICE_PERSONA_FILE,
-  legacyVoicePersonaBootstrapItemId,
-  voicePersona,
-  voicePersonaBootstrapIdentity,
+  voiceSessionPersona,
 } from "./voicePersona";
 
 function deliveryDedup(operationId: string): string {
@@ -561,13 +559,12 @@ describe("CodexAppServerHost", () => {
     });
 
     const started = await host.startRealtimeWebRtc("v=0\r\noffer");
+    const persona = voiceSessionPersona("modality");
     expect(started).toMatchObject({
       sdp: "v=0\r\nanswer",
       realtimeSessionId: "realtime-1",
-      personaBootstrap: { insertion: "accepted" },
+      persona: { variant: "modality", personaId: persona.personaId },
     });
-    expect(started.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
-    expect(started.personaBootstrap.itemId).toMatch(/^msg_voice_persona_[a-f0-9]{46}$/);
     // SDP requires a terminal CRLF; a missing one is healed, never trimmed —
     // OpenAI rejects an unterminated offer with "unmarshal SDP: EOF".
     /* The live model is named explicitly (#664): letting the backend choose
@@ -582,22 +579,19 @@ describe("CodexAppServerHost", () => {
       clientManagedHandoffs: true,
       codexResponsesAsItems: true,
       includeStartupContext: true,
+      /* THE SPOKEN MODEL'S INSTRUCTIONS (#1629). Omitting this is what left the
+         operator's orchestrator speaking as Codex's stock realtime assistant,
+         with no role and no idea what the thread behind it can reach. */
+      prompt: persona.prompt,
+      realtimeStartInstructions: persona.startInstructions,
+      realtimeEndInstructions: persona.endInstructions,
+      flushTranscriptTailOnSessionEnd: true,
     });
 
-    /* The thread owns the persona while a current V3 call may also receive a
-       bounded unresolved conversation tail through its creation payload. */
-    const injected = server.requests.find((request) => request.method === "thread/inject_items");
-    expect((injected?.params as { threadId?: string })?.threadId).toBe("voice-thread");
-    /* Shape and ordering only. Which text arrives is pinned by the override
-       test below, where the expected string cannot also be the default. */
-    expect((injected?.params as { items?: unknown[] })?.items).toEqual([{
-      type: "message",
-      id: started.personaBootstrap.itemId,
-      role: "developer",
-      content: [{ type: "input_text", text: voicePersona("modality") }],
-    }]);
-    expect(server.requests.findIndex((request) => request.method === "thread/inject_items"))
-      .toBeLessThan(server.requests.findIndex((request) => request.method === "thread/realtime/start"));
+    /* AND NOTHING IS WRITTEN TO THE THREAD. The persona used to be a
+       `thread/inject_items` developer row, which reached the backing model
+       permanently and the spoken model never. */
+    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toEqual([]);
 
     await host.appendRealtimeSpeech("Worker inspected package.json");
     expect(server.requests.find((request) => request.method === "thread/realtime/appendSpeech")?.params).toEqual({
@@ -611,8 +605,12 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
-  test("reuses one canonical persona row and stable receipt after duplicate start and host restart", async () => {
-    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-"));
+  test("an override edit reaches the next call, and no call writes to the thread", async () => {
+    /* The persona is a session parameter now, so it is resolved per call rather
+       than once per thread: an operator edit applies to the next call instead of
+       waiting for a new thread, and repeated calls — including across a host
+       restart — leave the canonical transcript exactly as they found it. */
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-session-persona-"));
     const transcriptPath = path.join(isolated, "voice-thread.jsonl");
     fs.writeFileSync(transcriptPath, "");
     const configDirectory = path.join(isolated, "config");
@@ -629,6 +627,9 @@ describe("CodexAppServerHost", () => {
       "v=0\r\no=- 202 2 IN IP4 127.0.0.1\r\na=ice-ufrag:second\r\na=ice-pwd:second-password\r\na=fingerprint:sha-256 33:44\r\n",
       "v=0\r\no=- 303 2 IN IP4 127.0.0.1\r\na=ice-ufrag:third\r\na=ice-pwd:third-password\r\na=fingerprint:sha-256 55:66\r\n",
     ] as const;
+    const sentPrompt = (server: FakeAppServer, occurrence: number): unknown =>
+      (server.requests.filter((request) => request.method === "thread/realtime/start")[occurrence]
+        ?.params as { prompt?: unknown })?.prompt;
     try {
       const firstServer = new FakeAppServer("voice-thread");
       firstServer.threadPath = transcriptPath;
@@ -638,13 +639,15 @@ describe("CodexAppServerHost", () => {
         spawnProcess: fakeSpawn(firstServer),
       });
       const first = await firstHost.startRealtimeWebRtc(offers[0], "coordinator");
-      expect(first.personaBootstrap.insertion).toBe("accepted");
+      expect(sentPrompt(firstServer, 0)).toBe("First resolved call persona.");
       await firstHost.stopRealtime();
 
-      fs.writeFileSync(overridePath, "Changed after the call was resolved.\n");
-      const duplicate = await firstHost.startRealtimeWebRtc(offers[1], "coordinator");
-      expect(duplicate.personaBootstrap).toEqual(first.personaBootstrap);
-      expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
+      fs.writeFileSync(overridePath, "Changed after the first call.\n");
+      const second = await firstHost.startRealtimeWebRtc(offers[1], "coordinator");
+      expect(sentPrompt(firstServer, 1)).toBe("Changed after the first call.");
+      /* A different persona is a different identity, which is what makes the
+         reported one evidence rather than decoration. */
+      expect(second.persona.personaId).not.toBe(first.persona.personaId);
       await firstHost.stopRealtime();
       await firstHost.release();
       firstHost = null;
@@ -657,15 +660,14 @@ describe("CodexAppServerHost", () => {
         eventStore: new MemoryEventStore(),
         spawnProcess: fakeSpawn(resumedServer),
       });
-      const recovered = await resumedHost.startRealtimeWebRtc(offers[2], "coordinator");
-      expect(recovered.personaBootstrap).toEqual(first.personaBootstrap);
-      expect(resumedServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
+      await resumedHost.startRealtimeWebRtc(offers[2], "coordinator");
+      expect(sentPrompt(resumedServer, 0)).toBe("Changed again after host restart.");
 
-      const canonical = fs.readFileSync(transcriptPath, "utf8").trim().split("\n")
-        .map((line) => JSON.parse(line) as { payload: { id?: string; content?: Array<{ text?: string }> } })
-        .filter((line) => line.payload.id === first.personaBootstrap.itemId);
-      expect(canonical).toHaveLength(1);
-      expect(canonical[0]?.payload.content?.[0]?.text).toBe("First resolved call persona.");
+      /* Three calls, two hosts, nothing appended. */
+      for (const server of [firstServer, resumedServer]) {
+        expect(server.requests.filter((request) => request.method === "thread/inject_items")).toEqual([]);
+      }
+      expect(fs.readFileSync(transcriptPath, "utf8")).toBe("");
     } finally {
       if (firstHost) await firstHost.release();
       if (resumedHost) await resumedHost.release();
@@ -675,100 +677,53 @@ describe("CodexAppServerHost", () => {
     }
   });
 
-  test("recognizes one persisted legacy persona row across repeated host restarts", async () => {
-    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-legacy-voice-bootstrap-"));
-    const transcriptPath = path.join(isolated, "legacy-voice-thread.jsonl");
-    const threadId = "legacy-voice-thread";
-    const legacyItemId = legacyVoicePersonaBootstrapItemId(threadId);
-    fs.writeFileSync(transcriptPath, `${JSON.stringify({
+  test("a thread already carrying a coordinator persona row still gets the modality correction", async () => {
+    /* #1615, the half that cannot be undone. A thread demoted by a call taken
+       before the persona moved out of the thread keeps that developer item
+       forever — the transcript is append-only. What the correction can no longer
+       do is append a rebuttal beside it; it now rides on the session's own
+       start instructions, which are the most recent developer instruction the
+       backing model receives and are withdrawn when the call ends. */
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-demoted-thread-"));
+    const threadId = "demoted-voice-thread";
+    const transcriptPath = path.join(isolated, "demoted.jsonl");
+    const priorRow = `${JSON.stringify({
       type: "response_item",
       payload: {
         type: "message",
-        id: legacyItemId,
+        id: `msg_voice_persona_${"a".repeat(46)}`,
         role: "developer",
-        content: [{ type: "input_text", text: "Persisted legacy persona." }],
+        content: [{ type: "input_text", text: COORDINATOR_VOICE_PERSONA }],
       },
-    })}\n`);
+    })}\n`;
+    fs.writeFileSync(transcriptPath, priorRow);
 
-    for (const suffix of ["first", "second"]) {
-      const server = new FakeAppServer(threadId);
-      server.threadPath = transcriptPath;
-      const host = await CodexAppServerHost.adopt(threadId, {
-        cwd: "/repo",
-        eventStore: new MemoryEventStore(),
-        spawnProcess: fakeSpawn(server),
-      });
-      try {
-        const started = await host.startRealtimeWebRtc(`v=0\r\na=ice-ufrag:${suffix}\r\n`, "coordinator");
-        expect(started.personaBootstrap.insertion).toBe("accepted");
-        expect(started.personaBootstrap.itemId.length).toBeLessThanOrEqual(64);
-        expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
-        await host.stopRealtime();
-      } finally {
-        await host.release();
-      }
-    }
+    const server = new FakeAppServer(threadId);
+    server.threadPath = transcriptPath;
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    try {
+      const started = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:correct\r\n", "modality");
+      expect(started.persona.variant).toBe("modality");
 
-    const personaRows = fs.readFileSync(transcriptPath, "utf8").trim().split("\n")
-      .map((line) => JSON.parse(line) as { payload?: { id?: string; role?: string } })
-      .filter((line) => line.payload?.role === "developer" && line.payload.id?.startsWith("msg_voice_persona_"));
-    expect(personaRows).toHaveLength(1);
-    expect(personaRows[0]?.payload?.id).toBe(legacyItemId);
-    fs.rmSync(isolated, { recursive: true, force: true });
-  });
+      const start = server.requests.find((request) => request.method === "thread/realtime/start")
+        ?.params as { prompt?: string; realtimeStartInstructions?: string; realtimeEndInstructions?: string };
+      /* The correction, not a second copy of the demotion. */
+      expect(start.realtimeStartInstructions).toMatch(/it was not written for you/i);
+      expect(start.realtimeStartInstructions).not.toBe(COORDINATOR_VOICE_PERSONA);
+      expect(start.prompt).not.toBe(COORDINATOR_VOICE_PERSONA);
+      expect(start.realtimeEndInstructions).toMatch(/realtime voice has ended/i);
 
-  test("a thread already carrying a coordinator persona still receives the modality correction", async () => {
-    /* #1615, the half that cannot be undone. A thread demoted by a call taken
-       before this fix keeps that developer item forever — the transcript is
-       append-only. What CAN happen is that the next call adds the text that
-       outranks it, and that only works because the two variants own different
-       item ids: a shared id would read the coordinator row as proof that this
-       thread was already bootstrapped and inject nothing.
-
-       Both shapes of the old row are covered: the canonical one and the
-       pre-#870 legacy one, which is a coordinator persona by construction. */
-    for (const existing of ["canonical", "legacy"] as const) {
-      const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-demoted-thread-"));
-      const threadId = "demoted-voice-thread";
-      const transcriptPath = path.join(isolated, "demoted.jsonl");
-      const priorItemId = existing === "legacy"
-        ? legacyVoicePersonaBootstrapItemId(threadId)
-        : voicePersonaBootstrapIdentity(threadId, "coordinator").itemId;
-      fs.writeFileSync(transcriptPath, `${JSON.stringify({
-        type: "response_item",
-        payload: {
-          type: "message",
-          id: priorItemId,
-          role: "developer",
-          content: [{ type: "input_text", text: COORDINATOR_VOICE_PERSONA }],
-        },
-      })}\n`);
-
-      const server = new FakeAppServer(threadId);
-      server.threadPath = transcriptPath;
-      const host = await CodexAppServerHost.adopt(threadId, {
-        cwd: "/repo",
-        eventStore: new MemoryEventStore(),
-        spawnProcess: fakeSpawn(server),
-      });
-      try {
-        const started = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:correct\r\n", "modality");
-        expect(started.personaBootstrap.insertion).toBe("accepted");
-        expect(started.personaBootstrap.itemId)
-          .toBe(voicePersonaBootstrapIdentity(threadId, "modality").itemId);
-
-        const injected = server.requests.filter((request) => request.method === "thread/inject_items");
-        expect(injected).toHaveLength(1);
-        const item = (injected[0]?.params as { items: Array<{ id: string; content: Array<{ text: string }> }> }).items[0];
-        expect(item?.id).toBe(started.personaBootstrap.itemId);
-        expect(item?.content[0]?.text).toBe(voicePersona("modality"));
-        /* The correction, not a second copy of the demotion. */
-        expect(item?.content[0]?.text).not.toBe(COORDINATOR_VOICE_PERSONA);
-        await host.stopRealtime();
-      } finally {
-        await host.release();
-        fs.rmSync(isolated, { recursive: true, force: true });
-      }
+      /* And the history the demotion lives in is left exactly as it was. */
+      expect(server.requests.filter((request) => request.method === "thread/inject_items")).toEqual([]);
+      expect(fs.readFileSync(transcriptPath, "utf8")).toBe(priorRow);
+      await host.stopRealtime();
+    } finally {
+      await host.release();
+      fs.rmSync(isolated, { recursive: true, force: true });
     }
   });
 
@@ -833,6 +788,7 @@ describe("CodexAppServerHost", () => {
       });
     expect(diagnostics).toEqual([["[realtime context] selected", {
       providerStartupContext: true,
+      personaVariant: "modality",
       durableTail: [
         { role: "assistant", source: "durable-delta", bytes: 26 },
         { role: "user", source: "durable-item", bytes: Buffer.byteLength(followUpText, "utf8") },
@@ -1105,7 +1061,7 @@ describe("CodexAppServerHost", () => {
     await replacementHost.release();
   });
 
-  test("the operator's override is the text that reaches the call's thread", async () => {
+  test("the operator's override is the text that reaches the call's spoken model", async () => {
     /* The call path has to resolve the persona the way production does, not
        just inject some persona. With no override file on disk the resolver and
        the built-in default are the same string, so a call that injected the
@@ -1132,19 +1088,12 @@ describe("CodexAppServerHost", () => {
         spawnProcess: fakeSpawn(server),
       });
       /* The override file is the coordinator variant's, so this is a coordinator
-         call — see `voicePersona`, where the modality variant deliberately keeps
-         the built-in text. */
+         call — see `spokenVoicePersona`, where the modality variant deliberately
+         keeps the built-in text. */
       await host.startRealtimeWebRtc("v=0\r\noffer", "coordinator");
 
-      const injected = server.requests.find((request) => request.method === "thread/inject_items");
-      const item = (injected?.params as {
-        items?: Array<{ type?: string; role?: string; content?: Array<{ type?: string; text?: string }> }>;
-      })?.items?.[0];
-      expect(item).toMatchObject({
-        type: "message",
-        role: "developer",
-        content: [{ type: "input_text", text: override }],
-      });
+      const start = server.requests.find((request) => request.method === "thread/realtime/start");
+      expect((start?.params as { prompt?: string })?.prompt).toBe(override);
       await host.release();
     } finally {
       if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
@@ -1198,16 +1147,22 @@ describe("CodexAppServerHost", () => {
     await host.startRealtimeWebRtc("v=0\r\noffer");
     const realtimeStart = server.requests.find((request) => request.method === "thread/realtime/start");
     const params = realtimeStart?.params as Record<string, unknown>;
-    /* App-server contract (codex 0.145.0): thread/realtime/start names the
-       thread and nothing else — no MCP table, config, or tool list rides the
-       call, so the session can only inherit the thread's servers above. */
+    /* App-server contract (codex-cli 0.154.0, bundled app-server 0.153.4):
+       thread/realtime/start carries the session's own instructions and nothing
+       about tools — no MCP table, config, or tool list rides the call, so the
+       backing model can only inherit the thread's servers above, and the spoken
+       model holds no tool of its own at all. */
     expect(params.threadId).toBe("voice-mcp-thread");
     expect(Object.keys(params).sort()).toEqual([
       "clientManagedHandoffs",
       "codexResponsesAsItems",
+      "flushTranscriptTailOnSessionEnd",
       "includeStartupContext",
       "model",
       "outputModality",
+      "prompt",
+      "realtimeEndInstructions",
+      "realtimeStartInstructions",
       "threadId",
       "transport",
       "version",
@@ -4814,247 +4769,6 @@ describe("CodexAppServerHost", () => {
   });
 });
 
-test("a refused persona insertion returns a bounded rejected receipt before realtime starts", async () => {
-  const server = new FakeAppServer("voice-thread");
-  server.injectItemsError = "Invalid request: unknown field `role`";
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-
-  const rejected = await host.startRealtimeWebRtc("v=0\r\noffer");
-  expect(rejected).toMatchObject({
-    sdp: null,
-    realtimeSessionId: null,
-    personaBootstrap: {
-      insertion: "rejected",
-      diagnostic: "Codex app-server request failed: Invalid request: unknown field `role`",
-    },
-  });
-  expect(rejected.personaBootstrap.receiptId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
-  expect(rejected.personaBootstrap.diagnostic?.length).toBeLessThanOrEqual(500);
-  expect(server.requests.find((request) => request.method === "thread/realtime/start")).toBeUndefined();
-  expect(host.currentRealtimeSessionId()).toBeNull();
-  await host.release();
-});
-
-test("replacement hosts reject an unverifiable canonical transcript without reinserting", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-scan-fault-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  const linkedPath = path.join(isolated, "linked-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  fs.symlinkSync(transcriptPath, linkedPath);
-  const warnings = spyOn(console, "warn").mockImplementation(() => {});
-  const firstServer = new FakeAppServer("voice-thread");
-  firstServer.threadPath = linkedPath;
-  const firstHost = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(firstServer),
-  });
-  let replacementHost: CodexAppServerHost | null = null;
-  try {
-    const first = await firstHost.startRealtimeWebRtc("v=0\r\no=- 404 2 IN IP4 127.0.0.1\r\n");
-    expect(first).toMatchObject({
-      sdp: null,
-      personaBootstrap: { insertion: "rejected", diagnostic: expect.stringContaining("ELOOP") },
-    });
-    await firstHost.release();
-
-    const replacementServer = new FakeAppServer("voice-thread");
-    replacementServer.threadPath = linkedPath;
-    replacementHost = await CodexAppServerHost.adopt("voice-thread", {
-      cwd: "/repo",
-      eventStore: new MemoryEventStore(),
-      spawnProcess: fakeSpawn(replacementServer),
-    });
-    const replacement = await replacementHost.startRealtimeWebRtc("v=0\r\no=- 405 2 IN IP4 127.0.0.1\r\n");
-    expect(replacement.personaBootstrap).toEqual(first.personaBootstrap);
-    expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
-    expect(replacementServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
-    expect(fs.readFileSync(transcriptPath, "utf8")).toBe("");
-    expect(warnings).toHaveBeenCalledWith(
-      "[voice persona bootstrap] canonical scan unavailable; refusing insertion",
-      expect.objectContaining({ code: "ELOOP", diagnostic: expect.stringContaining("ELOOP") }),
-    );
-    expect(warnings).toHaveBeenCalledTimes(2);
-  } finally {
-    warnings.mockRestore();
-    await replacementHost?.release();
-    await firstHost.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("an unrecoverable transcript path rejects before persona insertion", async () => {
-  const server = new FakeAppServer("voice-thread");
-  server.omitThreadPath = true;
-  server.omitThreadReadPath = true;
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const first = await host.startRealtimeWebRtc("v=0\r\no=- 406 2 IN IP4 127.0.0.1\r\n");
-    const repeated = await host.startRealtimeWebRtc("v=0\r\no=- 407 2 IN IP4 127.0.0.1\r\n");
-    expect(repeated.personaBootstrap).toEqual(first.personaBootstrap);
-    expect(first).toMatchObject({
-      sdp: null,
-      personaBootstrap: {
-        insertion: "rejected",
-        diagnostic: "canonical transcript path is unavailable",
-      },
-    });
-    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
-    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(0);
-  } finally {
-    await host.release();
-  }
-});
-
-test("replacement hosts recover an omitted canonical path and persist one persona row", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-path-recovery-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const firstServer = new FakeAppServer("voice-thread");
-  firstServer.omitThreadPath = true;
-  firstServer.threadPath = transcriptPath;
-  const firstHost = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(firstServer),
-  });
-  let replacementHost: CodexAppServerHost | null = null;
-  try {
-    const first = await firstHost.startRealtimeWebRtc("v=0\r\no=- 408 2 IN IP4 127.0.0.1\r\n");
-    await firstHost.release();
-
-    const replacementServer = new FakeAppServer("voice-thread");
-    replacementServer.omitThreadPath = true;
-    replacementServer.threadPath = transcriptPath;
-    replacementHost = await CodexAppServerHost.adopt("voice-thread", {
-      cwd: "/repo",
-      eventStore: new MemoryEventStore(),
-      spawnProcess: fakeSpawn(replacementServer),
-    });
-    const recovered = await replacementHost.startRealtimeWebRtc("v=0\r\no=- 409 2 IN IP4 127.0.0.1\r\n");
-    expect(recovered.personaBootstrap).toEqual(first.personaBootstrap);
-    expect(firstServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
-    expect(replacementServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
-    expect(fs.readFileSync(transcriptPath, "utf8").split(recovered.personaBootstrap.itemId)).toHaveLength(2);
-  } finally {
-    await replacementHost?.release();
-    await firstHost.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("a persisted persona row recovers an ambiguous insertion failure", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-ambiguous-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const server = new FakeAppServer("voice-thread");
-  server.threadPath = transcriptPath;
-  server.holdInjectItems = true;
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const pending = host.startRealtimeWebRtc("v=0\r\no=- 909 2 IN IP4 127.0.0.1\r\n");
-    void pending.catch(() => undefined);
-    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
-      await Bun.sleep(1);
-    }
-    const request = server.requests.find((candidate) => candidate.method === "thread/inject_items");
-    const item = (request?.params as { items?: unknown[] } | undefined)?.items?.[0];
-    if (!item) throw new Error("persona insertion item missing");
-    fs.appendFileSync(transcriptPath, `${JSON.stringify({ type: "response_item", payload: item })}\n`);
-    server.completeNextInject("thread/inject_items response was lost");
-
-    expect(await pending).toMatchObject({
-      sdp: "v=0\r\nanswer",
-      personaBootstrap: { insertion: "accepted" },
-    });
-    expect(server.requests.filter((candidate) => candidate.method === "thread/realtime/start")).toHaveLength(1);
-  } finally {
-    await host.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("an uncertain persona insertion timeout fences the writer and recovers on a replacement host", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-timeout-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const firstServer = new FakeAppServer("voice-thread", "voice-thread", true);
-  firstServer.threadPath = transcriptPath;
-  firstServer.injectItemsDelayMs = 25;
-  const firstHost = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(firstServer),
-    realtimePersonaTimeoutMs: 10,
-    shutdownGraceMs: 50,
-  });
-  let replacementHost: CodexAppServerHost | null = null;
-  try {
-    await expect(firstHost.startRealtimeWebRtc("v=0\r\no=- 910 2 IN IP4 127.0.0.1\r\n"))
-      .rejects.toThrow("thread/inject_items timed out; outcome is uncertain");
-    await Bun.sleep(40);
-    expect((await firstHost.health()).status).toBe("dead");
-
-    const replacementServer = new FakeAppServer("voice-thread");
-    replacementServer.threadPath = transcriptPath;
-    replacementHost = await CodexAppServerHost.adopt("voice-thread", {
-      cwd: "/repo",
-      eventStore: new MemoryEventStore(),
-      spawnProcess: fakeSpawn(replacementServer),
-    });
-    const recovered = await replacementHost.startRealtimeWebRtc("v=0\r\no=- 911 2 IN IP4 127.0.0.1\r\n");
-    expect(recovered.personaBootstrap.insertion).toBe("accepted");
-    expect(replacementServer.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(0);
-    expect(fs.readFileSync(transcriptPath, "utf8").split(recovered.personaBootstrap.itemId)).toHaveLength(2);
-  } finally {
-    await replacementHost?.release();
-    await firstHost.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("persona bootstrap completes before the single fenced realtime-start deadline begins", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-realtime-start-deadline-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const server = new FakeAppServer("voice-thread");
-  server.threadPath = transcriptPath;
-  server.injectItemsDelayMs = 20;
-  server.realtimeStartDelayMs = 20;
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-    realtimePersonaTimeoutMs: 50,
-    realtimeStartTimeoutMs: 30,
-  });
-  try {
-    expect(await host.startRealtimeWebRtc("v=0\r\no=- 912 2 IN IP4 127.0.0.1\r\n")).toMatchObject({
-      sdp: "v=0\r\nanswer",
-      realtimeSessionId: "realtime-1",
-      personaBootstrap: { insertion: "accepted" },
-    });
-    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
-  } finally {
-    await Bun.sleep(25);
-    if (host.currentRealtimeSessionId()) await host.stopRealtime();
-    await host.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
 test("the realtime notification deadline poisons a writer after the start RPC succeeds", async () => {
   const server = new FakeAppServer("voice-thread");
   server.suppressRealtimeStartNotifications = true;
@@ -5071,212 +4785,6 @@ test("the realtime notification deadline poisons a writer after the start RPC su
     expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
   } finally {
     await host.release();
-  }
-});
-
-test("a successor start joins the cancelled call's in-flight persona insertion", async () => {
-  const server = new FakeAppServer("voice-thread");
-  server.holdInjectItems = true;
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const cancelled = host.startRealtimeWebRtc("v=0\r\no=- 1001 2 IN IP4 127.0.0.1\r\n");
-    void cancelled.catch(() => undefined);
-    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
-      await Bun.sleep(1);
-    }
-    expect(server.heldInjectItemIds).toHaveLength(1);
-    await host.stopRealtime();
-
-    const successor = host.startRealtimeWebRtc("v=0\r\no=- 1002 2 IN IP4 127.0.0.1\r\n");
-    void successor.catch(() => undefined);
-    await Bun.sleep(10);
-    expect(server.heldInjectItemIds).toHaveLength(1);
-    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(1);
-    server.completeNextInject();
-
-    await expect(cancelled).rejects.toThrow("stopped during startup");
-    expect(await successor).toMatchObject({
-      sdp: "v=0\r\nanswer",
-      personaBootstrap: { insertion: "accepted" },
-    });
-    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
-  } finally {
-    await host.release();
-  }
-});
-
-test("a cancelled persona insertion failure cannot reject the successor start", async () => {
-  const server = new FakeAppServer("voice-thread");
-  server.holdInjectItems = true;
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const cancelled = host.startRealtimeWebRtc("v=0\r\no=- 707 2 IN IP4 127.0.0.1\r\n");
-    void cancelled.catch(() => undefined);
-    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
-      await Bun.sleep(1);
-    }
-    expect(server.heldInjectItemIds).toHaveLength(1);
-    await host.stopRealtime();
-
-    const successor = host.startRealtimeWebRtc("v=0\r\no=- 808 2 IN IP4 127.0.0.1\r\n");
-    void successor.catch(() => undefined);
-    await Bun.sleep(10);
-    expect(server.heldInjectItemIds).toHaveLength(1);
-    server.completeNextInject("cancelled call insertion failed");
-    await expect(cancelled).rejects.toThrow("stopped during startup");
-    for (let attempt = 0; attempt < 100 && server.heldInjectItemIds.length < 1; attempt += 1) {
-      await Bun.sleep(1);
-    }
-    expect(server.requests.filter((request) => request.method === "thread/inject_items")).toHaveLength(2);
-    server.completeNextInject();
-
-    expect(await successor).toMatchObject({
-      sdp: "v=0\r\nanswer",
-      personaBootstrap: { insertion: "accepted" },
-    });
-    expect(server.requests.filter((request) => request.method === "thread/realtime/start")).toHaveLength(1);
-  } finally {
-    await host.release();
-  }
-});
-
-/**
- * One thread now has TWO persona identities, so the host's bootstrap memo is per
- * variant or it is wrong (#1615 review, finding 1).
- *
- * Both fields were per-host booleans written when a thread could only ever hold
- * one persona item. With two variants that premise fails in two directions, and
- * each has its own test below: a stale unresolved payload puts the WRONG TEXT in
- * the transcript, and a global accepted flag makes the host claim an item it
- * never injected.
- */
-test("a variant switch after a rejected insertion injects the new variant's text, not the stale payload", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-variant-stale-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const server = new FakeAppServer("voice-thread");
-  server.threadPath = transcriptPath;
-  server.injectItemsError = "temporary insertion refusal";
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const rejected = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:rejected\r\n", "coordinator");
-    expect(rejected.personaBootstrap.insertion).toBe("rejected");
-
-    /* The next call resolves the OTHER variant — the fail-safe in
-       `voicePersonaVariantForConversation` answering `modality` for one start is
-       exactly how a host sees two variants in a row. */
-    server.injectItemsError = null;
-    const accepted = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:switched\r\n", "modality");
-    expect(accepted.personaBootstrap.insertion).toBe("accepted");
-    expect(accepted.personaBootstrap.itemId)
-      .toBe(voicePersonaBootstrapIdentity("voice-thread", "modality").itemId);
-
-    /* The item that actually went to the provider must be the one the receipt
-       names, carrying the persona the receipt implies. */
-    const injected = server.requests.filter((request) => request.method === "thread/inject_items").at(-1);
-    const item = (injected?.params as { items: Array<{ id: string; content: Array<{ text: string }> }> }).items[0];
-    expect(item?.id).toBe(accepted.personaBootstrap.itemId);
-    expect(item?.content[0]?.text).toBe(voicePersona("modality"));
-    expect(item?.content[0]?.text).not.toBe(COORDINATOR_VOICE_PERSONA);
-  } finally {
-    await host.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("a second variant on the same host is injected rather than reported accepted on the first one's receipt", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-variant-second-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const server = new FakeAppServer("voice-thread");
-  server.threadPath = transcriptPath;
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const first = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:first\r\n", "modality");
-    expect(first.personaBootstrap.insertion).toBe("accepted");
-    await host.stopRealtime();
-
-    const second = await host.startRealtimeWebRtc("v=0\r\na=ice-ufrag:second\r\n", "coordinator");
-    expect(second.personaBootstrap.insertion).toBe("accepted");
-    expect(second.personaBootstrap.itemId)
-      .toBe(voicePersonaBootstrapIdentity("voice-thread", "coordinator").itemId);
-
-    /* An `accepted` receipt naming an item that is not in the thread is the
-       failure `rejectStartedRealtimeContract` exists to catch, reported as a
-       success instead. Both variants are now genuinely present. */
-    const attempts = server.requests.filter((request) => request.method === "thread/inject_items");
-    expect(attempts).toHaveLength(2);
-    const persisted = fs.readFileSync(transcriptPath, "utf8");
-    expect(persisted).toContain(first.personaBootstrap.itemId);
-    expect(persisted).toContain(second.personaBootstrap.itemId);
-  } finally {
-    await host.release();
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("a rejected persona insertion retries the same resolved payload and stable receipt", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-bootstrap-retry-"));
-  const transcriptPath = path.join(isolated, "voice-thread.jsonl");
-  fs.writeFileSync(transcriptPath, "");
-  const configDirectory = path.join(isolated, "config");
-  const overridePath = path.join(configDirectory, "agent-log-viewer", ...VOICE_PERSONA_FILE.split("/"));
-  fs.mkdirSync(path.dirname(overridePath), { recursive: true });
-  fs.writeFileSync(overridePath, "Resolved before the rejected insertion.\n");
-  const previousConfigHome = process.env.XDG_CONFIG_HOME;
-  process.env.XDG_CONFIG_HOME = configDirectory;
-
-  const server = new FakeAppServer("voice-thread");
-  server.threadPath = transcriptPath;
-  server.injectItemsError = "temporary insertion refusal";
-  const host = await CodexAppServerHost.start({
-    cwd: "/repo",
-    eventStore: new MemoryEventStore(),
-    spawnProcess: fakeSpawn(server),
-  });
-  try {
-    const rejected = await host.startRealtimeWebRtc(
-      "v=0\r\no=- 505 2 IN IP4 127.0.0.1\r\na=ice-ufrag:rejected\r\n",
-      "coordinator",
-    );
-    expect(rejected.personaBootstrap.insertion).toBe("rejected");
-
-    fs.writeFileSync(overridePath, "A later edit must not change this call.\n");
-    server.injectItemsError = null;
-    const accepted = await host.startRealtimeWebRtc(
-      "v=0\r\no=- 606 2 IN IP4 127.0.0.1\r\na=ice-ufrag:retry\r\n",
-      "coordinator",
-    );
-    expect(accepted.personaBootstrap.receiptId).toBe(rejected.personaBootstrap.receiptId);
-    expect(accepted.personaBootstrap.itemId).toBe(rejected.personaBootstrap.itemId);
-    expect(accepted.personaBootstrap.insertion).toBe("accepted");
-
-    const attempts = server.requests.filter((request) => request.method === "thread/inject_items");
-    expect(attempts).toHaveLength(2);
-    expect((attempts[1]?.params as { items: Array<{ content: Array<{ text: string }> }> }).items[0]?.content[0]?.text)
-      .toBe("Resolved before the rejected insertion.");
-    expect(fs.readFileSync(transcriptPath, "utf8").split(accepted.personaBootstrap.itemId)).toHaveLength(2);
-  } finally {
-    await host.release();
-    if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
-    else process.env.XDG_CONFIG_HOME = previousConfigHome;
-    fs.rmSync(isolated, { recursive: true, force: true });
   }
 });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -711,7 +711,7 @@ describe("CodexAppServerHost", () => {
 
       const start = server.requests.find((request) => request.method === "thread/realtime/start")
         ?.params as { prompt?: string; realtimeStartInstructions?: string; realtimeEndInstructions?: string };
-      /* The correction, not a second copy of the demotion. */
+      /* The correction. A second copy of the demotion would be the defect. */
       expect(start.realtimeStartInstructions).toMatch(/it was not written for you/i);
       expect(start.realtimeStartInstructions).not.toBe(COORDINATOR_VOICE_PERSONA);
       expect(start.prompt).not.toBe(COORDINATOR_VOICE_PERSONA);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -582,7 +582,7 @@ describe("CodexAppServerHost", () => {
       /* THE SPOKEN MODEL'S INSTRUCTIONS (#1629). Omitting this is what left the
          operator's orchestrator speaking as Codex's stock realtime assistant,
          with no role and no idea what the thread behind it can reach. */
-      prompt: persona.prompt,
+      "prompt": persona.prompt,
       realtimeStartInstructions: persona.startInstructions,
       realtimeEndInstructions: persona.endInstructions,
       flushTranscriptTailOnSessionEnd: true,

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -85,7 +85,7 @@ export type CodexRealtimeFailure = {
   realtimeSessionId: string | null;
 };
 type PendingRealtimeStart = {
-  resolve(result: CodexRealtimeWebRtcResult): void;
+  resolve(result: CodexRealtimeWebRtcAnswer): void;
   reject(error: Error): void;
   timer: ReturnType<typeof setTimeout> | undefined;
   started: boolean;
@@ -219,8 +219,6 @@ export interface CodexRealtimeWebRtcAnswer {
   realtimeSessionId: string | null;
   persona: VoiceSessionPersonaReceipt;
 }
-
-export type CodexRealtimeWebRtcResult = CodexRealtimeWebRtcAnswer;
 
 const CHILD_ENV_ALLOWLIST = [
   "PATH",
@@ -1819,7 +1817,7 @@ export class CodexAppServerHost implements EngineHost {
   async startRealtimeWebRtc(
     sdp: string,
     personaVariant: VoicePersonaVariant = "modality",
-  ): Promise<CodexRealtimeWebRtcResult> {
+  ): Promise<CodexRealtimeWebRtcAnswer> {
     if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
       throw new Error("Codex app-server host is unavailable");
     }
@@ -1838,7 +1836,7 @@ export class CodexAppServerHost implements EngineHost {
     const persona = voiceSessionPersona(personaVariant);
 
     let pendingStart!: PendingRealtimeStart;
-    const answer = new Promise<CodexRealtimeWebRtcResult>((resolve, reject) => {
+    const answer = new Promise<CodexRealtimeWebRtcAnswer>((resolve, reject) => {
       pendingStart = {
         resolve,
         reject,

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1877,7 +1877,7 @@ export class CodexAppServerHost implements EngineHost {
            gives it Codex's stock realtime persona — a general-purpose assistant
            that knows nothing about this thread's role or tools — and no item
            written into the thread ever reaches it. */
-        prompt: persona.prompt,
+        "prompt": persona.prompt,
         /* THE BACKING MODEL'S FRAMING, scoped to this call. Paired with the end
            instructions so hanging up withdraws it, which is what keeps a text
            agent from inheriting spoken-delivery rules for the rest of its life. */

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -56,14 +56,9 @@ import {
   type RuntimeEventStore,
 } from "./eventStore";
 import {
-  canonicalVoicePersonaBootstrapExists,
-  legacyVoicePersonaBootstrapItemId,
-  voicePersonaBootstrap,
-  voicePersonaBootstrapIdentity,
+  voiceSessionPersona,
   type VoicePersonaVariant,
-  type VoicePersonaBootstrap,
-  type VoicePersonaBootstrapIdentity,
-  type VoicePersonaBootstrapReceipt,
+  type VoiceSessionPersona,
 } from "./voicePersona";
 
 type JsonObject = Record<string, unknown>;
@@ -96,11 +91,7 @@ type PendingRealtimeStart = {
   started: boolean;
   realtimeSessionId: string | null;
   sdp: string | null;
-  personaBootstrap: VoicePersonaBootstrapReceipt;
-};
-type VoicePersonaBootstrapInsertion = {
-  owner: PendingRealtimeStart;
-  promise: Promise<void>;
+  persona: VoiceSessionPersonaReceipt;
 };
 type PendingCompaction = {
   promise: Promise<RuntimeCompactOutcome>;
@@ -187,7 +178,6 @@ export interface CodexAppServerHostOptions {
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
-  realtimePersonaTimeoutMs?: number;
   realtimeStartTimeoutMs?: number;
   deliveryConfirmationTimeoutMs?: number;
   compactEvidenceTimeoutMs?: number;
@@ -210,22 +200,27 @@ export interface CodexThreadIdentity {
   path: string | null;
 }
 
+/**
+ * Which persona the live call is running on (#1629).
+ *
+ * The persona is a parameter of `thread/realtime/start` now, so it either went
+ * out with the start or the start did not happen — there is no separate write to
+ * succeed or fail, and so no separate receipt to reject. What remains worth
+ * reporting is WHICH one, which the voice panel shows and the regression tests
+ * assert against.
+ */
+export interface VoiceSessionPersonaReceipt {
+  variant: VoicePersonaVariant;
+  personaId: string;
+}
+
 export interface CodexRealtimeWebRtcAnswer {
   sdp: string;
   realtimeSessionId: string | null;
-  personaBootstrap: VoicePersonaBootstrapReceipt;
+  persona: VoiceSessionPersonaReceipt;
 }
 
-export interface CodexRealtimeWebRtcRejection {
-  sdp: null;
-  realtimeSessionId: null;
-  personaBootstrap: VoicePersonaBootstrapReceipt & {
-    insertion: "rejected";
-    diagnostic: string;
-  };
-}
-
-export type CodexRealtimeWebRtcResult = CodexRealtimeWebRtcAnswer | CodexRealtimeWebRtcRejection;
+export type CodexRealtimeWebRtcResult = CodexRealtimeWebRtcAnswer;
 
 const CHILD_ENV_ALLOWLIST = [
   "PATH",
@@ -298,7 +293,6 @@ const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const REALTIME_START_TIMEOUT_MS = 90_000;
 /* First speech waits for the persona's durable insertion outcome. Keep that
    gate bounded when an app-server accepts the method and then stalls. */
-const REALTIME_PERSONA_TIMEOUT_MS = 3_000;
 /* Releasing the host must not block on a wedged app-server, but the hangup is
    worth a moment: skipping it strands the account's realtime slot. */
 const REALTIME_HANGUP_TIMEOUT_MS = 2_000;
@@ -1093,7 +1087,6 @@ export class CodexAppServerHost implements EngineHost {
 
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly requestTimeoutMs: number;
-  private readonly realtimePersonaTimeoutMs: number;
   private readonly realtimeStartTimeoutMs: number;
   private readonly deliveryConfirmationTimeoutMs: number;
   private readonly compactEvidenceTimeoutMs: number;
@@ -1138,9 +1131,6 @@ export class CodexAppServerHost implements EngineHost {
      without ever injecting it, which is a false receipt that
      `rejectStartedRealtimeContract` would otherwise have caught.
      Successor starts of the SAME variant still join the same insertion promise. */
-  private readonly unresolvedVoicePersonaBootstrap = new Map<VoicePersonaVariant, VoicePersonaBootstrap>();
-  private voicePersonaBootstrapInsertion: VoicePersonaBootstrapInsertion | null = null;
-  private readonly voicePersonaBootstrapAccepted = new Set<VoicePersonaVariant>();
   private readonly pendingVoiceChunks = new Map<string, string>();
   private readonly cancelledVoiceTurns = new Set<string>();
   private readonly activeRealtimeDeliveries = new Map<string, {
@@ -1191,7 +1181,6 @@ export class CodexAppServerHost implements EngineHost {
     this.child = child;
     this.identity = identity;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.realtimePersonaTimeoutMs = options.realtimePersonaTimeoutMs ?? REALTIME_PERSONA_TIMEOUT_MS;
     this.realtimeStartTimeoutMs = options.realtimeStartTimeoutMs ?? REALTIME_START_TIMEOUT_MS;
     this.deliveryConfirmationTimeoutMs = options.deliveryConfirmationTimeoutMs
       ?? DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS;
@@ -1846,7 +1835,7 @@ export class CodexAppServerHost implements EngineHost {
        be reported against this one. */
     this.realtimeFailure = null;
     this.realtimeSessionId = null;
-    const personaBootstrapIdentity = voicePersonaBootstrapIdentity(this.identity.threadId, personaVariant);
+    const persona = voiceSessionPersona(personaVariant);
 
     let pendingStart!: PendingRealtimeStart;
     const answer = new Promise<CodexRealtimeWebRtcResult>((resolve, reject) => {
@@ -1857,36 +1846,16 @@ export class CodexAppServerHost implements EngineHost {
         started: false,
         realtimeSessionId: null,
         sdp: null,
-        personaBootstrap: { ...personaBootstrapIdentity, insertion: "accepted" },
+        persona: { variant: persona.variant, personaId: persona.personaId },
       };
     });
     this.pendingRealtimeStart = pendingStart;
     void answer.catch(() => undefined);
 
-    try {
-      const outcome = await this.ensureVoicePersonaBootstrap(personaBootstrapIdentity, personaVariant, pendingStart);
-      if (outcome === "superseded") return answer;
-    } catch (error) {
-      if (this.pendingRealtimeStart !== pendingStart) return answer;
-      const pending = pendingStart;
-      this.pendingRealtimeStart = null;
-      clearTimeout(pending.timer);
-      const rejected: CodexRealtimeWebRtcRejection = {
-        sdp: null,
-        realtimeSessionId: null,
-        personaBootstrap: {
-          ...personaBootstrapIdentity,
-          insertion: "rejected",
-          diagnostic: safeError(error),
-        },
-      };
-      pending.resolve(rejected);
-      return answer;
-    }
-    if (this.pendingRealtimeStart !== pendingStart) return answer;
     const realtimeContext = selectRealtimeContext(this.events);
     console.info("[realtime context] selected", {
       providerStartupContext: true,
+      personaVariant: persona.variant,
       durableTail: realtimeContext.diagnosticItems,
       truncated: realtimeContext.truncated,
     });
@@ -1904,6 +1873,20 @@ export class CodexAppServerHost implements EngineHost {
         clientManagedHandoffs: true,
         codexResponsesAsItems: true,
         includeStartupContext: true,
+        /* THE SPOKEN MODEL'S ONLY INSTRUCTIONS (#1629). Unset, the backend
+           gives it Codex's stock realtime persona — a general-purpose assistant
+           that knows nothing about this thread's role or tools — and no item
+           written into the thread ever reaches it. */
+        prompt: persona.prompt,
+        /* THE BACKING MODEL'S FRAMING, scoped to this call. Paired with the end
+           instructions so hanging up withdraws it, which is what keeps a text
+           agent from inheriting spoken-delivery rules for the rest of its life. */
+        realtimeStartInstructions: persona.startInstructions,
+        realtimeEndInstructions: persona.endInstructions,
+        /* The last thing said before a hangup is said INTO the tail. Without
+           this it is dropped instead of routed through Codex, so an instruction
+           given on the way out never reaches the canonical thread. */
+        flushTranscriptTailOnSessionEnd: true,
         /* Current V3 clients carry initial items in call creation. Add the
            durable tail only when a streamed assistant response has no
            committed item; provider startup context owns the persisted history. */
@@ -1915,114 +1898,6 @@ export class CodexAppServerHost implements EngineHost {
     return answer;
   }
 
-  private async ensureVoicePersonaBootstrap(
-    identity: VoicePersonaBootstrapIdentity,
-    variant: VoicePersonaVariant,
-    pendingStart: PendingRealtimeStart,
-  ): Promise<"accepted" | "superseded"> {
-    await this.ensureCanonicalTranscriptPath();
-    while (!this.voicePersonaBootstrapAccepted.has(variant)) {
-      const active = this.voicePersonaBootstrapInsertion;
-      if (active) {
-        try {
-          await active.promise;
-        } catch (error) {
-          if (this.pendingRealtimeStart !== pendingStart) return "superseded";
-          if (active.owner === pendingStart) throw error;
-          continue;
-        }
-        continue;
-      }
-
-      const canonicalExists = await this.scanVoicePersonaBootstrap(
-        identity.itemId,
-        "canonical scan unavailable; refusing insertion",
-      );
-      /* The pre-#870 row is a COORDINATOR persona — no other variant existed when
-         it was written — so it answers only a coordinator bootstrap. A modality
-         start that accepted it would read "this thread is already bootstrapped"
-         off the very item it exists to correct, and leave the session demoted. */
-      const legacyExists = canonicalExists || variant !== "coordinator"
-        ? false
-        : await this.scanVoicePersonaBootstrap(
-          legacyVoicePersonaBootstrapItemId(this.identity.threadId),
-          "legacy canonical scan unavailable; refusing insertion",
-        );
-      if (canonicalExists || legacyExists) {
-        this.voicePersonaBootstrapAccepted.add(variant);
-        this.unresolvedVoicePersonaBootstrap.delete(variant);
-        break;
-      }
-      if (this.pendingRealtimeStart !== pendingStart) return "superseded";
-      if (this.voicePersonaBootstrapInsertion) continue;
-
-      const bootstrap = this.unresolvedVoicePersonaBootstrap.get(variant)
-        ?? voicePersonaBootstrap(identity, variant);
-      this.unresolvedVoicePersonaBootstrap.set(variant, bootstrap);
-      const promise = this.insertVoicePersonaBootstrap(bootstrap, identity.itemId, variant);
-      const insertion = { owner: pendingStart, promise };
-      this.voicePersonaBootstrapInsertion = insertion;
-      const clearInsertion = () => {
-        if (this.voicePersonaBootstrapInsertion === insertion) this.voicePersonaBootstrapInsertion = null;
-      };
-      void promise.then(clearInsertion, clearInsertion);
-      try {
-        await promise;
-      } catch (error) {
-        if (this.pendingRealtimeStart !== pendingStart) return "superseded";
-        throw error;
-      }
-    }
-    return "accepted";
-  }
-
-  private async ensureCanonicalTranscriptPath(): Promise<void> {
-    if (this.identity.path) return;
-    /* Metadata-only on purpose: this reader consumes nothing but the thread
-       identity and path, and hydration is refused on paginated threads (#1332). */
-    const result = await this.rpc("thread/read", {
-      threadId: this.identity.threadId,
-    });
-    const recovered = threadFromResult(result, "thread/read");
-    if (recovered.threadId !== this.identity.threadId) {
-      throw new Error("thread/read returned a different thread id");
-    }
-    if (!recovered.path) {
-      const error = new Error("canonical transcript path is unavailable") as NodeJS.ErrnoException;
-      error.code = "NO_TRANSCRIPT_PATH";
-      throw error;
-    }
-    this.identity.path = recovered.path;
-  }
-
-  private async insertVoicePersonaBootstrap(
-    bootstrap: VoicePersonaBootstrap,
-    itemId: string,
-    variant: VoicePersonaVariant,
-  ): Promise<void> {
-    try {
-      await this.rpc("thread/inject_items", {
-        threadId: this.identity.threadId,
-        items: [bootstrap.item],
-      }, this.realtimePersonaTimeoutMs);
-    } catch (error) {
-      if (!await this.scanVoicePersonaBootstrap(itemId, "recovery scan unavailable")) throw error;
-    }
-    this.voicePersonaBootstrapAccepted.add(variant);
-    this.unresolvedVoicePersonaBootstrap.delete(variant);
-  }
-
-  private async scanVoicePersonaBootstrap(itemId: string, warning: string): Promise<boolean> {
-    try {
-      return await canonicalVoicePersonaBootstrapExists(this.identity.path, itemId);
-    } catch (error) {
-      console.warn(`[voice persona bootstrap] ${warning}`, {
-        code: (error as NodeJS.ErrnoException).code ?? "unknown",
-        diagnostic: safeError(error),
-      });
-      throw error;
-    }
-  }
 
   async appendRealtimeSpeech(text: string): Promise<void> {
     if (!text || Buffer.byteLength(text, "utf8") > MAX_REALTIME_SPEECH_BYTES) {
@@ -2413,7 +2288,6 @@ export class CodexAppServerHost implements EngineHost {
       this.realtimeSessionId = null;
     }
     this.releasing = true;
-    this.unresolvedVoicePersonaBootstrap.clear();
     this.rejectRealtimeStart(new Error("Codex app-server host released"));
     this.rejectPendingAnswers(new Error("Codex app-server host released"));
     this.rejectPendingDeliveries(new Error("Codex app-server host released"));
@@ -3500,7 +3374,7 @@ export class CodexAppServerHost implements EngineHost {
     pending.resolve({
       sdp: pending.sdp,
       realtimeSessionId: pending.realtimeSessionId,
-      personaBootstrap: pending.personaBootstrap,
+      persona: pending.persona,
     });
   }
 

--- a/src/lib/runtime/realtimeControl.selectedContext.test.ts
+++ b/src/lib/runtime/realtimeControl.selectedContext.test.ts
@@ -313,3 +313,83 @@ test("a corrupt WakaTime state file does not refuse a live realtime operator eve
     fs.rmSync(stateDirectory, { recursive: true, force: true });
   }
 });
+
+
+/* ------------------------------------------------------------------ *
+ * The handoff report (#1629): which work the last utterance became.
+ * ------------------------------------------------------------------ */
+
+const UTTERANCE = { id: "a".repeat(32), sequence: 1 };
+const HANDOFF = { handoffId: "handoff-1", itemId: "item-1", userBidiTurnId: "bidi-1" };
+
+async function publish(host: ReturnType<typeof hostFor>, body: Record<string, unknown>) {
+  return executeRealtimeControl(
+    { conversationId: "conversation_voice", ...body },
+    () => host,
+    PEER,
+  );
+}
+
+test("a handoff report completes the utterance it names", async () => {
+  const host = hostFor([]);
+  await start(host, DESK);
+  await publish(host, { action: "selectedContext", selectedContext: reference(DESK), utterance: UTTERANCE });
+
+  const recorded = await publish(host, { action: "handoff", utterance: UTTERANCE, handoff: HANDOFF });
+  expect(recorded.status).toBe(200);
+  expect(recorded.body).toEqual({ ok: true, handoff: HANDOFF });
+  expect(voiceSelectedContext("conversation_voice")?.handoff).toEqual(HANDOFF);
+});
+
+test("a handoff report naming nothing is refused before it reaches the ledger", async () => {
+  /* Not a 409: a report that names no utterance and no handoff is a malformed
+     request, and answering it with the ledger's "you have moved on" would send
+     the client looking for a race that is not there. */
+  const host = hostFor([]);
+  await start(host, DESK);
+  await publish(host, { action: "selectedContext", selectedContext: reference(DESK), utterance: UTTERANCE });
+
+  for (const body of [
+    { action: "handoff", utterance: UTTERANCE },
+    { action: "handoff", utterance: UTTERANCE, handoff: {} },
+    { action: "handoff", utterance: UTTERANCE, handoff: { handoffId: "" } },
+    { action: "handoff", handoff: HANDOFF },
+    { action: "handoff", utterance: { id: "not-hex", sequence: 1 }, handoff: HANDOFF },
+    { action: "handoff", utterance: { id: UTTERANCE.id, sequence: 0 }, handoff: HANDOFF },
+  ]) {
+    const refused = await publish(host, body);
+    expect(refused.status).toBe(400);
+  }
+  expect(voiceSelectedContext("conversation_voice")?.handoff).toBeNull();
+});
+
+test("a handoff from a caller with no live session credential is refused", async () => {
+  const host = hostFor([]);
+  await start(host, DESK);
+  await publish(host, { action: "selectedContext", selectedContext: reference(DESK), utterance: UTTERANCE });
+
+  const anonymous = await executeRealtimeControl(
+    { action: "handoff", conversationId: "conversation_voice", utterance: UTTERANCE, handoff: HANDOFF },
+    () => host,
+    { operator: false },
+  );
+  expect(anonymous.status).toBe(409);
+  expect(anonymous.body.code).toBe("unbound");
+  expect(voiceSelectedContext("conversation_voice")?.handoff).toBeNull();
+});
+
+test("a malformed utterance identity does not make an ordinary reference unpublishable", async () => {
+  /* The identity is ordering evidence, not a credential. A client that sends a
+     broken one still had something on screen, and refusing the reference would
+     trade a weaker ordering guarantee for no reference at all. */
+  const host = hostFor([]);
+  await start(host, DESK);
+  const published = await publish(host, {
+    action: "selectedContext",
+    selectedContext: reference(DESK),
+    utterance: { id: "not-hex", sequence: "second" },
+  });
+  expect(published.status).toBe(200);
+  expect(voiceSelectedContext("conversation_voice")?.reference).toEqual(reference(DESK));
+  expect(voiceSelectedContext("conversation_voice")?.utteranceId).toBeNull();
+});

--- a/src/lib/runtime/realtimeControl.selectedContext.test.ts
+++ b/src/lib/runtime/realtimeControl.selectedContext.test.ts
@@ -379,7 +379,7 @@ test("a handoff from a caller with no live session credential is refused", async
 });
 
 test("a malformed utterance identity does not make an ordinary reference unpublishable", async () => {
-  /* The identity is ordering evidence, not a credential. A client that sends a
+  /* The identity is ordering evidence and authorizes nothing. A client that sends a
      broken one still had something on screen, and refusing the reference would
      trade a weaker ordering guarantee for no reference at all. */
   const host = hostFor([]);

--- a/src/lib/runtime/realtimeControl.selectedContext.test.ts
+++ b/src/lib/runtime/realtimeControl.selectedContext.test.ts
@@ -22,10 +22,9 @@ import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorAct
 const NOW = Date.now();
 const DESK = { viewSessionId: "vs-desk-1", deviceId: "dev-desk" };
 const PHONE = { viewSessionId: "vs-phone-1", deviceId: "dev-phone" };
-const ACCEPTED_PERSONA_BOOTSTRAP = {
-  receiptId: `voice_persona_${"d".repeat(46)}`,
-  itemId: `msg_voice_persona_${"d".repeat(46)}`,
-  insertion: "accepted" as const,
+const LIVE_PERSONA = {
+  variant: "modality" as const,
+  personaId: `voice_persona_${"d".repeat(46)}`,
 };
 
 function reference(identity: { viewSessionId: string; deviceId: string }, card = "conversation_atlas_a"): SelectedContextRef {
@@ -45,7 +44,7 @@ function hostFor(spoken: string[]) {
       return {
         sdp: "v=0\r\nanswer",
         realtimeSessionId: "live-1",
-        personaBootstrap: ACCEPTED_PERSONA_BOOTSTRAP,
+        persona: LIVE_PERSONA,
       };
     },
     async appendRealtimeSpeech(text: string) {

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -4,7 +4,7 @@ import { redactCodexHostDiagnostic } from "./codexAppServerHost";
 import { structuredDeliveryHostForConversation } from "./structuredDeliveryController";
 import { permitRealtimeAction, type RealtimeCaller } from "./realtimeInjection";
 import type { RuntimeVoiceDelivery } from "./voiceDelivery";
-import type { VoicePersonaBootstrapReceipt, VoicePersonaVariant } from "./voicePersona";
+import type { VoicePersonaVariant } from "./voicePersona";
 import {
   admitVoiceSelectedContext,
   bindVoiceSession,
@@ -20,7 +20,7 @@ interface RealtimeHost {
   startRealtimeWebRtc(sdp: string, personaVariant?: VoicePersonaVariant): Promise<{
     sdp: string | null;
     realtimeSessionId: string | null;
-    personaBootstrap: VoicePersonaBootstrapReceipt;
+    persona: { variant: VoicePersonaVariant; personaId: string };
   }>;
   appendRealtimeSpeech(text: string): Promise<void>;
   deliverRealtimeWorkerResponse?(delivery: RuntimeVoiceDelivery): Promise<{
@@ -64,16 +64,21 @@ function byteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
 }
 
-function voicePersonaBootstrapReceipt(value: unknown): VoicePersonaBootstrapReceipt | null {
+/**
+ * Which persona the started call is running on (#1629).
+ *
+ * The persona now rides on `thread/realtime/start` itself, so a started call has
+ * one by construction and there is no insertion to accept or reject. This
+ * validates the shape only, so a host that answers something else is caught
+ * rather than reported to the browser as a live persona.
+ */
+function voiceSessionPersonaReceipt(value: unknown): { variant: VoicePersonaVariant; personaId: string } | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const receipt = value as Record<string, unknown>;
-  const receiptId = typeof receipt.receiptId === "string" ? receipt.receiptId : "";
-  const itemId = typeof receipt.itemId === "string" ? receipt.itemId : "";
-  if (!/^voice_persona_[a-f0-9]{46}$/.test(receiptId) || itemId !== `msg_${receiptId}`) return null;
-  if (receipt.insertion !== "accepted" && receipt.insertion !== "rejected") return null;
-  if (receipt.diagnostic !== undefined
-    && (typeof receipt.diagnostic !== "string" || receipt.diagnostic.length > 500)) return null;
-  return receipt as VoicePersonaBootstrapReceipt;
+  const personaId = typeof receipt.personaId === "string" ? receipt.personaId : "";
+  if (!/^voice_persona_[a-f0-9]{46}$/.test(personaId)) return null;
+  if (receipt.variant !== "coordinator" && receipt.variant !== "modality") return null;
+  return { variant: receipt.variant, personaId };
 }
 
 async function rejectStartedRealtimeContract(
@@ -164,20 +169,9 @@ export async function executeRealtimeControl(
          call site that did not ask has not established that this thread is the
          voice front. */
       const answer = await host.startRealtimeWebRtc(sdp, authority.personaVariant ?? "modality");
-      if (!answer.personaBootstrap) {
-        return rejectStartedRealtimeContract(host, { error: "Codex returned no voice persona bootstrap receipt" });
-      }
-      const personaBootstrap = voicePersonaBootstrapReceipt(answer.personaBootstrap);
-      if (!personaBootstrap) {
-        return rejectStartedRealtimeContract(host, { error: "Codex returned an invalid voice persona bootstrap receipt" });
-      }
-      if (personaBootstrap.insertion === "rejected") {
-        const diagnostic = redactCodexHostDiagnostic(personaBootstrap.diagnostic ?? "Voice persona insertion was rejected");
-        const error = redactCodexHostDiagnostic(`Voice persona could not be recorded: ${diagnostic}`);
-        return rejectStartedRealtimeContract(host, {
-          error,
-          personaBootstrap: { ...personaBootstrap, diagnostic },
-        });
+      const persona = voiceSessionPersonaReceipt(answer.persona);
+      if (!persona) {
+        return rejectStartedRealtimeContract(host, { error: "Codex returned no voice session persona" });
       }
       if (!answer.sdp) {
         return rejectStartedRealtimeContract(host, { error: "Codex returned no WebRTC answer" });
@@ -189,7 +183,7 @@ export async function executeRealtimeControl(
       if (answer.realtimeSessionId) {
         bindVoiceSession(conversationId, answer.realtimeSessionId, parseVoiceViewBinding(request.view));
       }
-      return { status: 200, body: { ok: true, ...answer, personaBootstrap } };
+      return { status: 200, body: { ok: true, ...answer, persona } };
     }
     /**
      * The browser's utterance boundary (#844 §2).

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -301,7 +301,7 @@ export async function executeRealtimeControl(
       const recorded = recordVoiceHandoff({
         conversationId,
         realtimeSessionId: caller.kind === "session" ? caller.realtimeSessionId : "",
-        utteranceId: utterance.id,
+        utterance,
         handoff,
       });
       if (!recorded.ok) {

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -67,15 +67,6 @@ function byteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
 }
 
-/**
- * The utterance a publication speaks for (#1629).
- *
- * Named by the browser, because the browser is the peer that sees the operator's
- * transcript go final — the operator's audio never passes through this server.
- * A malformed identity is dropped rather than refused: the reference is still
- * the bound view's and still admissible, and the ordering rules fall back to the
- * reference's own revision.
- */
 /** At least one canonical id, each bounded; a report naming nothing is refused. */
 function voiceHandoffIdentity(value: unknown): VoiceHandoffIdentity | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -92,6 +83,16 @@ function voiceHandoffIdentity(value: unknown): VoiceHandoffIdentity | null {
   return handoff.handoffId || handoff.itemId || handoff.userBidiTurnId ? handoff : null;
 }
 
+/**
+ * The utterance a publication speaks for (#1629).
+ *
+ * Named by the browser, because the browser is the peer that sees the operator's
+ * transcript go final — the operator's audio never passes through this server.
+ * A malformed identity is dropped rather than refused where a reference is being
+ * published: the reference is still the bound view's and still admissible, and
+ * the ordering rules fall back to its own revision. A handoff report has nothing
+ * left once it is dropped, so that path refuses instead.
+ */
 function voiceUtteranceIdentity(value: unknown): VoiceUtteranceIdentity | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const body = value as Record<string, unknown>;

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -11,6 +11,7 @@ import {
   parseVoiceViewBinding,
   recordVoiceHandoff,
   releaseVoiceSession,
+  voiceUtteranceContext,
   type VoiceHandoffIdentity,
   type VoiceUtteranceIdentity,
 } from "./voiceViewBinding";
@@ -188,6 +189,34 @@ export async function executeRealtimeControl(
     return { status: permitted.status, body: { error: permitted.error } };
   }
 
+  /**
+   * The reader (#1629), answered before the host requirement because it reads a
+   * process-local ledger and needs no thread.
+   *
+   * The agent running the backing turn asks what the operator was looking at
+   * when they spoke. It is entitled to that about ITS OWN call and nothing else,
+   * which the capability the registry mapped is what establishes — an agent
+   * cannot ask about another conversation's call, and a caller presenting
+   * nothing cannot ask at all.
+   *
+   * Every answer is 200 with a state, including the ones that say no. The four
+   * ways there is no card mean different things to the agent holding the
+   * microphone, and an error would flatten them into "something went wrong".
+   */
+  if (request.action === "utteranceContext") {
+    const own = caller.kind === "conversation" && caller.conversationId === conversationId;
+    if (!own && !authority.operator) {
+      return {
+        status: 403,
+        body: {
+          error: "utteranceContext reads what the operator's own voice call points at. "
+            + "Only that call's conversation may read it.",
+        },
+      };
+    }
+    return { status: 200, body: { ok: true, utterance: voiceUtteranceContext(conversationId) } };
+  }
+
   if (!host) {
     return { status: 409, body: { error: "the active conversation has no hosted Codex realtime thread" } };
   }
@@ -359,7 +388,7 @@ export async function executeRealtimeControl(
         },
       };
     }
-    return { status: 400, body: { error: "action must be start, operatorActivity, selectedContext, handoff, appendSpeech, deliverWorkerResponse, stop, or status" } };
+    return { status: 400, body: { error: "action must be start, operatorActivity, selectedContext, handoff, utteranceContext, appendSpeech, deliverWorkerResponse, stop, or status" } };
   } catch (error) {
     return { status: 409, body: { error: redactCodexHostDiagnostic(error) } };
   }

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -9,7 +9,9 @@ import {
   admitVoiceSelectedContext,
   bindVoiceSession,
   parseVoiceViewBinding,
+  recordVoiceHandoff,
   releaseVoiceSession,
+  type VoiceHandoffIdentity,
   type VoiceUtteranceIdentity,
 } from "./voiceViewBinding";
 import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorActivity";
@@ -74,6 +76,22 @@ function byteLength(value: string): number {
  * the bound view's and still admissible, and the ordering rules fall back to the
  * reference's own revision.
  */
+/** At least one canonical id, each bounded; a report naming nothing is refused. */
+function voiceHandoffIdentity(value: unknown): VoiceHandoffIdentity | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const body = value as Record<string, unknown>;
+  const id = (key: string): string | null => {
+    const raw = body[key];
+    return typeof raw === "string" && raw.length > 0 && raw.length <= 200 ? raw : null;
+  };
+  const handoff = {
+    handoffId: id("handoffId"),
+    itemId: id("itemId"),
+    userBidiTurnId: id("userBidiTurnId"),
+  };
+  return handoff.handoffId || handoff.itemId || handoff.userBidiTurnId ? handoff : null;
+}
+
 function voiceUtteranceIdentity(value: unknown): VoiceUtteranceIdentity | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const body = value as Record<string, unknown>;
@@ -236,6 +254,31 @@ export async function executeRealtimeControl(
         body: { ok: true, selectedContext: admission.admission.reference, sequence: admission.admission.sequence },
       };
     }
+    /**
+     * Which handoff the last published utterance became (#1629).
+     *
+     * Authorized the same way `selectedContext` is — by the ledger, against the
+     * session id the call was bound to — because it completes that ledger's own
+     * record and nothing else. It writes no words, mints no utterance and moves
+     * no counter.
+     */
+    if (request.action === "handoff") {
+      const utterance = voiceUtteranceIdentity(request.utterance);
+      const handoff = voiceHandoffIdentity(request.handoff);
+      if (!utterance || !handoff) {
+        return { status: 400, body: { error: "a handoff report needs an utterance identity and at least one handoff id" } };
+      }
+      const recorded = recordVoiceHandoff({
+        conversationId,
+        realtimeSessionId: caller.kind === "session" ? caller.realtimeSessionId : "",
+        utteranceId: utterance.id,
+        handoff,
+      });
+      if (!recorded.ok) {
+        return { status: 409, body: { error: recorded.failure.message, code: recorded.failure.code } };
+      }
+      return { status: 200, body: { ok: true, handoff: recorded.admission.handoff } };
+    }
     if (request.action === "operatorActivity") {
       const operatorEventId = typeof request.operatorEventId === "string" ? request.operatorEventId.trim() : "";
       if (!/^[a-f0-9]{64}$/.test(operatorEventId)) {
@@ -315,7 +358,7 @@ export async function executeRealtimeControl(
         },
       };
     }
-    return { status: 400, body: { error: "action must be start, operatorActivity, selectedContext, appendSpeech, deliverWorkerResponse, stop, or status" } };
+    return { status: 400, body: { error: "action must be start, operatorActivity, selectedContext, handoff, appendSpeech, deliverWorkerResponse, stop, or status" } };
   } catch (error) {
     return { status: 409, body: { error: redactCodexHostDiagnostic(error) } };
   }

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -10,6 +10,7 @@ import {
   bindVoiceSession,
   parseVoiceViewBinding,
   releaseVoiceSession,
+  type VoiceUtteranceIdentity,
 } from "./voiceViewBinding";
 import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorActivity";
 
@@ -62,6 +63,25 @@ function realtimeHost(value: unknown): RealtimeHost | null {
 
 function byteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
+}
+
+/**
+ * The utterance a publication speaks for (#1629).
+ *
+ * Named by the browser, because the browser is the peer that sees the operator's
+ * transcript go final — the operator's audio never passes through this server.
+ * A malformed identity is dropped rather than refused: the reference is still
+ * the bound view's and still admissible, and the ordering rules fall back to the
+ * reference's own revision.
+ */
+function voiceUtteranceIdentity(value: unknown): VoiceUtteranceIdentity | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const body = value as Record<string, unknown>;
+  const id = typeof body.id === "string" ? body.id : "";
+  const sequence = body.sequence;
+  if (!/^[a-f0-9]{32}$/.test(id)) return null;
+  if (typeof sequence !== "number" || !Number.isSafeInteger(sequence) || sequence < 1) return null;
+  return { id, sequence };
 }
 
 /**
@@ -205,6 +225,7 @@ export async function executeRealtimeControl(
         conversationId,
         realtimeSessionId: caller.kind === "session" ? caller.realtimeSessionId : "",
         reference: parseSelectedContextRef(request.selectedContext),
+        utterance: voiceUtteranceIdentity(request.utterance),
         now: Date.now(),
       });
       if (!admission.ok) {
@@ -252,6 +273,7 @@ export async function executeRealtimeControl(
           conversationId,
           realtimeSessionId: caller.kind === "session" ? caller.realtimeSessionId : "",
           reference,
+          utterance: voiceUtteranceIdentity(request.utterance),
           now: Date.now(),
         });
         if (!admission.ok) {

--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -1,18 +1,11 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-
 import { expect, test } from "bun:test";
 
 import {
-  canonicalVoicePersonaBootstrapExists,
   COORDINATOR_VOICE_PERSONA,
   MODALITY_VOICE_PERSONA,
-  legacyVoicePersonaBootstrapItemId,
   PERSONA_NAME,
-  voicePersona,
-  voicePersonaBootstrap,
-  voicePersonaBootstrapIdentity,
+  spokenVoicePersona,
+  voiceSessionPersona,
 } from "./voicePersona";
 
 /* Language names the prompt must never speak of, in the forms a hard pin would
@@ -52,91 +45,58 @@ function languagePins(persona: string): string[] {
 }
 
 test("the built-in persona stands when no override file exists", () => {
-  const persona = voicePersona("coordinator", () => { throw new Error("ENOENT"); });
+  const persona = spokenVoicePersona("coordinator", () => { throw new Error("ENOENT"); });
   expect(persona).toBe(COORDINATOR_VOICE_PERSONA);
 });
 
 test("an operator override replaces the built-in persona wholesale", () => {
   /* A new thread resolves the current override wholesale; an established
      thread keeps the developer item it already persisted. */
-  const persona = voicePersona("coordinator", () => "  You are the coordinator. Keep it short.  ");
+  const persona = spokenVoicePersona("coordinator", () => "  You are the coordinator. Keep it short.  ");
   expect(persona).toBe("You are the coordinator. Keep it short.");
   expect(persona).not.toBe(COORDINATOR_VOICE_PERSONA);
 });
 
 test("an empty or whitespace override falls back instead of muting the persona", () => {
-  expect(voicePersona("coordinator", () => "   \n  ")).toBe(COORDINATOR_VOICE_PERSONA);
+  expect(spokenVoicePersona("coordinator", () => "   \n  ")).toBe(COORDINATOR_VOICE_PERSONA);
 });
 
-test("one durable thread identity produces one stable canonical developer item", () => {
-  const identity = voicePersonaBootstrapIdentity("thread-voice", "coordinator");
-  expect(voicePersonaBootstrapIdentity("thread-voice", "coordinator")).toEqual(identity);
-  expect(voicePersonaBootstrapIdentity("thread-other", "coordinator")).not.toEqual(identity);
-  expect(identity.itemId.length).toBeLessThanOrEqual(64);
-  expect(legacyVoicePersonaBootstrapItemId("thread-voice")).toStartWith(identity.itemId);
-  expect(legacyVoicePersonaBootstrapItemId("thread-voice").length).toBe(82);
-  expect(voicePersonaBootstrap(identity, "coordinator", () => "  Resolved call persona. \n")).toEqual({
-    item: {
-      type: "message",
-      id: identity.itemId,
-      role: "developer",
-      content: [{ type: "input_text", text: "Resolved call persona." }],
-    },
-  });
+test("one variant produces one stable session persona", () => {
+  /* Stable so the voice panel and the tests can name the persona a live call is
+     running on, and so a reconnect on the same variant is recognisably the same
+     persona rather than a new one. */
+  const persona = voiceSessionPersona("coordinator", () => "  Resolved call persona. \n");
+  expect(voiceSessionPersona("coordinator", () => "  Resolved call persona. \n")).toEqual(persona);
+  expect(persona.prompt).toBe("Resolved call persona.");
+  expect(persona.variant).toBe("coordinator");
+  expect(voiceSessionPersona("modality").personaId).not.toBe(persona.personaId);
 });
 
-test("canonical receipt scanning recognizes reordered fields across a stream chunk boundary and refuses a symlink", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-scan-"));
-  const transcript = path.join(isolated, "thread.jsonl");
-  const linked = path.join(isolated, "linked.jsonl");
-  const itemId = `msg_voice_persona_${"b".repeat(46)}`;
-  const record = JSON.stringify({
-    padding: "x".repeat(65_400),
-    payload: { role: "developer", content: [], id: itemId, type: "message" },
-    type: "response_item",
-  });
-  fs.writeFileSync(transcript, `${record}\n`);
-  fs.symlinkSync(transcript, linked);
-  try {
-    expect(await canonicalVoicePersonaBootstrapExists(transcript, itemId)).toBeTrue();
-    await expect(canonicalVoicePersonaBootstrapExists(linked, itemId)).rejects.toThrow();
-    await expect(canonicalVoicePersonaBootstrapExists(null, itemId))
-      .rejects.toThrow("canonical transcript path is unavailable");
-  } finally {
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
-});
-
-test("canonical receipt scanning ignores malformed rows and marker-like content", async () => {
-  const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-voice-persona-structural-scan-"));
-  const transcript = path.join(isolated, "thread.jsonl");
-  const itemId = `msg_voice_persona_${"c".repeat(46)}`;
-  const markerLikeText = `"type":"message","id":"${itemId}","role":"developer"`;
-  fs.writeFileSync(transcript, [
-    `{malformed:${markerLikeText}}`,
-    JSON.stringify({
-      type: "response_item",
-      payload: {
-        type: "message",
-        id: "ordinary-system-row",
-        role: "developer",
-        content: [{ type: "input_text", text: markerLikeText }],
-      },
-    }),
-  ].join("\n") + "\n");
-  try {
-    expect(await canonicalVoicePersonaBootstrapExists(transcript, itemId)).toBeFalse();
-  } finally {
-    fs.rmSync(isolated, { recursive: true, force: true });
-  }
+test("a session persona writes nothing that could outlive its call", () => {
+  /* The property the whole repair rests on. `thread/inject_items` appends to an
+     append-only transcript, so a persona written that way is permanent and each
+     variant accumulated its own copy; these three strings are parameters of one
+     `thread/realtime/start` and are gone when the call is. */
+  const persona = voiceSessionPersona("modality");
+  expect(Object.keys(persona).sort()).toEqual([
+    "endInstructions", "personaId", "prompt", "startInstructions", "variant",
+  ]);
+  for (const value of Object.values(persona)) expect(typeof value).toBe("string");
 });
 
 test("no shipped persona pins a spoken language anywhere", () => {
   /* The whole property in one line: naming any language, in any sentence, is
      the defect — the prose may not even name the language it is written in.
-     Both variants are shipped text, so both are bound by it. */
+     Both variants are shipped text, so both are bound by it — and so are the
+     session-scoped instructions the backing model receives, which are prompt
+     text reaching a model exactly as the spoken persona is. */
   expect(languagePins(COORDINATOR_VOICE_PERSONA)).toEqual([]);
   expect(languagePins(MODALITY_VOICE_PERSONA)).toEqual([]);
+  for (const variant of ["coordinator", "modality"] as const) {
+    const persona = voiceSessionPersona(variant);
+    expect(languagePins(persona.startInstructions)).toEqual([]);
+    expect(languagePins(persona.endInstructions)).toEqual([]);
+  }
 });
 
 test("appending a hard pin to any language is caught", () => {
@@ -249,27 +209,33 @@ test("the character never buys itself room on truth", () => {
    agent is told which tool carries it and what to reuse on a retry; nothing else in
    the running system can say so. */
 
-test("the persona tells the gateway it relays to a manager rather than driving the board", () => {
-  expect(COORDINATOR_VOICE_PERSONA).toContain("only agent the user talks to");
+test("the spoken persona tells the voice it does not drive the board itself", () => {
+  expect(COORDINATOR_VOICE_PERSONA).toContain("only voice the user hears");
   expect(COORDINATOR_VOICE_PERSONA).toContain("do not touch the board yourself");
-  expect(COORDINATOR_VOICE_PERSONA).toContain("manager");
 });
 
-test("the persona names the directive tool and the id it must reuse on a retry", () => {
-  expect(COORDINATOR_VOICE_PERSONA).toContain("bridge_directive");
-  expect(COORDINATOR_VOICE_PERSONA).toContain("reuse the same turn id and index");
+test("the backing instructions name the directive tool and the id it must reuse on a retry", () => {
+  /* Addressed to the model that actually holds the tool. The spoken model has
+     none, so a relay mandate delivered to it can only produce a refusal. */
+  const backing = voiceSessionPersona("coordinator").startInstructions;
+  expect(backing).toContain("bridge_directive");
+  expect(backing).toContain("reuse the same turn id and index");
   /* The recipient is server-resolved; a gateway that thought it chose one would
      eventually try to message a worker. */
-  expect(COORDINATOR_VOICE_PERSONA).toContain("you never name it");
+  expect(backing).toContain("you never name it");
 });
 
-test("the persona carries the deploy round trip and its refusals", () => {
+test("the deploy round trip and its refusals reach both models", () => {
+  /* The user's spoken yes is heard by the spoken model and acted on by the
+     backing one, so neither half can carry the rule alone. */
   expect(COORDINATOR_VOICE_PERSONA).toContain("spoken yes");
-  expect(COORDINATOR_VOICE_PERSONA).toContain("Never invent or reword");
-  expect(COORDINATOR_VOICE_PERSONA).toContain("Anything other than a clear yes is a no");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("anything other than a clear yes is a no");
+  const backing = voiceSessionPersona("coordinator").startInstructions;
+  expect(backing).toContain("spoken yes");
+  expect(backing).toContain("Never invent or reword");
 });
 
-test("the persona keeps the plumbing out of the user's ear", () => {
+test("the spoken persona keeps the plumbing out of the user's ear", () => {
   expect(COORDINATOR_VOICE_PERSONA).toContain("do not narrate the plumbing");
-  expect(COORDINATOR_VOICE_PERSONA).toContain("do not read the report verbatim");
+  expect(COORDINATOR_VOICE_PERSONA).toContain("do not read a report verbatim");
 });

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -322,7 +322,7 @@ export interface VoiceSessionPersona {
   /** Stable digest of the resolved prompt; identical text yields identical id. */
   personaId: string;
   /** Instructions for the spoken model. */
-  prompt: string;
+  "prompt": string;
   /** Session-scoped developer instructions for the backing model. */
   startInstructions: string;
   /** Withdrawal handed to the backing model when the call ends. */

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -5,6 +5,38 @@ import { createHash } from "node:crypto";
 import { configFilePath } from "@/lib/configDir";
 
 /**
+ * WHICH MODEL EACH OF THESE TEXTS IS FOR (#1629).
+ *
+ * A realtime V3 call runs TWO models, and the whole voice failure was writing
+ * for one of them and delivering to the other:
+ *
+ * - The SPOKEN model (`gpt-live-1-codex`) holds the microphone. Its entire
+ *   instruction set is the `prompt` parameter of `thread/realtime/start`. It has
+ *   no tools; it delegates to the thread.
+ * - The BACKING model is the thread's own agent — the orchestrator, with its
+ *   mandate, its seat and its whole MCP inventory. It receives session-scoped
+ *   developer instructions through `realtimeStartInstructions` and, when the
+ *   call ends, `realtimeEndInstructions`.
+ *
+ * Until this split the Viewer sent NEITHER. It wrote the persona into the
+ * thread with `thread/inject_items`, which reaches only the backing model, and
+ * left `prompt` unset — so the spoken model ran Codex's stock built-in realtime
+ * persona ("You are Codex … a playful collaborator", 5.7 kB), whose startup
+ * context states in its own words that it excludes repo memory instructions and
+ * AGENTS files. The operator's orchestrator therefore lost its role and its
+ * tools the moment the microphone opened, exactly as reported, while the text
+ * agent quietly accumulated one permanent copy of the spoken-delivery rules per
+ * thread.
+ *
+ * Verified against the installed app-server, credential-free, in
+ * `docs/design/codex-api-update/voice_probe.py`: an incumbent thread carrying a
+ * durable developer role/tool mandate reaches the backing model and does NOT
+ * reach the spoken session, whose instructions are the stock persona; supplying
+ * `prompt` replaces those instructions, and neither `prompt` nor either
+ * instruction string is written to canonical history.
+ */
+
+/**
  * The assistant's established name, in its canonical English spelling.
  *
  * A name written in one script is read aloud in that script's language, so a
@@ -105,64 +137,48 @@ Never use the construction "not X, but Y" — say it straight.
 `;
 
 /**
- * The mandate of a session whose ONLY job is the call (#691 §4).
+ * What the SPOKEN model does for a session created to BE the voice front (#691 §4).
  *
- * This is a role, and a total one: it says the session talks to nobody but the
- * user, owns no board tool, and relays everything onward. That is right for a
- * session created to be the voice front and catastrophic for any other, which is
- * why it is reachable only through {@link voicePersonaVariantFor} naming an
- * explicitly-created coordinator.
+ * The spoken model owns no tool in either variant — a realtime V3 session has
+ * none — so this says how to talk about the work, not how to do it. The relay
+ * mechanics that used to live here moved to {@link COORDINATOR_BACKING_WORK},
+ * where the model that actually holds `bridge_directive` can read them.
  */
-const COORDINATOR_WORK = `
-You are the only agent the user talks to, and you do not touch the board yourself. There is a manager for that: it owns tasks, pipelines, pull requests, workers and deploys. You relay what the user wants to it, and you tell the user what comes back. You have no tools for spawning agents, editing tasks or deploying, and asking for them is not the move — relaying is.
+const COORDINATOR_SPOKEN_WORK = `
+You are the only voice the user hears, and you do not touch the board yourself. The agent behind you does: it owns tasks, pipelines, pull requests, workers and deploys, and it has the tools for all of it. Everything the user asks for goes to it, and you say back what comes of it.
 
-Relay with bridge_directive. Pass the current turn id and the index of this instruction within the turn, and the user's intent in plain words. The recipient is resolved for you; you never name it. If a call fails and you retry, reuse the same turn id and index — that is what stops one instruction arriving twice.
+Never say you cannot do something. Pass it to the agent behind you and let it answer.
 
-Answers, questions and blockers from the manager arrive in this conversation on their own. Say what matters out loud in your own words. Do not read identifiers, do not read the report verbatim, and do not narrate the plumbing.
+Answers, questions and blockers arrive on their own. Say what matters out loud in your own words. Do not read identifiers, do not read a report verbatim, and do not narrate the plumbing.
 
-When the manager asks something, put the question to the user, then relay their answer with bridge_directive carrying the reference from that report.
+A deploy needs the user's spoken yes. Put the question plainly and pass their answer back exactly as they gave it; anything other than a clear yes is a no.
 
-A deploy needs the user's spoken yes. The manager sends the exact commit and a one-time authorization; ask the user plainly, and on a yes relay it back with the reference, the nonce and the commit exactly as given. Never invent or reword any of the three. Anything other than a clear yes is a no — say so and relay nothing.
+Before any claim about the state of the work, ask rather than guess. Claims from memory go stale faster than the conversation runs.
 
-Before any claim about the state of the work, ask the manager rather than guessing. Claims from memory go stale faster than the conversation runs.
-
-While a worker runs, say briefly what is happening. Two minutes of silence sounds like a hang.
-
-Do not ask permission for what you can check yourself.
+While work runs, say briefly what is happening. Two minutes of silence sounds like a hang.
 
 Stay silent until you are spoken to: this text is context, and there is nothing here to greet.`;
 
 /**
- * What voice changes for a session that already has a role: how it hears and how
- * it answers, and nothing else (#1615).
+ * What the SPOKEN model does for a conversation that already has a role (#1615, #1629).
  *
- * The operator enabled voice on their orchestrator's conversation and the call
- * start wrote {@link COORDINATOR_WORK} into that thread. The seat read it,
- * concluded it was now a relay with no board tools, and relayed its own work to
- * "the manager" — which `bridge_directive` resolves from the designation record,
- * so the instruction arrived back at the seat that sent it. It then declined the
- * work it was holding, while the Viewer still showed it as the manager.
- *
- * So this section assigns nothing and removes nothing. It states that the role,
- * the authority, the seat, the tools and the pending work are untouched, and it
- * says so explicitly enough to outrank a coordinator item a thread may already
- * carry from a call taken before this fix — an injected item cannot be withdrawn
- * from an append-only transcript, so the correction has to be louder than it.
+ * The agent behind this microphone is the one holding the work — commonly the
+ * project's own orchestrator, with its mandate, its seat and its whole tool
+ * inventory. The spoken model's job is to be its voice, and the failure this
+ * text exists to prevent is the spoken model answering FOR it: Codex's stock
+ * realtime persona introduces itself as a general-purpose assistant, so left to
+ * itself it chats, guesses, and tells the operator it has no tools.
  */
-const MODALITY_WORK = `
-Voice changes how you hear and how you answer while a call is live. It changes nothing else.
+const MODALITY_SPOKEN_WORK = `
+You are the voice of the agent in this conversation. It is not a helper standing behind you; it is who you are speaking as, and it already has its own instructions, its own authority and its own tools.
 
-The delivery rules above are about speaking. This text stays in the thread after the call ends, so when you are writing rather than speaking, write the way you always have.
+So do not answer from your own knowledge and do not decide anything on your own. Every request, correction and question the user speaks goes to that agent, and what you say aloud is what came back.
 
-Your role in this conversation is exactly what it was a moment ago: the same instructions, the same authority, the same seat, the same tools, the same pending work, the same agents to run. Nothing here removes a tool you have or moves your responsibilities to anyone else.
+Never say that you have no tools, no access or no permission. You do not know what it can reach; it does. Pass the request on and let it answer.
 
-If something earlier in this thread cast you as a relay — that your only job is to speak, that the board belongs to someone else, that the tools you can see are not yours to use — it was written for a session created to be nothing but a voice front. It was not written for you, and it does not apply here. Your own instructions stand.
+Do not describe yourself as a separate assistant, a front end or a relay, and do not talk about the agent in the third person. To the user there is one participant in this conversation, and you are how it speaks.
 
-Do the work yourself. You are being spoken to because you are the one holding it.
-
-Do not relay your own work with bridge_directive. That tool addresses the project's designated orchestrator, so when you are that orchestrator it hands the instruction back to you and the request goes nowhere. Use it only to reach an orchestrator that is not you.
-
-A spoken request is an ordinary request. Take it with the authority you already have, do the work, and say out loud what came of it.
+While it works, say briefly what is happening. Two minutes of silence sounds like a hang.
 
 Stay silent until you are spoken to: this text is context, and there is nothing here to greet.`;
 
@@ -173,70 +189,74 @@ const COORDINATOR_IDENTITY = `Your name is ${PERSONA_NAME}. You are the voice co
 /** The same spoken name, and no claim about the role behind it. The operator
     hears one voice either way; what differs is what that voice is allowed to
     say it is responsible for. */
-const MODALITY_IDENTITY = `Your name is ${PERSONA_NAME} when you speak aloud. Speaking is how you hear this conversation and how you answer in it.`;
+const MODALITY_IDENTITY = `Your name is ${PERSONA_NAME} when you speak aloud. Speaking is how this conversation hears the operator and how it answers.`;
 
-/** Injected as the call's first thread item for a session created to BE the
-    voice front. Editable without a deploy — see {@link voicePersona}. */
+/** The spoken model's whole instruction set for a session created to BE the
+    voice front. Editable without a deploy — see {@link spokenVoicePersona}. */
 export const COORDINATOR_VOICE_PERSONA = `${COORDINATOR_IDENTITY}${SPOKEN_DELIVERY}
 ## Work
-${COORDINATOR_WORK}`;
+${COORDINATOR_SPOKEN_WORK}`;
 
-/** Injected for every other session: the spoken-delivery rules, and an explicit
-    statement that the session's existing role survives the call. */
+/** The spoken model's whole instruction set for every other session: the
+    spoken-delivery rules, and an explicit statement that the agent it speaks
+    for keeps its own role, authority and tools. */
 export const MODALITY_VOICE_PERSONA = `${MODALITY_IDENTITY}${SPOKEN_DELIVERY}
 ## Work
-${MODALITY_WORK}`;
-
-/** Operator override, resolved once per thread; edits apply when a new thread starts. */
-export const VOICE_PERSONA_FILE = "prompts/voice-persona.md";
-
-export type VoicePersonaBootstrapReceipt = {
-  receiptId: string;
-  itemId: string;
-  insertion: "accepted" | "rejected";
-  diagnostic?: string;
-};
-
-export type VoicePersonaBootstrap = {
-  item: {
-    type: "message";
-    id: string;
-    role: "developer";
-    content: [{ type: "input_text"; text: string }];
-  };
-};
-
-export type VoicePersonaBootstrapIdentity = Pick<VoicePersonaBootstrapReceipt, "receiptId" | "itemId">;
-
-/* Larger than the host's maximum admissible app-server frame, while keeping a
-   transcript with an oversized unrelated row from growing scanner memory. */
-const MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES = 32 * 1024 * 1024;
-/* Responses API item ids accept at most 64 characters. `msg_voice_persona_`
-   consumes 18, leaving 46 hex characters (184 bits) for the stable digest. */
-const VOICE_PERSONA_ID_DIGEST_HEX = 46;
-
-function record(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null;
-}
-
-function isCanonicalVoicePersonaRecord(line: Buffer, itemId: string): boolean {
-  let row: Record<string, unknown> | null = null;
-  try {
-    row = record(JSON.parse(line.toString("utf8")));
-  } catch {
-    return false;
-  }
-  const payload = record(row?.payload);
-  return row?.type === "response_item"
-    && payload?.type === "message"
-    && payload.id === itemId
-    && payload.role === "developer";
-}
+${MODALITY_SPOKEN_WORK}`;
 
 /**
- * The persona text for a starting call.
+ * What the BACKING model is told while a call is live, and what it is told when
+ * the call ends (#1629).
+ *
+ * Native Codex hands its backing model exactly this pair, and the pairing is the
+ * point: the start text is scoped to the session and the end text withdraws it,
+ * so a call leaves the thread's own instructions standing instead of a permanent
+ * layer of spoken-delivery rules. The Viewer used to write that layer into
+ * canonical history with `thread/inject_items`, once per thread, never withdrawn
+ * — which is why a conversation kept answering in two-sentence spoken register
+ * long after the microphone closed.
+ *
+ * FAILS TOWARD THE THREAD'S OWN ROLE. Neither string assigns a role, and the
+ * modality one says so in as many words: it has to outrank a coordinator item a
+ * thread may still carry in its history from a call taken before #1615, and an
+ * append-only transcript cannot have that item withdrawn.
+ */
+const MODALITY_BACKING_WORK = `Realtime voice is active for this conversation. Preserve this conversation's original instructions, role, authority, seat, permissions, tools and ongoing work — voice changes none of them, and nothing here moves your responsibilities to anyone else.
+
+Do the work yourself. You are being spoken to because you are the one holding it. A spoken request is an ordinary request: take it with the authority you already have.
+
+Do not relay your own work with bridge_directive. That tool addresses the project's designated orchestrator, so when you are that orchestrator it hands the instruction back to you and the request goes nowhere. Use it only to reach an orchestrator that is not you.
+
+If an earlier item in this conversation cast you as a relay — that your only job is to speak, that the board belongs to someone else, that the tools you can see are not yours to use — it was written for a session created to be nothing but a voice front. It was not written for you and it does not apply here.
+
+Your answers are spoken aloud while this call is live, so keep them short and plain: no markup, no lists read out, no identifiers or numbers spoken digit by digit. Say the thing that matters and offer to go further.`;
+
+const COORDINATOR_BACKING_WORK = `Realtime voice is active for this conversation, which is the voice front: it speaks to the user and relays the work onward.
+
+Relay with bridge_directive. Pass the current turn id and the index of this instruction within the turn, and the user's intent in plain words. The recipient is resolved for you; you never name it. If a call fails and you retry, reuse the same turn id and index — that is what stops one instruction arriving twice.
+
+When the manager asks something, put the question to the user, then relay their answer with bridge_directive carrying the reference from that report.
+
+A deploy needs the user's spoken yes. The manager sends the exact commit and a one-time authorization; on a yes relay it back with the reference, the nonce and the commit exactly as given. Never invent or reword any of the three.
+
+Your answers are spoken aloud while this call is live, so keep them short and plain: no markup, no lists read out, no identifiers or numbers spoken digit by digit.`;
+
+/** Withdrawn at hangup, so the thread returns to being a text agent. Shared by
+    both variants: neither of them assigned a role, so neither has one to
+    restore — what has to be restored is the output policy. */
+const BACKING_END_WORK = `Realtime voice has ended. Resume this conversation's original instructions, role, authority, permissions, tools, ongoing work and normal text-output policy. The spoken-delivery rules applied only while the call was live; write as you always have.`;
+
+/** Operator override, resolved per call; edits apply to the next call. */
+export const VOICE_PERSONA_FILE = "prompts/voice-persona.md";
+
+/* The digest is an identity, not a secret: 46 hex characters (184 bits) is what
+   the previous canonical item id carried, and the voice panel and its tests
+   still match on that width. */
+const VOICE_PERSONA_ID_DIGEST_HEX = 46;
+
+/**
+ * The SPOKEN model's instruction set for a starting call — the `prompt` of
+ * `thread/realtime/start`, and the only instructions that model ever has.
  *
  * The COORDINATOR variant honours the operator's override file, exactly as it
  * always has. The MODALITY variant does not, and that is the point: an override
@@ -245,11 +265,10 @@ function isCanonicalVoicePersonaRecord(line: Buffer, itemId: string): boolean {
  * reintroduce this defect through the operator's own file. It keeps the
  * built-in text, which assigns nothing.
  *
- * The host invokes this resolver only while the thread has no canonical persona
- * item for the resolved variant, so an established thread keeps its wording and
- * a new one picks up edits.
+ * Resolved per call rather than per thread: the prompt is a session parameter
+ * now, so an edit applies to the next call instead of waiting for a new thread.
  */
-export function voicePersona(
+export function spokenVoicePersona(
   variant: VoicePersonaVariant,
   readFile: (path: string) => string = (target) => fs.readFileSync(target, "utf8"),
 ): string {
@@ -288,144 +307,45 @@ export function resetVoicePersonaOverrideWarningForTest(): void {
 }
 
 /**
- * The bootstrap digest, which the variant is part of.
+ * What a live call carries, resolved once per start (#1629).
  *
- * The COORDINATOR digest is byte-for-byte the one that shipped, so every thread
- * that has already taken a coordinator item is still recognized and takes no
- * second one. The MODALITY digest is deliberately different: the item id is the
- * idempotency receipt, so sharing it would make a thread that was demoted before
- * this fix look already-bootstrapped and leave it demoted for the rest of its
- * life. A distinct id is what lets the correction land.
+ * Three strings and an identity, and no write to the thread anywhere in it. The
+ * `prompt` instructs the spoken model, the two instruction strings frame the
+ * session for the backing model and withdraw that framing at hangup, and
+ * `personaId` is a digest of the exact text sent — evidence of WHICH persona a
+ * live call is running on, which is what the voice panel and the regression
+ * tests need and all they need. It is deliberately not an idempotency receipt:
+ * there is no longer anything durable to be idempotent about.
  */
-function voicePersonaBootstrapDigest(threadId: string, variant: VoicePersonaVariant): string {
-  const digest = createHash("sha256")
-    .update("voice-persona-bootstrap\0", "utf8")
-    .update(threadId, "utf8");
-  if (variant !== "coordinator") digest.update("\0modality", "utf8");
-  return digest.digest("hex");
+export interface VoiceSessionPersona {
+  variant: VoicePersonaVariant;
+  /** Stable digest of the resolved prompt; identical text yields identical id. */
+  personaId: string;
+  /** Instructions for the spoken model. */
+  prompt: string;
+  /** Session-scoped developer instructions for the backing model. */
+  startInstructions: string;
+  /** Withdrawal handed to the backing model when the call ends. */
+  endInstructions: string;
 }
 
-/** Provider-invalid identity emitted before #870, used only to recognize an existing
-    row. Coordinator-only: no thread ever received a modality item under it. */
-export function legacyVoicePersonaBootstrapItemId(threadId: string): string {
-  return `msg_voice_persona_${voicePersonaBootstrapDigest(threadId, "coordinator")}`;
-}
-
-/** Stable canonical identity shared by every WebRTC attempt on one thread at one
-    variant. */
-export function voicePersonaBootstrapIdentity(
-  threadId: string,
-  variant: VoicePersonaVariant,
-): VoicePersonaBootstrapIdentity {
-  const digest = voicePersonaBootstrapDigest(threadId, variant).slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
-  const receiptId = `voice_persona_${digest}`;
-  const itemId = `msg_${receiptId}`;
-  return { receiptId, itemId };
-}
-
-/** Canonical developer item resolved once after its identity is known absent. */
-export function voicePersonaBootstrap(
-  identity: VoicePersonaBootstrapIdentity,
+export function voiceSessionPersona(
   variant: VoicePersonaVariant,
   readFile?: (path: string) => string,
-): VoicePersonaBootstrap {
-  const text = voicePersona(variant, readFile);
+): VoiceSessionPersona {
+  const prompt = spokenVoicePersona(variant, readFile);
+  const digest = createHash("sha256")
+    .update("voice-session-persona\0", "utf8")
+    .update(variant, "utf8")
+    .update("\0", "utf8")
+    .update(prompt, "utf8")
+    .digest("hex")
+    .slice(0, VOICE_PERSONA_ID_DIGEST_HEX);
   return {
-    item: {
-      type: "message",
-      id: identity.itemId,
-      role: "developer",
-      content: [{ type: "input_text", text }],
-    },
+    variant,
+    personaId: `voice_persona_${digest}`,
+    prompt,
+    startInstructions: variant === "coordinator" ? COORDINATOR_BACKING_WORK : MODALITY_BACKING_WORK,
+    endInstructions: BACKING_END_WORK,
   };
-}
-
-/**
- * Check the app-server-owned canonical JSONL without loading a possibly large
- * transcript into memory. A successful inject flushes this item before its RPC
- * response, so finding the stable id is the durable idempotency receipt.
- */
-export async function canonicalVoicePersonaBootstrapExists(
-  transcriptPath: string | null,
-  itemId: string,
-): Promise<boolean> {
-  if (!transcriptPath) {
-    const error = new Error("canonical transcript path is unavailable") as NodeJS.ErrnoException;
-    error.code = "NO_TRANSCRIPT_PATH";
-    throw error;
-  }
-  let handle: fs.promises.FileHandle;
-  try {
-    handle = await fs.promises.open(
-      transcriptPath,
-      fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
-    );
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "ENOTDIR") return false;
-    throw error;
-  }
-  return new Promise<boolean>((resolve, reject) => {
-    const stream = handle.createReadStream({ autoClose: true });
-    let settled = false;
-    let pending: Buffer[] = [];
-    let pendingBytes = 0;
-    let skippingRecord = false;
-    const finish = (found: boolean) => {
-      if (settled) return;
-      settled = true;
-      stream.destroy();
-      resolve(found);
-    };
-    const resetLine = () => {
-      pending = [];
-      pendingBytes = 0;
-      skippingRecord = false;
-    };
-    stream.on("data", (chunk) => {
-      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      let cursor = 0;
-      while (cursor <= bytes.length) {
-        const newline = bytes.indexOf(0x0a, cursor);
-        if (newline === -1) {
-          const rest = bytes.length - cursor;
-          if (!skippingRecord && rest > 0) {
-            if (pendingBytes + rest > MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES) {
-              pending = [];
-              pendingBytes = 0;
-              skippingRecord = true;
-            } else {
-              pending.push(Buffer.from(bytes.subarray(cursor)));
-              pendingBytes += rest;
-            }
-          }
-          return;
-        }
-        if (!skippingRecord) {
-          const segment = bytes.subarray(cursor, newline);
-          if (pendingBytes + segment.length <= MAX_CANONICAL_VOICE_PERSONA_RECORD_BYTES) {
-            const line = pendingBytes
-              ? Buffer.concat([...pending, segment], pendingBytes + segment.length)
-              : segment;
-            if (isCanonicalVoicePersonaRecord(line, itemId)) return finish(true);
-          }
-        }
-        resetLine();
-        cursor = newline + 1;
-      }
-    });
-    stream.on("end", () => {
-      if (!skippingRecord && pendingBytes > 0
-        && isCanonicalVoicePersonaRecord(Buffer.concat(pending, pendingBytes), itemId)) {
-        finish(true);
-        return;
-      }
-      finish(false);
-    });
-    stream.on("error", (error: NodeJS.ErrnoException) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
-    });
-  });
 }

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -140,7 +140,7 @@ Never use the construction "not X, but Y" — say it straight.
  * What the SPOKEN model does for a session created to BE the voice front (#691 §4).
  *
  * The spoken model owns no tool in either variant — a realtime V3 session has
- * none — so this says how to talk about the work, not how to do it. The relay
+ * none — so this says how to talk about the work. Doing it belongs elsewhere: the relay
  * mechanics that used to live here moved to {@link COORDINATOR_BACKING_WORK},
  * where the model that actually holds `bridge_directive` can read them.
  */
@@ -170,7 +170,7 @@ Stay silent until you are spoken to: this text is context, and there is nothing 
  * itself it chats, guesses, and tells the operator it has no tools.
  */
 const MODALITY_SPOKEN_WORK = `
-You are the voice of the agent in this conversation. It is not a helper standing behind you; it is who you are speaking as, and it already has its own instructions, its own authority and its own tools.
+You are the voice of the agent in this conversation. You speak as it. It already has its own instructions, its own authority and its own tools, and all of that stands while you speak.
 
 So do not answer from your own knowledge and do not decide anything on your own. Every request, correction and question the user speaks goes to that agent, and what you say aloud is what came back.
 
@@ -249,7 +249,7 @@ const BACKING_END_WORK = `Realtime voice has ended. Resume this conversation's o
 /** Operator override, resolved per call; edits apply to the next call. */
 export const VOICE_PERSONA_FILE = "prompts/voice-persona.md";
 
-/* The digest is an identity, not a secret: 46 hex characters (184 bits) is what
+/* The digest is an identity and carries nothing secret. 46 hex characters (184 bits) is what
    the previous canonical item id carried, and the voice panel and its tests
    still match on that width. */
 const VOICE_PERSONA_ID_DIGEST_HEX = 46;

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -220,6 +220,16 @@ ${MODALITY_SPOKEN_WORK}`;
  * modality one says so in as many words: it has to outrank a coordinator item a
  * thread may still carry in its history from a call taken before #1615, and an
  * append-only transcript cannot have that item withdrawn.
+ *
+ * AND IT ADDS NO PROCEDURE. A conversation that already has a role has its own
+ * rules about how work is accepted and how a deploy is decided — the Viewer's
+ * own manager mandate, for one, states that nobody ever asks the operator to
+ * confirm, approve or repeat anything. The modality text therefore carries no
+ * approval step, no confirmation step and no deploy gate; the relay procedure in
+ * {@link COORDINATOR_BACKING_WORK} belongs to a session created to be nothing
+ * but a voice front, which by construction has no mandate of its own to
+ * contradict. {@link voicePersonaVariantFor} is the only thing that chooses
+ * between them, and it fails toward modality.
  */
 const MODALITY_BACKING_WORK = `Realtime voice is active for this conversation. Preserve this conversation's original instructions, role, authority, seat, permissions, tools and ongoing work — voice changes none of them, and nothing here moves your responsibilities to anyone else.
 

--- a/src/lib/runtime/voicePersonaRole.test.ts
+++ b/src/lib/runtime/voicePersonaRole.test.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import { expect, test } from "bun:test";
 
 import { executeRealtimeControl } from "./realtimeControl";
@@ -8,9 +6,8 @@ import {
   MODALITY_VOICE_PERSONA,
   resetVoicePersonaOverrideWarningForTest,
   VOICE_PERSONA_FILE,
-  voicePersona,
-  voicePersonaBootstrap,
-  voicePersonaBootstrapIdentity,
+  spokenVoicePersona,
+  voiceSessionPersona,
 } from "./voicePersona";
 import { voicePersonaVariantFor } from "./voicePersonaMandate";
 
@@ -82,48 +79,73 @@ test("an unresolvable conversation fails safe to the modality persona", () => {
 });
 
 /* ------------------------------------------------------------------ *
- * 2. What the modality persona may and may not say.
+ * 2. What the SPOKEN persona may and may not say.
  * ------------------------------------------------------------------ */
 
-/** The three sentences that demoted the seat, as the properties they assert. */
-const ROLE_REPLACEMENTS: { label: string; pattern: RegExp }[] = [
+/** The sentences that demoted the seat, as the properties they assert. They now
+    live in two places — what the spoken model is told, and what the backing
+    model is told — so each is checked against the text it belongs to. */
+const SPOKEN_ROLE_REPLACEMENTS: { label: string; pattern: RegExp }[] = [
   { label: "declares a replacement identity", pattern: /you are the voice coordinator/i },
-  { label: "hands the work to a separate manager", pattern: /there is a manager for that/i },
-  { label: "strips the session's own tools", pattern: /you have no tools for spawning agents/i },
-  { label: "mandates relaying instead of acting", pattern: /relay (?:what the user wants|with bridge_directive)/i },
   { label: "forbids touching the board", pattern: /you do not touch the board yourself/i },
 ];
 
-test("the modality persona replaces no part of an existing role", () => {
-  const offences = ROLE_REPLACEMENTS
+const BACKING_ROLE_REPLACEMENTS: { label: string; pattern: RegExp }[] = [
+  { label: "casts the session as the voice front", pattern: /which is the voice front/i },
+  { label: "mandates relaying instead of acting", pattern: /relay with bridge_directive/i },
+];
+
+test("the modality spoken persona replaces no part of an existing role", () => {
+  const offences = SPOKEN_ROLE_REPLACEMENTS
     .filter(({ pattern }) => pattern.test(MODALITY_VOICE_PERSONA))
     .map(({ label }) => label);
   expect(offences).toEqual([]);
 });
 
-test("the modality persona says outright that the role and its pending work stand", () => {
-  /* Not decoration. The thread may ALREADY carry the coordinator item from a call
-     taken before this fix, and this is the only text that outranks it. */
-  expect(MODALITY_VOICE_PERSONA).toMatch(/voice (?:is|changes) (?:only )?how/i);
-  expect(MODALITY_VOICE_PERSONA).toMatch(/role/i);
-  expect(MODALITY_VOICE_PERSONA).toMatch(/pending work/i);
+test("the modality backing instructions replace no part of an existing role", () => {
+  const backing = voiceSessionPersona("modality").startInstructions;
+  const offences = BACKING_ROLE_REPLACEMENTS
+    .filter(({ pattern }) => pattern.test(backing))
+    .map(({ label }) => label);
+  expect(offences).toEqual([]);
 });
 
-test("the modality persona keeps the spoken-delivery rules the call needs", () => {
-  /* The reason a persona is injected at all: a thread's instructions are written
-     for a reader, and every one of these fails out loud. Dropping them would trade
-     one defect for another. */
-  for (const rule of [/## Language/, /## Voice/, /## Honesty/]) {
-    expect(MODALITY_VOICE_PERSONA).toMatch(rule);
-  }
-  expect(MODALITY_VOICE_PERSONA).toMatch(/never speak numbers or identifiers aloud/i);
+test("the modality backing instructions say outright that the role and its work stand", () => {
+  /* Not decoration. The thread may ALREADY carry the coordinator item in its
+     append-only history from a call taken before #1615, and this is the only text
+     that outranks it — now delivered per session rather than written beside it. */
+  const backing = voiceSessionPersona("modality").startInstructions;
+  expect(backing).toMatch(/preserve this conversation's original instructions/i);
+  expect(backing).toMatch(/\btools\b/);
+  expect(backing).toMatch(/ongoing work/i);
+  expect(backing).toMatch(/it was not written for you/i);
 });
 
-test("the modality persona tells an incumbent manager not to relay its own work", () => {
+test("the modality backing instructions tell an incumbent manager not to relay its own work", () => {
   /* The observed loop, closed in the text as well as in the tool: a seat told to
      relay sends the instruction to the seat, which is itself. */
-  expect(MODALITY_VOICE_PERSONA).toMatch(/yourself/i);
-  expect(MODALITY_VOICE_PERSONA).toMatch(/bridge_directive/);
+  const backing = voiceSessionPersona("modality").startInstructions;
+  expect(backing).toMatch(/do the work yourself/i);
+  expect(backing).toMatch(/bridge_directive/);
+});
+
+test("the modality spoken persona forbids the spoken model claiming it has no tools", () => {
+  /* The reported symptom, stated as a rule. The spoken model genuinely holds no
+     tool — a realtime session has none — so left to Codex's stock persona it
+     answers for itself and reports that it cannot reach anything. */
+  expect(MODALITY_VOICE_PERSONA).toMatch(/never say that you have no tools/i);
+  expect(MODALITY_VOICE_PERSONA).toMatch(/do not answer from your own knowledge/i);
+});
+
+test("both spoken personas keep the spoken-delivery rules the call needs", () => {
+  /* The reason a persona is sent at all: a thread's instructions are written for
+     a reader, and every one of these fails out loud. */
+  for (const persona of [MODALITY_VOICE_PERSONA, COORDINATOR_VOICE_PERSONA]) {
+    for (const rule of [/## Language/, /## Voice/, /## Honesty/]) {
+      expect(persona).toMatch(rule);
+    }
+    expect(persona).toMatch(/never speak numbers or identifiers aloud/i);
+  }
 });
 
 /* ------------------------------------------------------------------ *
@@ -131,15 +153,19 @@ test("the modality persona tells an incumbent manager not to relay its own work"
  * ------------------------------------------------------------------ */
 
 test("the coordinator persona still carries the relay mandate it was written for", () => {
-  for (const { pattern } of ROLE_REPLACEMENTS) {
+  for (const { pattern } of SPOKEN_ROLE_REPLACEMENTS) {
     expect(COORDINATOR_VOICE_PERSONA).toMatch(pattern);
+  }
+  const backing = voiceSessionPersona("coordinator").startInstructions;
+  for (const { pattern } of BACKING_ROLE_REPLACEMENTS) {
+    expect(backing).toMatch(pattern);
   }
 });
 
-test("voicePersona resolves the variant it is asked for", () => {
+test("spokenVoicePersona resolves the variant it is asked for", () => {
   const nothingOnDisk = () => { throw new Error("ENOENT"); };
-  expect(voicePersona("coordinator", nothingOnDisk)).toBe(COORDINATOR_VOICE_PERSONA);
-  expect(voicePersona("modality", nothingOnDisk)).toBe(MODALITY_VOICE_PERSONA);
+  expect(spokenVoicePersona("coordinator", nothingOnDisk)).toBe(COORDINATOR_VOICE_PERSONA);
+  expect(spokenVoicePersona("modality", nothingOnDisk)).toBe(MODALITY_VOICE_PERSONA);
 });
 
 test("an ignored override is reported once, so the operator can find out why", () => {
@@ -152,17 +178,17 @@ test("an ignored override is reported once, so the operator can find out why", (
   const warn = console.warn;
   console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
   try {
-    expect(voicePersona("modality", () => "An operator's own persona.")).toBe(MODALITY_VOICE_PERSONA);
-    expect(voicePersona("modality", () => "An operator's own persona.")).toBe(MODALITY_VOICE_PERSONA);
-    /* Once per process: this resolves on every bootstrap. */
+    expect(spokenVoicePersona("modality", () => "An operator's own persona.")).toBe(MODALITY_VOICE_PERSONA);
+    expect(spokenVoicePersona("modality", () => "An operator's own persona.")).toBe(MODALITY_VOICE_PERSONA);
+    /* Once per process: this resolves on every call start. */
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain(VOICE_PERSONA_FILE);
 
     /* And nothing at all when there is no override to ignore. */
     resetVoicePersonaOverrideWarningForTest();
     warnings.length = 0;
-    expect(voicePersona("modality", () => { throw new Error("ENOENT"); })).toBe(MODALITY_VOICE_PERSONA);
-    expect(voicePersona("modality", () => "   \n ")).toBe(MODALITY_VOICE_PERSONA);
+    expect(spokenVoicePersona("modality", () => { throw new Error("ENOENT"); })).toBe(MODALITY_VOICE_PERSONA);
+    expect(spokenVoicePersona("modality", () => "   \n ")).toBe(MODALITY_VOICE_PERSONA);
     expect(warnings).toEqual([]);
   } finally {
     console.warn = warn;
@@ -175,60 +201,61 @@ test("an operator persona override applies to the coordinator only", () => {
      by construction. Applying it to an incumbent would reintroduce this very
      defect through the operator's own file, so the modality variant is built-in. */
   const override = () => "You are the voice coordinator. Relay everything.";
-  expect(voicePersona("coordinator", override)).toBe("You are the voice coordinator. Relay everything.");
-  expect(voicePersona("modality", override)).toBe(MODALITY_VOICE_PERSONA);
+  expect(spokenVoicePersona("coordinator", override)).toBe("You are the voice coordinator. Relay everything.");
+  expect(spokenVoicePersona("modality", override)).toBe(MODALITY_VOICE_PERSONA);
 });
 
 /* ------------------------------------------------------------------ *
- * 4. Identity: a demoted thread can still be corrected.
+ * 4. Identity: which persona a live call is running on.
  * ------------------------------------------------------------------ */
 
-test("each variant owns a distinct bootstrap item id on the same thread", () => {
-  /* The item id is the idempotency receipt. Were it shared, a thread that already
-     took the coordinator item would be seen as bootstrapped and could never be
-     told otherwise — the demotion would outlive the fix for the thread's life. */
-  const coordinator = voicePersonaBootstrapIdentity("thread-1", "coordinator");
-  const modality = voicePersonaBootstrapIdentity("thread-1", "modality");
-  expect(modality.itemId).not.toBe(coordinator.itemId);
-  for (const identity of [coordinator, modality]) {
-    /* The provider's 64-character ceiling (#870) binds both variants. */
-    expect(identity.receiptId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
-    expect(identity.itemId).toBe(`msg_${identity.receiptId}`);
-    expect(identity.itemId.length).toBeLessThanOrEqual(64);
+test("each variant owns a distinct persona identity", () => {
+  const coordinator = voiceSessionPersona("coordinator");
+  const modality = voiceSessionPersona("modality");
+  expect(modality.personaId).not.toBe(coordinator.personaId);
+  for (const persona of [coordinator, modality]) {
+    expect(persona.personaId).toMatch(/^voice_persona_[a-f0-9]{46}$/);
   }
 });
 
-test("the coordinator identity is unchanged, so established root threads take no second item", () => {
-  /* The pre-fix digest, recomputed here from the formula that shipped rather than
-     pasted as a literal. A new id would inject a duplicate persona into every
-     thread that has ever hosted a coordinator call. */
-  const legacyDigest = createHash("sha256")
-    .update("voice-persona-bootstrap\0", "utf8")
-    .update("thread-1", "utf8")
-    .digest("hex")
-    .slice(0, 46);
-  expect(voicePersonaBootstrapIdentity("thread-1", "coordinator")).toEqual({
-    receiptId: `voice_persona_${legacyDigest}`,
-    itemId: `msg_voice_persona_${legacyDigest}`,
-  });
+test("the persona identity follows the text, so an override is visible as a different call", () => {
+  /* The id is evidence of WHICH persona a live call is running on. An override
+     that changed the spoken instructions while reporting the built-in identity
+     would make the voice panel and every regression assertion agree about a
+     persona the call is not using. */
+  const builtIn = voiceSessionPersona("coordinator", () => { throw new Error("ENOENT"); });
+  const overridden = voiceSessionPersona("coordinator", () => "An operator's own persona.");
+  expect(overridden.personaId).not.toBe(builtIn.personaId);
+  expect(overridden.prompt).toBe("An operator's own persona.");
 });
 
-test("the injected item carries the resolved variant's text", () => {
-  const identity = voicePersonaBootstrapIdentity("thread-1", "modality");
-  const bootstrap = voicePersonaBootstrap(identity, "modality", () => { throw new Error("ENOENT"); });
-  expect(bootstrap.item.role).toBe("developer");
-  expect(bootstrap.item.id).toBe(identity.itemId);
-  expect(bootstrap.item.content[0].text).toBe(MODALITY_VOICE_PERSONA);
+test("a session persona carries the spoken prompt and the backing pair, and nothing thread-durable", () => {
+  /* The whole repair, as a shape: three session-scoped strings. Before this,
+     the persona was a `thread/inject_items` write that reached the backing model
+     permanently and the spoken model never. */
+  const persona = voiceSessionPersona("modality", () => { throw new Error("ENOENT"); });
+  expect(persona.prompt).toBe(MODALITY_VOICE_PERSONA);
+  expect(persona.startInstructions).toMatch(/realtime voice is active/i);
+  expect(persona.endInstructions).toMatch(/realtime voice has ended/i);
+  expect(persona.endInstructions).toMatch(/normal text-output policy/i);
+  expect(Object.keys(persona).sort()).toEqual([
+    "endInstructions", "personaId", "prompt", "startInstructions", "variant",
+  ]);
+});
+
+test("the end instructions withdraw the spoken register the start instructions imposed", () => {
+  /* The pairing is what keeps a text agent from inheriting spoken-delivery rules
+     for the rest of its life, which is what a permanent injected item did. */
+  for (const variant of ["modality", "coordinator"] as const) {
+    const persona = voiceSessionPersona(variant);
+    expect(persona.startInstructions).toMatch(/spoken aloud while this call is live/i);
+    expect(persona.endInstructions).toMatch(/only while the call was live/i);
+  }
 });
 
 /* ------------------------------------------------------------------ *
  * 5. On, off, and back on again.
  * ------------------------------------------------------------------ */
-
-function personaBootstrapReceipt(variant: "coordinator" | "modality") {
-  const identity = voicePersonaBootstrapIdentity("thread-live", variant);
-  return { ...identity, insertion: "accepted" as const };
-}
 
 /** A host that records the persona variant every start was asked for. */
 function recordingHost(variant: "coordinator" | "modality") {
@@ -240,11 +267,8 @@ function recordingHost(variant: "coordinator" | "modality") {
       async startRealtimeWebRtc(sdp: string, persona?: unknown) {
         starts.push(persona);
         live = "live-1";
-        return {
-          sdp: "v=0\r\nanswer",
-          realtimeSessionId: live,
-          personaBootstrap: personaBootstrapReceipt(variant),
-        };
+        const { variant: resolved, personaId } = voiceSessionPersona(variant);
+        return { sdp: "v=0\r\nanswer", realtimeSessionId: live, persona: { variant: resolved, personaId } };
       },
       async appendRealtimeSpeech() {},
       async stopRealtime() { live = null; },

--- a/src/lib/runtime/voicePersonaRole.test.ts
+++ b/src/lib/runtime/voicePersonaRole.test.ts
@@ -324,3 +324,27 @@ test("a start that asks no persona question gets the modality persona", async ()
   expect(started.status).toBe(200);
   expect(starts).toEqual(["modality"]);
 });
+
+
+test("the modality instructions add no procedure to a conversation that has its own", () => {
+  /* An incumbent orchestrator arrives with a mandate that already says how work
+     is accepted and how a deploy is decided — the Viewer's own manager mandate
+     states that nobody ever asks the operator to confirm, approve or repeat
+     anything. A voice call that quietly added a confirmation step would put the
+     seat in the position of contradicting its own instructions out loud, which
+     is the same class of harm as taking its tools away. */
+  const persona = voiceSessionPersona("modality");
+  /* The shapes that IMPOSE a step. "permissions" survives on its own, because
+     the modality text names it only to say it is preserved. */
+  for (const procedure of [
+    /\bconfirm\b/i, /\bapprove\b/i, /\bapproval\b/i, /spoken yes/i,
+    /ask the (?:user|operator)/i, /needs the (?:user|operator)/i,
+    /\bauthoriz/i, /\bnonce\b/i, /commit (?:hash|exactly)/i, /wait for the (?:user|operator)/i,
+  ]) {
+    expect(persona.startInstructions).not.toMatch(procedure);
+    expect(persona.endInstructions).not.toMatch(procedure);
+  }
+  /* And the deploy relay stays where it was written for: a session created to be
+     nothing but a voice front, which has no mandate of its own to contradict. */
+  expect(voiceSessionPersona("coordinator").startInstructions).toMatch(/spoken yes/i);
+});

--- a/src/lib/runtime/voiceViewBinding.test.ts
+++ b/src/lib/runtime/voiceViewBinding.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, test } from "bun:test";
 
+import { SELECTED_CONTEXT_MAX_AGE_MS } from "@/lib/realtime/selectedContextBinding";
 import { captureSelectedContext, type SelectedContextRef } from "@/lib/selection/selectedContext";
 
 import {
@@ -9,6 +10,7 @@ import {
   releaseVoiceSession,
   resetVoiceViewBindings,
   voiceSelectedContext,
+  voiceUtteranceContext,
 } from "./voiceViewBinding";
 
 /**
@@ -251,7 +253,7 @@ test("a handoff completes the standing admission without minting an utterance", 
   });
   const recorded = recordVoiceHandoff({
     conversationId: CONVERSATION, realtimeSessionId: "rt-1",
-    utteranceId: utterance(1).id, handoff: HANDOFF,
+    utterance: utterance(1), handoff: HANDOFF,
   });
   expect(recorded.ok).toBe(true);
   /* The reference and the boundary counter are untouched: this reports what the
@@ -277,7 +279,7 @@ test("a handoff for an utterance the call has moved past is dropped", () => {
   });
   const late = recordVoiceHandoff({
     conversationId: CONVERSATION, realtimeSessionId: "rt-1",
-    utteranceId: utterance(1).id, handoff: HANDOFF,
+    utterance: utterance(1), handoff: HANDOFF,
   });
   expect(late.ok).toBe(false);
   expect(late.ok || late.failure.code).toBe("superseded");
@@ -292,9 +294,106 @@ test("a handoff presented with another call's session id is refused", () => {
   });
   const impostor = recordVoiceHandoff({
     conversationId: CONVERSATION, realtimeSessionId: "rt-2",
-    utteranceId: utterance(1).id, handoff: HANDOFF,
+    utterance: utterance(1), handoff: HANDOFF,
   });
   expect(impostor.ok).toBe(false);
   expect(impostor.ok || impostor.failure.code).toBe("unbound");
   expect(voiceSelectedContext(CONVERSATION)?.handoff).toBeNull();
+});
+
+
+/* ------------------------------------------------------------------ *
+ * After the hangup: what the work the call started may still read.
+ * ------------------------------------------------------------------ */
+
+test("an accepted join survives the hangup, because the work it started does", () => {
+  /* The operator asks for something, hangs up, and the agent is still working
+     when it reaches for the card they were pointing at. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  const ref = reference(DESK, "conversation_atlas_a", NOW, 1);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: ref, utterance: utterance(1), now: NOW,
+  });
+  recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    utterance: utterance(1), handoff: HANDOFF,
+  });
+  releaseVoiceSession(CONVERSATION, NOW + 1_000);
+
+  const retained = voiceUtteranceContext(CONVERSATION, NOW + 2_000);
+  expect(retained.state).toBe("joined");
+  expect(retained.state === "joined" && retained.reference).toEqual(ref);
+  /* And it says what it is, so a reader can tell live context from a legacy. */
+  expect(retained.state === "joined" && retained.callEnded).toBe(true);
+});
+
+test("a hangup with no accepted join leaves nothing behind", () => {
+  /* An utterance that never became work has nothing running that could need it,
+     and keeping its card would leave one standing for a later turn to pick up. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK), utterance: utterance(1), now: NOW,
+  });
+  releaseVoiceSession(CONVERSATION, NOW + 1_000);
+  expect(voiceUtteranceContext(CONVERSATION, NOW + 2_000)).toEqual({ state: "no-call" });
+  expect(voiceSelectedContext(CONVERSATION)).toBeNull();
+});
+
+test("what a finished call left ages out of the window a capture may steer from", () => {
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_a", NOW, 1), utterance: utterance(1), now: NOW,
+  });
+  recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    utterance: utterance(1), handoff: HANDOFF,
+  });
+  releaseVoiceSession(CONVERSATION, NOW + 1_000);
+
+  expect(voiceUtteranceContext(CONVERSATION, NOW + SELECTED_CONTEXT_MAX_AGE_MS - 1).state).toBe("joined");
+  expect(voiceUtteranceContext(CONVERSATION, NOW + SELECTED_CONTEXT_MAX_AGE_MS + 1)).toEqual({ state: "no-call" });
+});
+
+test("a hung-up call admits nothing further", () => {
+  /* The transport is gone, so there is no window speaking for it. What it left
+     is a record of work already started, never a channel still open. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_a", NOW, 1), utterance: utterance(1), now: NOW,
+  });
+  recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    utterance: utterance(1), handoff: HANDOFF,
+  });
+  releaseVoiceSession(CONVERSATION, NOW + 1_000);
+
+  const later = admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_b", NOW + 2_000, 2), utterance: utterance(2), now: NOW + 2_000,
+  });
+  expect(later.ok).toBe(false);
+  expect(later.ok || later.failure.code).toBe("unbound");
+  const standing = voiceUtteranceContext(CONVERSATION, NOW + 2_000);
+  expect(standing.state === "joined" && standing.reference.state === "selected"
+    && standing.reference.conversationId).toBe("conversation_atlas_a");
+});
+
+test("a new call replaces what the last one left", () => {
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_a", NOW, 1), utterance: utterance(1), now: NOW,
+  });
+  recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    utterance: utterance(1), handoff: HANDOFF,
+  });
+  releaseVoiceSession(CONVERSATION, NOW + 1_000);
+
+  bindVoiceSession(CONVERSATION, "rt-2", DESK);
+  expect(voiceUtteranceContext(CONVERSATION, NOW + 2_000)).toEqual({ state: "no-reference" });
 });

--- a/src/lib/runtime/voiceViewBinding.test.ts
+++ b/src/lib/runtime/voiceViewBinding.test.ts
@@ -5,6 +5,7 @@ import { captureSelectedContext, type SelectedContextRef } from "@/lib/selection
 import {
   admitVoiceSelectedContext,
   bindVoiceSession,
+  recordVoiceHandoff,
   releaseVoiceSession,
   resetVoiceViewBindings,
   voiceSelectedContext,
@@ -232,4 +233,68 @@ test("a new call starts its own utterance ledger", () => {
   });
   expect(admitted.ok).toBe(true);
   expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(first);
+});
+
+
+/* ------------------------------------------------------------------ *
+ * The join: what was on screen, what was said, what was handed off.
+ * ------------------------------------------------------------------ */
+
+const HANDOFF = { handoffId: "handoff-1", itemId: "item-1", userBidiTurnId: "bidi-1" };
+
+test("a handoff completes the standing admission without minting an utterance", () => {
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  const ref = reference(DESK, "conversation_atlas_a", NOW, 1);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: ref, utterance: utterance(1), now: NOW,
+  });
+  const recorded = recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    utteranceId: utterance(1).id, handoff: HANDOFF,
+  });
+  expect(recorded.ok).toBe(true);
+  /* The reference and the boundary counter are untouched: this reports what the
+     utterance became, it does not claim a new one happened. */
+  expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(ref);
+  expect(voiceSelectedContext(CONVERSATION)?.sequence).toBe(1);
+  expect(voiceSelectedContext(CONVERSATION)?.handoff).toEqual(HANDOFF);
+});
+
+test("a handoff for an utterance the call has moved past is dropped", () => {
+  /* Handoff events are asynchronous like everything else on this leg. One that
+     names a superseded utterance must not reopen it and attach itself to the
+     reference that replaced it — that would join the operator's newest card to
+     an older spoken turn's work. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_a", NOW, 1), utterance: utterance(1), now: NOW,
+  });
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_b", NOW + 1_000, 2), utterance: utterance(2), now: NOW + 1_000,
+  });
+  const late = recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    utteranceId: utterance(1).id, handoff: HANDOFF,
+  });
+  expect(late.ok).toBe(false);
+  expect(late.ok || late.failure.code).toBe("superseded");
+  expect(voiceSelectedContext(CONVERSATION)?.handoff).toBeNull();
+});
+
+test("a handoff presented with another call's session id is refused", () => {
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK), utterance: utterance(1), now: NOW,
+  });
+  const impostor = recordVoiceHandoff({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-2",
+    utteranceId: utterance(1).id, handoff: HANDOFF,
+  });
+  expect(impostor.ok).toBe(false);
+  expect(impostor.ok || impostor.failure.code).toBe("unbound");
+  expect(voiceSelectedContext(CONVERSATION)?.handoff).toBeNull();
 });

--- a/src/lib/runtime/voiceViewBinding.test.ts
+++ b/src/lib/runtime/voiceViewBinding.test.ts
@@ -24,15 +24,25 @@ const DESK = { viewSessionId: "vs-desk-1", deviceId: "dev-desk" };
 const PHONE = { viewSessionId: "vs-phone-1", deviceId: "dev-phone" };
 const CONVERSATION = "conversation_orchestrator";
 
-function reference(identity: { viewSessionId: string; deviceId: string }, card = "conversation_atlas_a", now = NOW): SelectedContextRef {
+function reference(
+  identity: { viewSessionId: string; deviceId: string },
+  card = "conversation_atlas_a",
+  now = NOW,
+  revision = 1,
+): SelectedContextRef {
   return captureSelectedContext({
     context: { project: "atlas" },
     slice: { focusedPath: "fixtures/projects/atlas/worker-a.jsonl", selectedPaths: [] },
     cards: [{ path: "fixtures/projects/atlas/worker-a.jsonl", conversationId: card, label: "Worker A" }],
     identity,
-    revision: 1,
+    revision,
     now,
   });
+}
+
+/** One utterance's identity, as the browser mints it. */
+function utterance(sequence: number, id = `${sequence}`.padStart(32, "f")): { id: string; sequence: number } {
+  return { id, sequence };
 }
 
 beforeEach(() => resetVoiceViewBindings());
@@ -116,4 +126,110 @@ test("rebinding the same conversation to a new call drops the previous admission
   expect(voiceSelectedContext(CONVERSATION)).toBeNull();
   const admitted = admitVoiceSelectedContext({ conversationId: CONVERSATION, realtimeSessionId: "rt-2", reference: reference(PHONE), now: NOW });
   expect(admitted.ok).toBe(true);
+});
+
+
+/* ------------------------------------------------------------------ *
+ * Ordering: publishing is asynchronous, retried, and out of order (#1629).
+ * ------------------------------------------------------------------ */
+
+test("a late publication for an earlier utterance cannot replace a newer one", () => {
+  /* The reproduced defect. Both publications are the bound window's and both
+     pass the freshness window, so nothing in the binding check can separate
+     them — the ledger used to take whichever arrived last, and a slow POST for
+     the previous utterance dragged the call back to the previous card. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  const older = reference(DESK, "conversation_atlas_a", NOW, 1);
+  const newer = reference(DESK, "conversation_atlas_b", NOW + 1_000, 2);
+
+  expect(admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: newer, utterance: utterance(2), now: NOW + 1_000,
+  }).ok).toBe(true);
+
+  const late = admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: older, utterance: utterance(1), now: NOW + 1_200,
+  });
+  expect(late.ok).toBe(false);
+  expect(late.ok || late.failure.code).toBe("superseded");
+
+  /* A refusal changes nothing: the newer reference still stands, and the
+     boundary counter still says two utterances have been published for. */
+  expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(newer);
+  expect(voiceSelectedContext(CONVERSATION)?.sequence).toBe(1);
+});
+
+test("without an utterance identity the reference's own revision decides", () => {
+  /* A client that carries no utterance identity still cannot go backwards:
+     `revision` is monotonic within a view session, and a call is bound to
+     exactly one. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  const newer = reference(DESK, "conversation_atlas_b", NOW + 1_000, 7);
+  const older = reference(DESK, "conversation_atlas_a", NOW, 3);
+  admitVoiceSelectedContext({ conversationId: CONVERSATION, realtimeSessionId: "rt-1", reference: newer, now: NOW + 1_000 });
+  const late = admitVoiceSelectedContext({ conversationId: CONVERSATION, realtimeSessionId: "rt-1", reference: older, now: NOW + 1_200 });
+  expect(late.ok).toBe(false);
+  expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(newer);
+});
+
+test("a retried publication is the same utterance, not a second one", () => {
+  /* The publish path is fire-and-forget with one retry, so a POST that timed
+     out on the client and succeeded on the server arrives twice. Counting that
+     as two utterances would make the boundary sequence describe the network. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  const ref = reference(DESK, "conversation_atlas_a", NOW, 4);
+  const first = admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: ref, utterance: utterance(1), now: NOW,
+  });
+  const replay = admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: ref, utterance: utterance(1), now: NOW + 50,
+  });
+  expect(first.ok && replay.ok).toBe(true);
+  if (!first.ok || !replay.ok) throw new Error("both admissions were expected to succeed");
+  expect(replay.admission).toEqual(first.admission);
+  expect(voiceSelectedContext(CONVERSATION)?.sequence).toBe(1);
+});
+
+test("a later utterance still admits after a refused earlier one", () => {
+  /* The refusal is about ordering, not about the window: the call keeps
+     working, and the next thing the operator says lands normally. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_b", NOW + 1_000, 2), utterance: utterance(2), now: NOW + 1_000,
+  });
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_a", NOW, 1), utterance: utterance(1), now: NOW + 1_200,
+  });
+  const third = reference(DESK, "conversation_atlas_c", NOW + 2_000, 3);
+  const admitted = admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: third, utterance: utterance(3), now: NOW + 2_000,
+  });
+  expect(admitted.ok).toBe(true);
+  expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(third);
+  expect(voiceSelectedContext(CONVERSATION)?.sequence).toBe(2);
+});
+
+test("a new call starts its own utterance ledger", () => {
+  /* Rebinding is a new call. If the previous call's utterance sequence carried
+     over, the first utterance of the new one would be refused as superseded by
+     the last of the old one. */
+  bindVoiceSession(CONVERSATION, "rt-1", DESK);
+  admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-1",
+    reference: reference(DESK, "conversation_atlas_b", NOW, 9), utterance: utterance(9), now: NOW,
+  });
+  bindVoiceSession(CONVERSATION, "rt-2", DESK);
+  const first = reference(DESK, "conversation_atlas_a", NOW + 1_000, 1);
+  const admitted = admitVoiceSelectedContext({
+    conversationId: CONVERSATION, realtimeSessionId: "rt-2",
+    reference: first, utterance: utterance(1), now: NOW + 1_000,
+  });
+  expect(admitted.ok).toBe(true);
+  expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(first);
 });

--- a/src/lib/runtime/voiceViewBinding.test.ts
+++ b/src/lib/runtime/voiceViewBinding.test.ts
@@ -174,7 +174,7 @@ test("without an utterance identity the reference's own revision decides", () =>
   expect(voiceSelectedContext(CONVERSATION)?.reference).toEqual(newer);
 });
 
-test("a retried publication is the same utterance, not a second one", () => {
+test("a retried publication stays one utterance", () => {
   /* The publish path is fire-and-forget with one retry, so a POST that timed
      out on the client and succeeded on the server arrives twice. Counting that
      as two utterances would make the boundary sequence describe the network. */
@@ -195,7 +195,7 @@ test("a retried publication is the same utterance, not a second one", () => {
 });
 
 test("a later utterance still admits after a refused earlier one", () => {
-  /* The refusal is about ordering, not about the window: the call keeps
+  /* The refusal is about ordering alone — the window is still the bound one, so the call keeps
      working, and the next thing the operator says lands normally. */
   bindVoiceSession(CONVERSATION, "rt-1", DESK);
   admitVoiceSelectedContext({

--- a/src/lib/runtime/voiceViewBinding.ts
+++ b/src/lib/runtime/voiceViewBinding.ts
@@ -1,5 +1,6 @@
 import {
   bindSelectedContextToVoiceSession,
+  SELECTED_CONTEXT_MAX_AGE_MS,
   type SelectedContextBindingFailure,
   type VoiceViewBinding,
 } from "@/lib/realtime/selectedContextBinding";
@@ -86,6 +87,8 @@ interface VoiceSessionState {
   sequence: number;
   /** The utterance sequence the standing admission was published for. */
   utteranceSequence: number | null;
+  /** Set when the call ended while a joined admission was still standing. */
+  endedAt: number | null;
 }
 
 const store = globalThis as typeof globalThis & {
@@ -117,12 +120,34 @@ export function parseVoiceViewBinding(value: unknown): VoiceViewBinding | null {
     call: the previous admission is dropped rather than inherited. */
 export function bindVoiceSession(conversationId: string, realtimeSessionId: string, binding: VoiceViewBinding | null): void {
   sessions.set(conversationId, {
-    realtimeSessionId, binding, admission: null, sequence: 0, utteranceSequence: null,
+    realtimeSessionId, binding, admission: null, sequence: 0, utteranceSequence: null, endedAt: null,
   });
 }
 
-export function releaseVoiceSession(conversationId: string): void {
-  sessions.delete(conversationId);
+/**
+ * Hang up, and keep only what the work still running may legitimately need.
+ *
+ * A turn started by the last thing the operator said outlives the transport that
+ * carried it: they ask for something, hang up, and the agent is still working
+ * when it reaches for the card they were pointing at. Dropping the whole ledger
+ * at `stop` threw that away, so the tool answered "you have no call" to work the
+ * call itself started.
+ *
+ * ONLY AN ACCEPTED JOIN SURVIVES. A reference with no handoff describes an
+ * utterance that never became work, so nothing is running that could need it,
+ * and keeping it would leave a card standing for a later turn to pick up. What
+ * is kept expires with the reference's own freshness window — the same bound
+ * that governs how long a capture may steer a turn at all — and a new call
+ * replaces it outright.
+ */
+export function releaseVoiceSession(conversationId: string, now = Date.now()): void {
+  const session = sessions.get(conversationId);
+  if (!session?.admission?.handoff) {
+    sessions.delete(conversationId);
+    return;
+  }
+  session.binding = null;
+  session.endedAt = now;
 }
 
 /**
@@ -241,16 +266,22 @@ export function admitVoiceSelectedContext(input: VoiceSelectedContextAdmissionIn
 /**
  * Record which handoff an already-admitted utterance became.
  *
- * Deliberately not an admission: it mints no utterance, moves no counter and
- * replaces no reference. It only completes the record of one that already
- * exists, so a handoff reported for an utterance the ledger has moved past — a
- * late event, or one belonging to a superseded publication — is dropped rather
- * than allowed to reopen it.
+ * It mints no utterance, moves no counter and replaces no reference: it only
+ * completes the record of one that already exists, so a handoff reported for an
+ * utterance the ledger has moved past — a late event, or one belonging to a
+ * superseded publication — is dropped rather than allowed to reopen it.
+ *
+ * WHAT IT CANNOT CHECK is whether the caller labelled the report correctly. The
+ * peer that hears the operator is the only one that sees both the transcript
+ * boundary and the handoff, so it is the only one that can tell whether the
+ * association is a fact; this end refuses everything that contradicts its own
+ * record and trusts the rest. That is why the client reports nothing at all when
+ * more than one utterance is outstanding.
  */
 export function recordVoiceHandoff(input: {
   conversationId: string;
   realtimeSessionId: string;
-  utteranceId: string;
+  utterance: VoiceUtteranceIdentity;
   handoff: VoiceHandoffIdentity;
 }): VoiceSelectedContextAdmissionResult {
   const session = sessions.get(input.conversationId);
@@ -264,7 +295,14 @@ export function recordVoiceHandoff(input: {
     };
   }
   const admission = session.admission;
-  if (!admission || admission.utteranceId !== input.utteranceId) {
+  /* BOTH halves of the identity, because they answer different questions. The id
+     says which publication this report belongs to; the sequence says where that
+     publication sits in the call. A report whose halves disagree describes a
+     boundary this ledger never saw, and completing the standing admission from
+     it would attach one turn's work to another turn's card. */
+  if (!admission
+    || admission.utteranceId !== input.utterance.id
+    || session.utteranceSequence !== input.utterance.sequence) {
     return {
       ok: false,
       failure: {
@@ -299,6 +337,11 @@ export function voiceSelectedContext(conversationId: string): VoiceSelectedConte
  * and its own handoff has not landed yet. So a later turn that pointed at nothing
  * reads `awaiting-handoff` and refuses. It never reads the card from the turn
  * before, which is the failure this state machine exists to make impossible.
+ *
+ * A hangup does not end it. The work the last utterance started outlives the
+ * transport, so an accepted join survives `stop` until the reference ages out of
+ * its own freshness window — see {@link releaseVoiceSession}, which keeps
+ * nothing else.
  */
 export type VoiceUtteranceContext =
   | { state: "no-call" }
@@ -310,20 +353,33 @@ export type VoiceUtteranceContext =
     handoff: VoiceHandoffIdentity;
     utteranceId: string | null;
     sequence: number;
+    /** True when the call has ended and this is what it left for the work it
+        started. The card is still the one that work was asked about. */
+    callEnded: boolean;
   };
 
-export function voiceUtteranceContext(conversationId: string): VoiceUtteranceContext {
+export function voiceUtteranceContext(conversationId: string, now = Date.now()): VoiceUtteranceContext {
   const session = sessions.get(conversationId);
   if (!session) return { state: "no-call" };
   const admission = session.admission;
   if (!admission) return { state: "no-reference" };
   if (!admission.handoff) return { state: "awaiting-handoff" };
+  if (session.endedAt !== null && now - Date.parse(admission.reference.capturedAt) > SELECTED_CONTEXT_MAX_AGE_MS) {
+    /* The call is over and what it left has aged out of the window a capture may
+       steer a turn from. Nothing that started with it is still plausibly
+       running, so this stops being an answer rather than becoming a stale one. */
+    sessions.delete(conversationId);
+    return { state: "no-call" };
+  }
   return {
     state: "joined",
     reference: admission.reference,
     handoff: admission.handoff,
     utteranceId: admission.utteranceId,
     sequence: admission.sequence,
+    /** Evidence, so a reader can tell live context from what a finished call
+        left behind for the work it started. */
+    callEnded: session.endedAt !== null,
   };
 }
 

--- a/src/lib/runtime/voiceViewBinding.ts
+++ b/src/lib/runtime/voiceViewBinding.ts
@@ -62,6 +62,21 @@ export interface VoiceSelectedContextAdmission {
   sequence: number;
   /** The utterance this reference was published for, when the caller named one. */
   utteranceId: string | null;
+  /**
+   * The handoff this utterance became, once the call reported one (#1629).
+   *
+   * The join between what the operator was looking at, what they said, and the
+   * work the backing model was asked to do. Null until the handoff is reported,
+   * and null for an utterance that never produced one.
+   */
+  handoff: VoiceHandoffIdentity | null;
+}
+
+/** The canonical identities a realtime handoff carries. */
+export interface VoiceHandoffIdentity {
+  handoffId: string | null;
+  itemId: string | null;
+  userBidiTurnId: string | null;
 }
 
 interface VoiceSessionState {
@@ -218,7 +233,47 @@ export function admitVoiceSelectedContext(input: VoiceSelectedContextAdmissionIn
     admittedAt: new Date(input.now).toISOString(),
     sequence: session.sequence,
     utteranceId: utterance?.id ?? null,
+    handoff: null,
   };
+  return { ok: true, admission: session.admission };
+}
+
+/**
+ * Record which handoff an already-admitted utterance became.
+ *
+ * Deliberately not an admission: it mints no utterance, moves no counter and
+ * replaces no reference. It only completes the record of one that already
+ * exists, so a handoff reported for an utterance the ledger has moved past — a
+ * late event, or one belonging to a superseded publication — is dropped rather
+ * than allowed to reopen it.
+ */
+export function recordVoiceHandoff(input: {
+  conversationId: string;
+  realtimeSessionId: string;
+  utteranceId: string;
+  handoff: VoiceHandoffIdentity;
+}): VoiceSelectedContextAdmissionResult {
+  const session = sessions.get(input.conversationId);
+  if (!session || !session.binding || session.realtimeSessionId !== input.realtimeSessionId) {
+    return {
+      ok: false,
+      failure: {
+        code: "unbound",
+        message: "This voice session is not bound to a Viewer window, so it cannot resolve a selected card.",
+      },
+    };
+  }
+  const admission = session.admission;
+  if (!admission || admission.utteranceId !== input.utteranceId) {
+    return {
+      ok: false,
+      failure: {
+        code: "superseded",
+        message: "This voice session has already been told about a later utterance, so an earlier one cannot replace it.",
+      },
+    };
+  }
+  session.admission = { ...admission, handoff: input.handoff };
   return { ok: true, admission: session.admission };
 }
 

--- a/src/lib/runtime/voiceViewBinding.ts
+++ b/src/lib/runtime/voiceViewBinding.ts
@@ -284,6 +284,49 @@ export function voiceSelectedContext(conversationId: string): VoiceSelectedConte
   return sessions.get(conversationId)?.admission ?? null;
 }
 
+/**
+ * What a tool call made from this conversation is entitled to read (#1629).
+ *
+ * This is the whole reader contract, and it is a state rather than a value on
+ * purpose: the four ways there is no card each mean something different to the
+ * agent holding the microphone, and collapsing them into `null` is how the agent
+ * ends up guessing.
+ *
+ * THE CARD IS ONLY AVAILABLE WHILE IT DESCRIBES THE WORK IN HAND. A reference
+ * becomes readable when its utterance has been handed off — that handoff is the
+ * work this tool call belongs to — and stops being readable the moment the
+ * operator speaks again, because a new utterance replaces the admission wholesale
+ * and its own handoff has not landed yet. So a later turn that pointed at nothing
+ * reads `awaiting-handoff` and refuses. It never reads the card from the turn
+ * before, which is the failure this state machine exists to make impossible.
+ */
+export type VoiceUtteranceContext =
+  | { state: "no-call" }
+  | { state: "no-reference" }
+  | { state: "awaiting-handoff" }
+  | {
+    state: "joined";
+    reference: SelectedContextRef;
+    handoff: VoiceHandoffIdentity;
+    utteranceId: string | null;
+    sequence: number;
+  };
+
+export function voiceUtteranceContext(conversationId: string): VoiceUtteranceContext {
+  const session = sessions.get(conversationId);
+  if (!session) return { state: "no-call" };
+  const admission = session.admission;
+  if (!admission) return { state: "no-reference" };
+  if (!admission.handoff) return { state: "awaiting-handoff" };
+  return {
+    state: "joined",
+    reference: admission.reference,
+    handoff: admission.handoff,
+    utteranceId: admission.utteranceId,
+    sequence: admission.sequence,
+  };
+}
+
 /** Test seam: the ledger is process-global, so a suite must be able to start
     from an empty one without reaching into module internals. */
 export function resetVoiceViewBindings(): void {

--- a/src/lib/runtime/voiceViewBinding.ts
+++ b/src/lib/runtime/voiceViewBinding.ts
@@ -21,9 +21,11 @@ import { parseSelectedContextRef, type SelectedContextRef } from "@/lib/selectio
  *   (see `realtimeInjection`), so admission reuses it rather than inventing a
  *   second notion of who is calling.
  * - `admitVoiceSelectedContext` runs at the utterance/delegation boundary. It
- *   validates the reference against the binding and, only then, replaces what
- *   the call points at. A refusal changes NOTHING: the previously admitted
- *   reference stands, so a phone's stray publish cannot blank the desk's.
+ *   validates the reference against the binding AND against what the call has
+ *   already been told, and only then replaces what the call points at. A refusal
+ *   changes NOTHING: the previously admitted reference stands, so a phone's
+ *   stray publish cannot blank the desk's, and a slow publish for an earlier
+ *   utterance cannot drag the call back to an earlier screen.
  * - `voiceSelectedContext` is what realtime delegation and tool routing read.
  *
  * Process-scoped and deliberately not durable: it describes a live transport. A
@@ -33,6 +35,23 @@ import { parseSelectedContextRef, type SelectedContextRef } from "@/lib/selectio
  * on the structured-user record instead.
  */
 
+/**
+ * Who published, and which utterance of theirs (#1629).
+ *
+ * The reference alone cannot answer either question. It says what was on screen,
+ * not which spoken turn it belongs to, so two publications from one window are
+ * indistinguishable — which is how a retried POST used to count as a second
+ * utterance and how a late one used to overwrite a newer one. The browser owns
+ * the utterance boundary (it is the peer that sees its own transcript go final),
+ * so it is the peer that names it.
+ */
+export interface VoiceUtteranceIdentity {
+  /** Stable for one utterance, including across this publication's retries. */
+  id: string;
+  /** Monotonic within one call, starting at 1. */
+  sequence: number;
+}
+
 export interface VoiceSelectedContextAdmission {
   conversationId: string;
   realtimeSessionId: string;
@@ -41,6 +60,8 @@ export interface VoiceSelectedContextAdmission {
   admittedAt: string;
   /** Utterance boundary counter for this call: 1 for the first admission. */
   sequence: number;
+  /** The utterance this reference was published for, when the caller named one. */
+  utteranceId: string | null;
 }
 
 interface VoiceSessionState {
@@ -48,6 +69,8 @@ interface VoiceSessionState {
   binding: VoiceViewBinding | null;
   admission: VoiceSelectedContextAdmission | null;
   sequence: number;
+  /** The utterance sequence the standing admission was published for. */
+  utteranceSequence: number | null;
 }
 
 const store = globalThis as typeof globalThis & {
@@ -78,7 +101,9 @@ export function parseVoiceViewBinding(value: unknown): VoiceViewBinding | null {
 /** Bind a call to the window that opened it. Rebinding a conversation is a new
     call: the previous admission is dropped rather than inherited. */
 export function bindVoiceSession(conversationId: string, realtimeSessionId: string, binding: VoiceViewBinding | null): void {
-  sessions.set(conversationId, { realtimeSessionId, binding, admission: null, sequence: 0 });
+  sessions.set(conversationId, {
+    realtimeSessionId, binding, admission: null, sequence: 0, utteranceSequence: null,
+  });
 }
 
 export function releaseVoiceSession(conversationId: string): void {
@@ -102,7 +127,43 @@ export interface VoiceSelectedContextAdmissionInput {
   /** The credential the caller presented; must be the call's own. */
   realtimeSessionId: string;
   reference: SelectedContextRef | null;
+  /** The utterance this publication speaks for, when the caller named one. */
+  utterance?: VoiceUtteranceIdentity | null;
   now: number;
+}
+
+/**
+ * Is this publication newer than the one standing?
+ *
+ * Preference order, and each step is used only when the one before it cannot
+ * decide:
+ *
+ * 1. The utterance sequence, when both publications carry one. It is minted by
+ *    the peer that saw the utterances happen, so it is the only ordering that
+ *    describes the CALL rather than the network.
+ * 2. The reference's own `revision`, monotonic within a view session — and a
+ *    call is bound to exactly one view session, so within a call it is total.
+ * 3. `capturedAt`, for a client that carries neither.
+ *
+ * Ties admit. A publication that cannot be shown to be older is treated as the
+ * current one: refusing it would strand the call on a stale card whenever a
+ * client stops carrying ordering evidence, which is the worse of the two.
+ */
+function supersedes(
+  candidate: { reference: SelectedContextRef; utterance: VoiceUtteranceIdentity | null },
+  standing: VoiceSelectedContextAdmission | null,
+  standingUtteranceSequence: number | null,
+): boolean {
+  if (!standing) return true;
+  if (candidate.utterance && standingUtteranceSequence !== null) {
+    return candidate.utterance.sequence >= standingUtteranceSequence;
+  }
+  const candidateRevision = candidate.reference.revision;
+  const standingRevision = standing.reference.revision;
+  if (typeof candidateRevision === "number" && typeof standingRevision === "number") {
+    return candidateRevision >= standingRevision;
+  }
+  return candidate.reference.capturedAt >= standing.reference.capturedAt;
 }
 
 export type VoiceSelectedContextAdmissionResult =
@@ -124,13 +185,31 @@ export function admitVoiceSelectedContext(input: VoiceSelectedContextAdmissionIn
       },
     };
   }
+  const utterance = input.utterance ?? null;
+  /* A REPLAY IS NOT A SECOND UTTERANCE. Publishing is fire-and-forget with a
+     retry, so the same utterance can arrive twice; answering with the standing
+     admission keeps the boundary counter equal to the number of spoken turns
+     instead of the number of successful POSTs. */
+  if (utterance && session.admission?.utteranceId === utterance.id) {
+    return { ok: true, admission: session.admission };
+  }
   const bound = bindSelectedContextToVoiceSession({
     binding: session.binding,
     reference: input.reference,
     now: input.now,
   });
   if (!bound.ok) return bound;
+  if (!supersedes({ reference: bound.reference, utterance }, session.admission, session.utteranceSequence)) {
+    return {
+      ok: false,
+      failure: {
+        code: "superseded",
+        message: "This voice session has already been told about a later utterance, so an earlier one cannot replace it.",
+      },
+    };
+  }
   session.sequence += 1;
+  if (utterance) session.utteranceSequence = utterance.sequence;
   session.admission = {
     conversationId: input.conversationId,
     realtimeSessionId: session.realtimeSessionId,
@@ -138,6 +217,7 @@ export function admitVoiceSelectedContext(input: VoiceSelectedContextAdmissionIn
     reference: bound.reference,
     admittedAt: new Date(input.now).toISOString(),
     sequence: session.sequence,
+    utteranceId: utterance?.id ?? null,
   };
   return { ok: true, admission: session.admission };
 }


### PR DESCRIPTION
Configures the spoken prompt and native backing-model start/end instructions, enables transcript-tail flushing, surfaces the usage warning, and adds voice-context lookup plumbing. The intended outcome is reliable voice in the existing orchestrator conversation, with its role, tools and ongoing work preserved.

This component is incorporated into #1636 for parent #1629. **It is not independently approved for merge:** the exact-head review of `016271376270bb306839ed2ea6b38199ea2de61c` found two P1 context-binding defects and one P2 retention defect. The integration experience stage owns their repair.

Outstanding findings:

- A delayed or duplicate handoff can bind to a later utterance after the ambiguous queue is cleared.
- Conversation identity alone cannot establish which work may consume a selected-card reference.
- Ten-minute post-hangup retention can expose an earlier card to unrelated text work, expire ongoing work, and lose its binding on reconnect.

Evidence corrections from a stronger, successful local native session:

- A USER-delivered synthetic manager mandate reaches spoken startup context and remains in backing requests. The earlier developer-only failed-call fixture does not establish wholesale loss of the actual Viewer mandate.
- The native tool catalog is unchanged before, during and after voice in that fixture.
- Native records start/end instructions as canonical developer messages. The end instruction remains alongside earlier history; it does not literally remove the start text. Same-turn reconnect can retain the earlier start instruction until another mode transition.
- The native app's fallback spoken prompt also uses a general Codex identity. Its functional delegation, steering and USER/BACKEND framing must be preserved when adapting persona. A generic identity alone is insufficient causal proof of the reported behavior.

The original component passed 460 named local tests, TypeScript, privacy checks and applicable CI. Its notice/error images establish fixture presentation. Additional tests drove real Codex 0.154.0 through credential-free loopback Responses, WebSocket and MCP fixtures. Those results establish protocol/context behavior; real-provider audio, model quality and whole-call production behavior remain unverified.

No deployment is represented by this PR. Final readiness requires the remaining #1629 integration, repaired context behavior, and independent review of the complete integration head.
