### PR TITLE
feat(runtime): bounded native Codex canonical history reader

### DIFF
--- a/docs/design/codex-history-reader.md
+++ b/docs/design/codex-history-reader.md
@@ -14,6 +14,8 @@ Results:
 
 `findCodexHistoryDelivery(history, target)` accepts the original client ID, frozen native input content, explicit null/string turn ID, and optional canonical item ID. Null means the turn is not yet known; a supplied string must match. The lookup returns `found` only for one canonical user message with matching identity and payload. Multiple instances of the original key remain ambiguous. Identical text under other keys cannot establish delivery. Comparison preserves Unicode, content order, markers, attachment identity/detail and text spans; only object property ordering and documented empty/null input defaults are normalized. It does not invent a delivery timestamp or terminal turn outcome. A missing message always remains `unknown`, even after complete traversal.
 
+Codex 0.154 serializes an omitted `text_elements[].placeholder` as `null`. Payload comparison treats those two forms as equivalent, while preserving explicit placeholder strings (including empty strings), byte ranges, text, keys, turn fences and attachments. Normalization creates comparison copies and retains the original admitted input and canonical record. The native round-trip regression observes this serialization and requires the omitted input to match; changed placeholders and ranges remain unknown. That lookup fails on the original reader and passes with normalization.
+
 ## Remaining integration work
 
 After the voice owner releases the host file, the integration worker must:

--- a/docs/design/codex-history-reader.md
+++ b/docs/design/codex-history-reader.md
@@ -1,0 +1,36 @@
+# Native Codex canonical history reader
+
+Reader-only implementation for [#1557](https://github.com/Latand/live-log-viewer-next/issues/1557), supporting the authorized native integration in [#1629](https://github.com/Latand/live-log-viewer-next/issues/1629). Based on `22ca45579f01bb0088b753cc2cf7b84c93422f58`. The September 8 research was independently approved; host integration remains owed.
+
+`readCodexHistory(rpc, identity, options)` takes the existing host-style injected RPC, a frozen native thread ID and canonical path, and the caller's existing absolute deadline. It reads metadata with `includeTurns: false`, then traverses turns and the required per-turn item pages. Default limits are 16 MiB of aggregate JSON response bytes, 128 responses including metadata, 16 turns per page and 32 items per page. These limits may be lowered by callers. No per-page deadline renewal occurs.
+
+The default turn view is `notLoaded`, followed by item pagination in ascending order. Explicit `full` turns are usable directly; the CLI schema also defines omitted `itemsView` as `full`. `summary`, `notLoaded` and legacy partial-cursor turns require a fresh item traversal. Summary items never establish delivery. Turn order follows the requested direction; item order remains native ascending order. Opaque continuation and backwards cursors are retained unchanged in `pages`.
+
+Results:
+
+- `complete`: metadata matches and every required page ended with an explicit null cursor. The result retains canonical items, client IDs, payloads and turn IDs. This describes one traversal, without claiming an atomic snapshot or authoritative absence.
+- `unknown`: identity mismatch, malformed/missing/error pages, repeated cursors, duplicate records, transport failure, missing persistence, or a byte/page/deadline limit. Partial evidence is withheld.
+- `legacy-fallback`: explicit method-not-found or recognized unsupported-pagination protocol errors only. The caller may use its established legacy reader. No disk access occurs in this helper.
+
+`findCodexHistoryDelivery(history, target)` accepts the original client ID, frozen native input content, explicit null/string turn ID, and optional canonical item ID. Null means the turn is not yet known; a supplied string must match. The lookup returns `found` only for one canonical user message with matching identity and payload. Multiple instances of the original key remain ambiguous. Identical text under other keys cannot establish delivery. Comparison preserves Unicode, content order, markers, attachment identity/detail and text spans; only object property ordering and documented empty/null input defaults are normalized. It does not invent a delivery timestamp or terminal turn outcome. A missing message always remains `unknown`, even after complete traversal.
+
+## Remaining integration work
+
+After the voice owner releases the host file, the integration worker must:
+
+1. Bind the RPC to the existing account/connection/generation and pass the existing materialization or delivery deadline. Preserve its transport frame cap: byte checking here runs after the RPC has parsed a response and cannot prevent allocation inside the transport.
+2. Wire this reader into `sessionMaterializationEvidence` and original-key delivery reconciliation. Supply the exact native input frozen at admission, including structured-user markers and attachments. A Viewer content digest and raw native input are different contracts; the caller must retain or reconstruct the admitted native input faithfully.
+3. Map `found` into existing evidence/receipt handling without manufacturing completion or delivery time. Map all unknowns to existing unresolved recovery, retaining the original operation and blobs. Use legacy fallback only for the explicit capability result. Keep account, writer generation and lifecycle fences in the host.
+4. Prove actual Viewer host replacement, materialization and delivery behavior with no second send, plus parent #1629's send/queue/voice acceptance. This PR has no host, queue, HTTP, UI, journal, voice, scheduler, registry or lifecycle changes. Keep #1557 open until that integration is reviewed.
+
+## Verification and limits
+
+Named test: `src/lib/runtime/codexHistoryReader.test.ts`, run under Bun 1.4.0. Seam cases cover second turns/items pages, full/summary/partial semantics, original key/payload/turn/item matching, missing-record negative control, wrong identity, cursor loops, malformed/error pages, delayed visibility, page/deadline exhaustion, aggregate UTF-8 bytes and a 512 KiB tool output.
+
+The opt-in real test requires `LLV_CODEX_HISTORY_CLI` to name the Codex 0.154.0 executable and `/usr/bin/zstd`. It creates private HOME, XDG config/cache/data, CODEX_HOME, CLAUDE_CONFIG_DIR, GEMINI_CLI_HOME, LLV_STATE_DIR and short TMPDIR. Child environment is allowlisted. A loopback credential-free Responses fixture completes three synthetic turns. Real turns and items paginate with a page size of one; `notLoaded`, `summary` and `full` produce the same canonical history. Cold app-server replacement recovers the original key without another send. The negative control then removes the exact thread/turn/item row from the stopped fixture's native history projection, retaining a database backup; a fresh app-server completes pagination, leaves that key unknown, and still finds another original key.
+
+A real native fork establishes a `history_base` reference and cutoff. Both fixture rollouts are converted to byte-verified `.jsonl.zst` representations while the fixture app-server is stopped, retaining original bytes until fixture cleanup. A cold reader returns the parent and shared child while their rollout files are compressed. Native pagination uses the retained `thread_history` SQLite projection; this does not prove decompression or projection rebuilding from compressed files. A separate experiment without that projection did not recover the message through read-only pagination. The helper correctly leaves that result unknown. Compression worker scheduling and recovery from a missing projection remain unverified. The representation is grounded in the [0.154 compression implementation](https://github.com/openai/codex/blob/rust-v0.154.0/codex-rs/rollout/src/compression.rs) and [native shared-history test](https://github.com/openai/codex/blob/rust-v0.154.0/codex-rs/core/tests/suite/rollout_compression.rs).
+
+Real model consumption, provider credentials, compaction, attachment upload and Viewer host replacement are outside this fixture. Large tool output and delayed materialization are exercised at the injected RPC seam. CI does not currently invoke this new named test or install the optional CLI; local native evidence must remain distinct from the existing CI checks. ESLint's documented baseline plugin crash is not a passing check.
+
+Prior conversation discovery used two project-scoped and three unscoped queries, then read relevant turns. The August 25 pagination review identified full-turn byte exposure and lost oversized-notification evidence. Current baseline still uses hydration/disk fallback in `readThreadWithTurns`; this helper bounds native pagination, while notification handling remains with the host owner. September 10 parent records confirm the independent reader scope and the later integration stage.

--- a/src/lib/runtime/codexHistoryReader.test.ts
+++ b/src/lib/runtime/codexHistoryReader.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { createInterface } from "node:readline";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, renameSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  readCodexHistory, findCodexHistoryDelivery,
+  type CodexHistoryRpc, type CodexHistoryOptions, type CodexHistoryDeliveryTarget,
+} from "./codexHistoryReader";
+
+const identity = { threadId: "thread-a", path: "/fixture/session.jsonl" };
+const content = [{ type: "text", text: "Повідомлення 🌍 e\u0301", text_elements: [] }];
+const user = { type: "userMessage", id: "item-a", clientId: "original-key", content };
+const target: CodexHistoryDeliveryTarget = { clientId: user.clientId, content, turnId: "turn-a", itemId: user.id };
+const turn = (items: unknown[] = [user], itemsView = "full", id = "turn-a") => ({ id, status: "completed", items, itemsView });
+const page = (data: unknown[], nextCursor: string | null = null) => ({ data, nextCursor, backwardsCursor: null });
+const metadata = { thread: { id: identity.threadId, path: identity.path, ephemeral: false } };
+const options = (extra: Partial<CodexHistoryOptions> = {}): CodexHistoryOptions => ({ deadlineAt: Date.now() + 2000, ...extra });
+function fixture(responses: unknown[]) {
+  const calls: { method: string; params: Record<string, unknown>; timeout: number }[] = [];
+  const rpc: CodexHistoryRpc = async (method, params, timeout) => {
+    calls.push({ method, params, timeout });
+    const response = responses[calls.length - 1];
+    if (response instanceof Error) throw response;
+    return structuredClone(response);
+  };
+  return { rpc, calls };
+}
+async function lookup(responses: unknown[], wanted = target, extra: Partial<CodexHistoryOptions> = {}) {
+  const f = fixture(responses);
+  const history = await readCodexHistory(f.rpc, identity, options(extra));
+  return { history, delivery: findCodexHistoryDelivery(history, wanted), calls: f.calls };
+}
+
+describe("bounded canonical history", () => {
+  test("walks second turns and items pages, preserves order and opaque cursors", async () => {
+    const turnCursor = '{"anchor":"opaque-turn"}';
+    const itemCursor = '{"anchor":"opaque-item"}';
+    const tool = { type: "commandExecution", id: "tool-a", aggregatedOutput: "tool result" };
+    const result = await lookup([
+      metadata,
+      page([turn([], "notLoaded", "turn-b")], turnCursor),
+      page([]),
+      page([turn([], "summary")]),
+      page([{ turnId: "turn-a", item: tool }], itemCursor),
+      page([{ turnId: "turn-a", item: user }]),
+    ]);
+    expect(result.delivery.state).toBe("found");
+    expect(result.calls.map(c => [c.method, c.params.cursor])).toEqual([
+      ["thread/read", undefined], ["thread/turns/list", null], ["thread/items/list", null],
+      ["thread/turns/list", turnCursor], ["thread/items/list", null], ["thread/items/list", itemCursor],
+    ]);
+    if (result.history.state !== "complete") throw new Error("history incomplete");
+    expect(result.history.turns.map(t => t.id)).toEqual(["turn-b", "turn-a"]);
+    expect(result.history.turns[1].items.map(i => i.id)).toEqual(["tool-a", "item-a"]);
+    expect(result.history.pages[3].nextCursor).toBe(itemCursor);
+    expect(result.calls.every(c => c.timeout > 0 && c.timeout <= 2000)).toBe(true);
+  });
+
+  test("full is complete, including the schema's omitted itemsView default", async () => {
+    const full = turn();
+    const { itemsView: _view, ...omitted } = full;
+    for (const row of [full, omitted]) {
+      const result = await lookup([metadata, page([row])]);
+      expect(result.delivery.state).toBe("found");
+      expect(result.calls).toHaveLength(2);
+    }
+  });
+
+  test("summary and partial full items cannot supply delivery evidence", async () => {
+    for (const row of [turn([user], "summary"), turn([], "notLoaded"), { ...turn(), itemsBackwardsCursor: "older" }]) {
+      const result = await lookup([metadata, page([row]), page([])]);
+      expect(result.history.state).toBe("complete");
+      expect(result.delivery).toEqual({ state: "unknown", reason: "not-observed" });
+      expect(result.calls[2].params.cursor).toBeNull();
+    }
+  });
+
+  test("canonical record removal makes the positive control red", async () => {
+    expect((await lookup([metadata, page([turn()])])).delivery.state).toBe("found");
+    expect((await lookup([metadata, page([turn([])])])).delivery.state).toBe("unknown");
+  });
+
+  test("requires key, exact payload, turn and optional canonical item identity", async () => {
+    for (const change of [
+      { clientId: "wrong" }, { content: [{ type: "text", text: "other" }] },
+      { turnId: "other-turn" }, { itemId: "other-item" },
+      { content: [{ type: "text", text: "Повідомлення 🌍 é" }] },
+      { content: [...content, { type: "image", url: "fixture-image" }] },
+    ]) expect((await lookup([metadata, page([turn()])], { ...target, ...change })).delivery.state).toBe("unknown");
+    expect((await lookup([metadata, page([turn()])], { ...target, turnId: null })).delivery.state).toBe("found");
+    expect((await lookup([metadata, page([turn()])], { ...target, turnId: undefined } as unknown as CodexHistoryDeliveryTarget)).delivery.state).toBe("unknown");
+  });
+
+  test("normalizes only schema defaults and object key order; preserves spans and attachments", async () => {
+    const reordered = [{ text: content[0].text, type: "text" }];
+    expect((await lookup([metadata, page([turn()])], { ...target, content: reordered })).delivery.state).toBe("found");
+    const mixed = [...content, { type: "image", url: "fixture-image", detail: "original" }];
+    const response = [metadata, page([turn([{ ...user, content: mixed }])])];
+    expect((await lookup(response, { ...target, content: mixed })).delivery.state).toBe("found");
+    expect((await lookup(response, { ...target, content: [...content, { type: "image", url: "fixture-image" }] })).delivery.state).toBe("unknown");
+    expect((await lookup([metadata, page([turn()])], { ...target, content: [{ ...content[0], text_elements: [{ byteRange: { start: 0, end: 2 }, placeholder: "x" }] }] })).delivery.state).toBe("unknown");
+  });
+
+  test("duplicate text under other keys is harmless, duplicate original keys are ambiguous", async () => {
+    const other = { ...user, id: "item-b", clientId: "other-key" };
+    expect((await lookup([metadata, page([turn([other, user])])])).delivery.state).toBe("found");
+    expect((await lookup([metadata, page([turn([other])])])).delivery.state).toBe("unknown");
+    expect((await lookup([metadata, page([turn([user, { ...user, id: "item-b" }])])])).delivery.state).toBe("unknown");
+    expect((await lookup([metadata, page([turn(), turn([user], "full", "turn-b")])])).delivery.state).toBe("unknown");
+  });
+
+  test("wrong metadata path/thread, page thread and item turn remain unknown", async () => {
+    for (const thread of [{ ...metadata.thread, id: "thread-b" }, { ...metadata.thread, path: "wrong" }, { ...metadata.thread, path: null }, { ...metadata.thread, ephemeral: true }]) {
+      expect((await lookup([{ thread }, page([turn()])])).history).toEqual({ state: "unknown", reason: "identity" });
+    }
+    expect((await lookup([metadata, { ...page([turn()]), threadId: "thread-b" }])).history.state).toBe("unknown");
+    expect((await lookup([metadata, page([turn([], "notLoaded")]), page([{ turnId: "turn-b", item: user }])])).history.state).toBe("unknown");
+  });
+
+  test("missing, malformed and error pages never establish absence or fallback", async () => {
+    for (const bad of [undefined, null, {}, { data: [] }, { nextCursor: null }, { data: "bad", nextCursor: null }, { data: [], nextCursor: 1 }, { ...page([]), error: { code: -32601 } }, page([null]), page([{ ...turn(), items: null }]), page([{ ...turn(), itemsView: null }]), page([{ ...turn(), status: "unknown" }])]) {
+      expect((await lookup([metadata, bad])).history.state).toBe("unknown");
+    }
+    expect((await lookup([metadata, page([turn([], "summary")]), { data: [] }])).history.state).toBe("unknown");
+    expect((await lookup([metadata, page([turn()], "more"), new Error("connection lost")])).delivery.state).toBe("unknown");
+  });
+
+  test("malformed canonical content remains unknown", async () => {
+    for (const malformed of [
+      [{ type: "text", text: "text", text_elements: [42] }],
+      [{ type: "text", text: "text", text_elements: [{ byteRange: { start: 3, end: 1 } }] }],
+      [{ type: "image", url: "fixture", detail: "invalid" }],
+      [{ type: "localImage", path: 3 }],
+    ]) expect((await lookup([metadata, page([turn([{ ...user, content: malformed }])])])).history.state).toBe("unknown");
+  });
+
+  test("repeated cursors, duplicate records and empty continuation pages fail closed", async () => {
+    for (const responses of [
+      [metadata, page([turn()], "same"), page([turn([], "full", "turn-b")], "same")],
+      [metadata, page([turn()], "next"), page([turn()])],
+      [metadata, page([], "next")],
+      [metadata, page([turn([user, user])])],
+      [metadata, page([turn([], "summary")]), page([{ turnId: "turn-a", item: user }], "same"), page([{ turnId: "turn-a", item: { ...user, id: "item-b" } }], "same")],
+    ]) expect((await lookup(responses)).history.state).toBe("unknown");
+  });
+
+  test("capability refusal alone permits legacy fallback", async () => {
+    for (const error of [Object.assign(new Error("Method not found"), { code: -32601 }), new Error("Codex app-server request failed: list_turns is not supported yet")]) {
+      expect((await lookup([metadata, error])).history).toEqual({ state: "legacy-fallback", reason: "unsupported" });
+    }
+    for (const error of [new Error("transport not supported"), new Error("Codex app-server request failed: permission denied"), new Error("Codex app-server request failed: thread not materialized yet before first user message"), new Error("thread/read timed out")]) {
+      expect((await lookup([error])).history).toEqual({ state: "unknown", reason: "transport" });
+    }
+  });
+
+  test("delayed materialization is polled by the caller without mutation or new identity", async () => {
+    const early = await lookup([metadata, page([])]);
+    const late = await lookup([metadata, page([turn()])]);
+    expect(early.delivery.state).toBe("unknown");
+    expect(late.delivery.state).toBe("found");
+    expect([...early.calls, ...late.calls].every(c => c.method.endsWith("/list") || c.method === "thread/read")).toBe(true);
+  });
+
+  test("bounds aggregate bytes including large tool items and UTF-8", async () => {
+    const tool = { type: "commandExecution", id: "tool-a", aggregatedOutput: "🌍".repeat(128 * 1024) };
+    const responses = [metadata, page([turn([], "notLoaded")]), page([{ turnId: "turn-a", item: tool }, { turnId: "turn-a", item: user }])];
+    expect((await lookup(responses, target, { maxBytes: 100_000 })).history).toEqual({ state: "unknown", reason: "bytes" });
+    const exact = responses.reduce((sum, r) => sum + Buffer.byteLength(JSON.stringify(r)), 0);
+    const result = await lookup(responses, target, { maxBytes: exact });
+    expect(result.delivery.state).toBe("found");
+    if (result.history.state === "complete") expect(result.history.bytes).toBe(exact);
+    expect((await lookup(responses, target, { maxBytes: exact - 1 })).history.state).toBe("unknown");
+  });
+
+  test("bounds pages, enforces one deadline even if RPC never settles, ignores late results", async () => {
+    expect((await lookup([metadata, page([turn()])], target, { maxPages: 1 })).history).toEqual({ state: "unknown", reason: "pages" });
+    const calls: number[] = [];
+    const rpc: CodexHistoryRpc = async (_method, _params, timeout) => {
+      calls.push(timeout);
+      await new Promise(resolve => setTimeout(resolve, 15));
+      return calls.length === 1 ? metadata : page([turn()]);
+    };
+    const result = await readCodexHistory(rpc, identity, options({ deadlineAt: Date.now() + 22 }));
+    expect(result).toEqual({ state: "unknown", reason: "deadline" });
+    expect(calls[1]).toBeLessThan(calls[0]);
+    expect(await readCodexHistory(() => new Promise(() => {}), identity, options({ deadlineAt: Date.now() + 10 }))).toEqual({ state: "unknown", reason: "deadline" });
+  });
+});
+
+// Opt in with an explicit executable. CI without the CLI still runs every seam test.
+const nativeCli = process.env.LLV_CODEX_HISTORY_CLI;
+test.skipIf(!nativeCli)("real Codex 0.154: isolated Responses, multi-page history, original-key persistence across restart", async () => {
+  const root = mkdtempSync("/tmp/chr-");
+  const env: NodeJS.ProcessEnv & Record<string, string> = { PATH: "/usr/bin:/bin", LANG: "C.UTF-8", NODE_ENV: "test" };
+  for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "CODEX_HOME", "CLAUDE_CONFIG_DIR", "GEMINI_CLI_HOME", "LLV_STATE_DIR", "TMPDIR"]) {
+    env[key] = join(root, key.toLowerCase()); mkdirSync(env[key], { mode: 0o700 });
+  }
+  const cwd = join(root, "workspace"); mkdirSync(cwd);
+  let requests = 0;
+  const server = createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      requests++;
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      const output = { id: `answer-${requests}`, type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text: "Fixture answer 🌍", annotations: [] }] };
+      for (const event of [
+        { type: "response.created", response: { id: `response-${requests}` } },
+        { type: "response.output_item.added", output_index: 0, item: { ...output, status: "in_progress", content: [] } },
+        { type: "response.output_item.done", output_index: 0, item: output },
+        { type: "response.completed", response: { id: `response-${requests}`, status: "completed", output: [output], usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } },
+      ]) res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+      res.end();
+    });
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  writeFileSync(join(env.CODEX_HOME, "config.toml"), `model = "fixture-model"
+model_provider = "fixture"
+approval_policy = "never"
+sandbox_mode = "read-only"
+web_search = "disabled"
+[model_providers.fixture]
+name = "Credential-free local Responses"
+base_url = "http://127.0.0.1:${port}/v1"
+wire_api = "responses"
+requires_openai_auth = false
+supports_websockets = false
+[analytics]
+enabled = false
+[features]
+apps = false
+plugins = false
+`);
+  type Client = { rpc: CodexHistoryRpc; events: Record<string, unknown>[]; stop: () => Promise<void> };
+  const clients: Client[] = [];
+  function startClient(): Client {
+    const child = spawn(nativeCli!, ["app-server", "--stdio"], { cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    child.stderr.resume();
+    const lines = createInterface({ input: child.stdout });
+    let serial = 0;
+    const events: Record<string, unknown>[] = [];
+    const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>();
+    lines.on("line", line => {
+      const row = JSON.parse(line);
+      const waiter = pending.get(row.id);
+      if (waiter) { pending.delete(row.id); if (row.error) waiter.reject(Object.assign(new Error(row.error.message), { code: row.error.code })); else waiter.resolve(row.result); }
+      else events.push(row);
+    });
+    const rpc: CodexHistoryRpc = (method, params, timeoutMs) => new Promise((resolve, reject) => {
+      const id = ++serial;
+      const timer = setTimeout(() => { pending.delete(id); reject(new Error(`Fixture RPC timeout: ${method}`)); }, timeoutMs);
+      pending.set(id, { resolve: v => { clearTimeout(timer); resolve(v); }, reject: e => { clearTimeout(timer); reject(e); } });
+      child.stdin.write(JSON.stringify({ id, method, params }) + "\n");
+    });
+    const stop = async () => {
+      child.stdin.end();
+      if (child.exitCode === null) await new Promise<void>(resolve => {
+        const timer = setTimeout(() => child.kill("SIGTERM"), 2000);
+        child.once("exit", () => { clearTimeout(timer); resolve(); });
+      });
+      lines.close();
+    };
+    const client = { rpc, events, stop };
+    clients.push(client);
+    return client;
+  }
+  const init = async (client: Client) => {
+    const result = await client.rpc("initialize", { clientInfo: { name: "history_reader_fixture", version: "1" }, capabilities: { experimentalApi: true } }, 5000) as { userAgent: string };
+    expect(result.userAgent).toContain("/0.154.0");
+    expect(await client.rpc("account/read", { refreshToken: false }, 5000)).toMatchObject({ account: null });
+  };
+  try {
+    expect(spawnSync(nativeCli!, ["--version"], { env, cwd, encoding: "utf8" }).stdout.trim()).toBe("codex-cli 0.154.0");
+    let client = startClient(); await init(client);
+    const started = await client.rpc("thread/start", { cwd, model: "fixture-model", modelProvider: "fixture", approvalPolicy: "never", sandbox: "read-only", historyMode: "paginated" }, 5000) as { thread: { id: string; path: string } };
+    const nativeIdentity = { threadId: started.thread.id, path: started.thread.path };
+    const targets: CodexHistoryDeliveryTarget[] = [];
+    for (let i = 0; i < 3; i++) {
+      const input = [{ type: "text", text: `Canonical fixture ${i} 🌍` }];
+      const result = await client.rpc("turn/start", { threadId: nativeIdentity.threadId, clientUserMessageId: `original-${i}`, input }, 5000) as { turn: { id: string } };
+      targets.push({ clientId: `original-${i}`, content: input, turnId: result.turn.id });
+      const deadline = Date.now() + 8000;
+      while (!client.events.some(e => e.method === "turn/completed" && (e.params as { turn?: { id?: string } })?.turn?.id === result.turn.id)) {
+        if (Date.now() > deadline) throw new Error("Fixture turn did not complete");
+        await new Promise(resolve => setTimeout(resolve, 20));
+      }
+    }
+    expect(requests).toBe(3);
+    const read = (view: "notLoaded" | "summary" | "full") => readCodexHistory(client.rpc, nativeIdentity, options({ deadlineAt: Date.now() + 8000, itemsView: view, turnsPerPage: 1, itemsPerPage: 1 }));
+    const history = await read("notLoaded");
+    expect(history.state).toBe("complete");
+    if (history.state !== "complete") throw new Error(JSON.stringify(history));
+    expect(history.turns).toHaveLength(3);
+    expect(history.pages.filter(p => p.method === "thread/turns/list" && p.cursor !== null).length).toBeGreaterThanOrEqual(2);
+    expect(history.pages.filter(p => p.method === "thread/items/list" && p.cursor !== null).length).toBeGreaterThanOrEqual(3);
+    for (const wanted of targets) expect(findCodexHistoryDelivery(history, wanted).state).toBe("found");
+    const removed = { ...history, turns: history.turns.map(t => ({ ...t, items: t.items.filter(i => i.clientId !== targets[1].clientId) })) };
+    expect(findCodexHistoryDelivery(removed, targets[1]).state).toBe("unknown");
+    for (const view of ["summary", "full"] as const) {
+      const alternate = await read(view);
+      expect(alternate.state).toBe("complete");
+      if (alternate.state === "complete") expect(alternate.turns).toEqual(history.turns);
+    }
+    // A fork exercises the native shared-history cutoff. This is synthetic
+    // protocol data; it never launches a helper or contacts a model service.
+    const fork = await client.rpc("thread/fork", { threadId: nativeIdentity.threadId, lastTurnId: targets[1].turnId, excludeTurns: true, cwd }, 5000) as { thread: { id: string; path: string } };
+    const forkIdentity = { threadId: fork.thread.id, path: fork.thread.path };
+    const forkHistory = await readCodexHistory(client.rpc, forkIdentity, options({ deadlineAt: Date.now() + 8000, turnsPerPage: 1, itemsPerPage: 1 }));
+    expect(findCodexHistoryDelivery(forkHistory, targets[1]).state).toBe("found");
+    expect(findCodexHistoryDelivery(forkHistory, targets[2]).state).toBe("unknown");
+    await client.stop();
+    const forkMeta = JSON.parse(readFileSync(forkIdentity.path, "utf8").split("\n")[0]);
+    expect(forkMeta.payload.history_base.thread_id).toBe(nativeIdentity.threadId);
+    // Reproduce the supported cold .jsonl.zst representation while retaining
+    // the original fixture bytes beside it. Never alter an operator rollout.
+    for (const path of [nativeIdentity.path, forkIdentity.path]) {
+      const compressed = spawnSync("/usr/bin/zstd", ["-q", "-c", path], { env, cwd, maxBuffer: 8 * 1024 * 1024 });
+      expect(compressed.status).toBe(0);
+      writeFileSync(path + ".zst", compressed.stdout);
+      const decoded = spawnSync("/usr/bin/zstd", ["-q", "-d", "-c", path + ".zst"], { env, cwd, maxBuffer: 8 * 1024 * 1024 });
+      expect(decoded.stdout.equals(readFileSync(path))).toBe(true);
+      renameSync(path, path + ".fixture-backup");
+    }
+    client = startClient(); await init(client);
+    // Read persisted history cold. No resume/start/send occurs during reconciliation.
+    const restarted = await read("notLoaded");
+    expect(findCodexHistoryDelivery(restarted, targets[1]).state).toBe("found");
+    expect(findCodexHistoryDelivery(restarted, { ...targets[1], clientId: "missing-original" }).state).toBe("unknown");
+    const compressedFork = await readCodexHistory(client.rpc, forkIdentity, options({ deadlineAt: Date.now() + 8000, turnsPerPage: 1, itemsPerPage: 1 }));
+    expect(findCodexHistoryDelivery(compressedFork, targets[1]).state).toBe("found");
+    expect(findCodexHistoryDelivery(compressedFork, targets[2]).state).toBe("unknown");
+    expect(requests).toBe(3);
+    await client.stop();
+    // Native pagination reads the persisted thread-history projection. Remove
+    // the exact canonical row there, preserving the original fixture database.
+    const dbPath = join(env.CODEX_HOME, "thread_history_1.sqlite");
+    copyFileSync(dbPath, dbPath + ".negative-backup");
+    const db = new Database(dbPath);
+    const evidence = findCodexHistoryDelivery(history, targets[1]);
+    if (evidence.state !== "found") throw new Error("Missing positive control");
+    try {
+      const deleted = db.query("DELETE FROM thread_items WHERE thread_id = ? AND turn_id = ? AND item_id = ?")
+        .run(nativeIdentity.threadId, evidence.turnId, evidence.item.id);
+      expect(deleted.changes).toBe(1);
+    } finally { db.close(); }
+    client = startClient(); await init(client);
+    const missingCanonical = await read("notLoaded");
+    expect(missingCanonical.state).toBe("complete");
+    expect(findCodexHistoryDelivery(missingCanonical, targets[1]).state).toBe("unknown");
+    expect(findCodexHistoryDelivery(missingCanonical, targets[0]).state).toBe("found");
+    expect(requests).toBe(3);
+  } finally {
+    for (const client of clients) await client.stop();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 45_000);

--- a/src/lib/runtime/codexHistoryReader.test.ts
+++ b/src/lib/runtime/codexHistoryReader.test.ts
@@ -104,6 +104,41 @@ describe("bounded canonical history", () => {
     expect((await lookup([metadata, page([turn()])], { ...target, content: [{ ...content[0], text_elements: [{ byteRange: { start: 0, end: 2 }, placeholder: "x" }] }] })).delivery.state).toBe("unknown");
   });
 
+  test("omitted and null span placeholders match without changing frozen content or other fields", async () => {
+    const span = { byteRange: { start: 0, end: 2 } };
+    const withSpan = (element: Record<string, unknown>) => [
+      { ...content[0], text_elements: [element] },
+      { type: "image", url: "fixture-image", detail: "original" },
+    ];
+    for (const canonicalSpan of [span, { ...span, placeholder: null }]) {
+      const responses = [metadata, page([turn([{ ...user, content: withSpan(canonicalSpan) }])])];
+      const before = structuredClone(responses);
+      for (const admittedSpan of [span, { ...span, placeholder: null }]) {
+        const wanted = { ...target, content: withSpan(admittedSpan) };
+        const frozen = structuredClone(wanted);
+        expect((await lookup(responses, wanted)).delivery.state).toBe("found");
+        expect(wanted).toEqual(frozen);
+      }
+      for (const changed of [
+        { content: withSpan({ ...span, placeholder: "" }) },
+        { content: withSpan({ ...span, placeholder: "marker" }) },
+        { content: withSpan({ byteRange: { start: 2, end: 4 } }) },
+        { content: withSpan({ byteRange: { start: 0, end: 4 } }) },
+        { content: [{ ...withSpan(span)[0], text: "Інший текст" }, withSpan(span)[1]] },
+        { content: [withSpan(span)[0], { type: "image", url: "other-image", detail: "original" }] },
+        { clientId: "other-key", content: withSpan(span) },
+        { turnId: "other-turn", content: withSpan(span) },
+        { itemId: "other-item", content: withSpan(span) },
+      ]) expect((await lookup(responses, { ...target, ...changed })).delivery.state).toBe("unknown");
+      expect(responses).toEqual(before);
+    }
+    const named = withSpan({ ...span, placeholder: "marker" });
+    const responses = [metadata, page([turn([{ ...user, content: named }])])];
+    expect((await lookup(responses, { ...target, content: named })).delivery.state).toBe("found");
+    expect((await lookup(responses, { ...target, content: withSpan({ ...span, placeholder: "changed" }) })).delivery.state).toBe("unknown");
+    expect((await lookup(responses, { ...target, content: withSpan(span) })).delivery.state).toBe("unknown");
+  });
+
   test("duplicate text under other keys is harmless, duplicate original keys are ambiguous", async () => {
     const other = { ...user, id: "item-b", clientId: "other-key" };
     expect((await lookup([metadata, page([turn([other, user])])])).delivery.state).toBe("found");
@@ -279,7 +314,9 @@ plugins = false
     const nativeIdentity = { threadId: started.thread.id, path: started.thread.path };
     const targets: CodexHistoryDeliveryTarget[] = [];
     for (let i = 0; i < 3; i++) {
-      const input = [{ type: "text", text: `Canonical fixture ${i} 🌍` }];
+      const input = [{ type: "text", text: `Canonical fixture ${i} 🌍`, text_elements: [
+        { byteRange: { start: 0, end: 9 }, ...(i === 0 ? {} : { placeholder: i === 1 ? null : "marker" }) },
+      ] }];
       const result = await client.rpc("turn/start", { threadId: nativeIdentity.threadId, clientUserMessageId: `original-${i}`, input }, 5000) as { turn: { id: string } };
       targets.push({ clientId: `original-${i}`, content: input, turnId: result.turn.id });
       const deadline = Date.now() + 8000;
@@ -296,7 +333,20 @@ plugins = false
     expect(history.turns).toHaveLength(3);
     expect(history.pages.filter(p => p.method === "thread/turns/list" && p.cursor !== null).length).toBeGreaterThanOrEqual(2);
     expect(history.pages.filter(p => p.method === "thread/items/list" && p.cursor !== null).length).toBeGreaterThanOrEqual(3);
-    for (const wanted of targets) expect(findCodexHistoryDelivery(history, wanted).state).toBe("found");
+    const firstUser = history.turns[0].items.find(item => item.clientId === targets[0].clientId);
+    expect(firstUser?.content).toEqual([{ ...targets[0].content[0], text_elements: [
+      { byteRange: { start: 0, end: 9 }, placeholder: null },
+    ] }]);
+    expect(targets[0].content[0].text_elements).toEqual([{ byteRange: { start: 0, end: 9 } }]);
+    for (const wanted of targets) {
+      expect(findCodexHistoryDelivery(history, wanted).state).toBe("found");
+      for (const element of [
+        { byteRange: { start: 0, end: 9 }, placeholder: "changed" },
+        { byteRange: { start: 0, end: 8 }, placeholder: null },
+      ]) expect(findCodexHistoryDelivery(history, {
+        ...wanted, content: [{ ...wanted.content[0], text_elements: [element] }],
+      })).toEqual({ state: "unknown", reason: "conflicting-record" });
+    }
     const removed = { ...history, turns: history.turns.map(t => ({ ...t, items: t.items.filter(i => i.clientId !== targets[1].clientId) })) };
     expect(findCodexHistoryDelivery(removed, targets[1]).state).toBe("unknown");
     for (const view of ["summary", "full"] as const) {

--- a/src/lib/runtime/codexHistoryReader.ts
+++ b/src/lib/runtime/codexHistoryReader.ts
@@ -1,0 +1,294 @@
+import { isDeepStrictEqual } from "node:util";
+
+/** The host owns the connection, account, generation and RPC cancellation. */
+export type CodexHistoryRpc = (
+  method: string, params: Record<string, unknown>, timeoutMs: number,
+) => Promise<unknown>;
+
+type ObjectValue = Record<string, unknown>;
+export interface CodexHistoryIdentity { threadId: string; path: string }
+export interface CodexHistoryItem extends ObjectValue { id: string; type: string }
+export interface CodexHistoryTurn extends ObjectValue {
+  id: string;
+  items: CodexHistoryItem[];
+  itemsView: "full";
+}
+export interface CodexHistoryOptions {
+  /** Absolute deadline supplied by the existing caller; never renewed per page. */
+  deadlineAt: number;
+  maxBytes?: number;
+  /** Counts every RPC response, including metadata. */
+  maxPages?: number;
+  turnsPerPage?: number;
+  itemsPerPage?: number;
+  sortDirection?: "asc" | "desc";
+  itemsView?: "notLoaded" | "summary" | "full";
+}
+export interface CodexHistoryPage {
+  method: string;
+  turnId?: string;
+  cursor: string | null;
+  nextCursor: string | null;
+  backwardsCursor?: string | null;
+}
+type UnknownReason = "identity" | "malformed" | "cursor" | "bytes" | "pages" | "deadline" | "transport" | "not-observed" | "conflicting-record";
+export type CodexHistoryResult =
+  | { state: "complete"; identity: CodexHistoryIdentity; turns: CodexHistoryTurn[]; pages: CodexHistoryPage[]; bytes: number }
+  | { state: "unknown"; reason: UnknownReason }
+  | { state: "legacy-fallback"; reason: "unsupported" };
+
+class ReadFailure extends Error {
+  constructor(readonly reason: UnknownReason | "unsupported") { super(reason); }
+}
+function object(value: unknown): ObjectValue | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as ObjectValue : null;
+}
+function nonempty(value: unknown): value is string { return typeof value === "string" && value.length > 0; }
+function requireValue(condition: unknown, reason: UnknownReason = "malformed"): asserts condition {
+  if (!condition) throw new ReadFailure(reason);
+}
+
+/** Explicit capability errors only. Permission, persistence and network errors are unknown. */
+function unsupported(error: unknown): boolean {
+  if (object(error)?.code === -32601) return true;
+  const message = error instanceof Error ? error.message : object(error)?.message;
+  return typeof message === "string" && /^Codex app-server request failed: (?:method not found|unknown method [`'"]?thread\/(?:turns|items)\/list[`'"]?|(?:list_turns|list_items) is not supported yet)[.!]?$/i.test(message);
+}
+
+/** Counts JSON wire bytes before retaining a response. Large strings fail before encoding. */
+function jsonBytes(value: unknown, remaining: number, depth = 0): number {
+  requireValue(depth <= 64);
+  let size = 0;
+  const add = (n: number) => { size += n; requireValue(size <= remaining, "bytes"); };
+  if (typeof value === "string") {
+    requireValue(Buffer.byteLength(value) <= remaining, "bytes");
+    add(Buffer.byteLength(JSON.stringify(value)));
+  } else if (value === null || typeof value === "boolean" || typeof value === "number") {
+    requireValue(typeof value !== "number" || Number.isFinite(value));
+    add(String(value).length);
+  } else if (Array.isArray(value)) {
+    add(2);
+    for (let i = 0; i < value.length; i++) {
+      if (i) add(1);
+      add(jsonBytes(value[i], remaining - size, depth + 1));
+    }
+  } else {
+    const row = object(value);
+    requireValue(row && Object.getPrototypeOf(row) === Object.prototype);
+    add(2);
+    let first = true;
+    for (const key of Object.keys(row)) {
+      if (!first) add(1);
+      first = false;
+      add(jsonBytes(key, remaining - size, depth + 1));
+      add(1);
+      add(jsonBytes(row[key], remaining - size, depth + 1));
+    }
+  }
+  return size;
+}
+
+function validContent(value: unknown): value is ObjectValue[] {
+  return Array.isArray(value) && value.length > 0 && value.every((input) => {
+    const row = object(input);
+    if (!row) return false;
+    switch (row.type) {
+      case "text": {
+        if (typeof row.text !== "string") return false;
+        const length = Buffer.byteLength(row.text);
+        return row.text_elements === undefined || (Array.isArray(row.text_elements) && row.text_elements.every(element => {
+          const span = object(element);
+          const range = object(span?.byteRange);
+          return !!range && Number.isSafeInteger(range.start) && Number.isSafeInteger(range.end)
+            && (range.start as number) >= 0 && (range.start as number) <= (range.end as number)
+            && (range.end as number) <= length
+            && (span?.placeholder === undefined || span.placeholder === null || typeof span.placeholder === "string");
+        }));
+      }
+      case "image": return nonempty(row.url) && (row.detail === undefined || row.detail === null || ["auto", "low", "high", "original"].includes(String(row.detail)));
+      case "audio": return nonempty(row.url);
+      case "localImage": return nonempty(row.path) && (row.detail === undefined || row.detail === null || ["auto", "low", "high", "original"].includes(String(row.detail)));
+      case "localAudio": return nonempty(row.path);
+      case "skill": case "mention": return nonempty(row.path) && nonempty(row.name);
+      default: return false;
+    }
+  });
+}
+function item(value: unknown): CodexHistoryItem {
+  const row = object(value);
+  requireValue(row && nonempty(row.id) && nonempty(row.type));
+  if (row.type === "userMessage") {
+    requireValue(validContent(row.content));
+    requireValue(row.clientId === undefined || row.clientId === null || nonempty(row.clientId));
+  }
+  return row as CodexHistoryItem;
+}
+
+/**
+ * Complete means all requested pages were read, not an atomic snapshot or proof
+ * that a missing message was never delivered. No mutation, polling or cache.
+ * RPC must enforce its own frame cap: this seam receives already parsed values.
+ */
+export async function readCodexHistory(
+  rpc: CodexHistoryRpc, identity: CodexHistoryIdentity, options: CodexHistoryOptions,
+): Promise<CodexHistoryResult> {
+  try {
+    const maxBytes = options.maxBytes ?? 16 * 1024 * 1024;
+    const maxPages = options.maxPages ?? 128;
+    const turnsPerPage = options.turnsPerPage ?? 16;
+    const itemsPerPage = options.itemsPerPage ?? 32;
+    const sortDirection = options.sortDirection ?? "asc";
+    const itemsView = options.itemsView ?? "notLoaded";
+    requireValue(nonempty(identity.threadId) && nonempty(identity.path), "identity");
+    requireValue(Number.isFinite(options.deadlineAt));
+    for (const n of [maxBytes, maxPages, turnsPerPage, itemsPerPage]) requireValue(Number.isSafeInteger(n) && n > 0);
+    requireValue(turnsPerPage <= 100 && itemsPerPage <= 100);
+    requireValue(["asc", "desc"].includes(sortDirection) && ["notLoaded", "summary", "full"].includes(itemsView));
+    // Freeze caller input before the first asynchronous boundary.
+    const target = { ...identity };
+    const deadlineAt = options.deadlineAt;
+    let bytes = 0;
+    let requests = 0;
+    const pages: CodexHistoryPage[] = [];
+    const call = async (method: string, params: ObjectValue): Promise<ObjectValue> => {
+      const remainingMs = deadlineAt - Date.now();
+      requireValue(remainingMs > 0, "deadline");
+      requireValue(requests++ < maxPages, "pages");
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let response: unknown;
+      try {
+        response = await Promise.race([
+          rpc(method, params, remainingMs),
+          new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new ReadFailure("deadline")), remainingMs); }),
+        ]);
+      } catch (error) {
+        if (error instanceof ReadFailure) throw error;
+        throw new ReadFailure(unsupported(error) ? "unsupported" : "transport");
+      } finally { clearTimeout(timer); }
+      requireValue(Date.now() < deadlineAt, "deadline");
+      bytes += jsonBytes(response, maxBytes - bytes);
+      requireValue(Date.now() < deadlineAt, "deadline");
+      const result = object(response);
+      requireValue(result && !Object.hasOwn(result, "error"));
+      // Detach retained evidence from a mutable RPC fixture/transport buffer.
+      return structuredClone(result);
+    };
+    const metadata = object((await call("thread/read", { threadId: target.threadId, includeTurns: false })).thread);
+    requireValue(metadata?.id === target.threadId && metadata?.path === target.path, "identity");
+    requireValue(metadata?.ephemeral !== true, "identity");
+
+    const readPage = async (method: string, params: ObjectValue, cursor: string | null, seen: Set<string>, turnId?: string) => {
+      const result = await call(method, { ...params, cursor });
+      requireValue(result.threadId === undefined || result.threadId === target.threadId, "identity");
+      requireValue(result.turnId === undefined || result.turnId === turnId, "identity");
+      requireValue(Array.isArray(result.data));
+      // Require an explicit end marker. Omission cannot establish completeness.
+      requireValue(result.nextCursor === null || nonempty(result.nextCursor));
+      requireValue(result.backwardsCursor === undefined || result.backwardsCursor === null || nonempty(result.backwardsCursor));
+      const nextCursor = result.nextCursor as string | null;
+      if (nextCursor !== null) {
+        requireValue(result.data.length > 0 && !seen.has(nextCursor), "cursor");
+        seen.add(nextCursor);
+      }
+      pages.push({ method, ...(turnId ? { turnId } : {}), cursor, nextCursor,
+        ...(result.backwardsCursor !== undefined ? { backwardsCursor: result.backwardsCursor as string | null } : {}) });
+      return { data: result.data, nextCursor };
+    };
+    const turns: CodexHistoryTurn[] = [];
+    const turnIds = new Set<string>();
+    const turnCursors = new Set<string>();
+    let cursor: string | null = null;
+    do {
+      const page = await readPage("thread/turns/list", { threadId: target.threadId, limit: turnsPerPage, sortDirection, itemsView }, cursor, turnCursors);
+      for (const raw of page.data) {
+        const turn = object(raw);
+        requireValue(turn && nonempty(turn.id) && Array.isArray(turn.items));
+        requireValue(!turnIds.has(turn.id), "cursor");
+        turnIds.add(turn.id);
+        requireValue(["completed", "interrupted", "failed", "inProgress"].includes(String(turn.status)));
+        requireValue(turn.threadId === undefined || turn.threadId === target.threadId, "identity");
+        turn.items.forEach(item);
+        // 0.154 schema defaults omitted itemsView to full. A partial cursor
+        // from an older protocol forces a fresh item traversal from its start.
+        const view = turn.itemsView ?? (Object.hasOwn(turn, "itemsView") ? null : "full");
+        requireValue(["full", "summary", "notLoaded"].includes(String(view)));
+        requireValue(turn.itemsBackwardsCursor === undefined || turn.itemsBackwardsCursor === null || nonempty(turn.itemsBackwardsCursor));
+        let items: CodexHistoryItem[];
+        if (view === "full" && !turn.itemsBackwardsCursor) {
+          items = turn.items.map(item);
+        } else {
+          items = [];
+          const itemCursors = new Set<string>();
+          let itemCursor: string | null = null;
+          do {
+            const itemPage = await readPage("thread/items/list", { threadId: target.threadId, turnId: turn.id, limit: itemsPerPage, sortDirection: "asc" }, itemCursor, itemCursors, turn.id);
+            for (const entry of itemPage.data) {
+              const row = object(entry);
+              requireValue(row?.turnId === turn.id, "identity");
+              const canonical = item(row?.item);
+              requireValue(canonical.threadId === undefined || canonical.threadId === target.threadId, "identity");
+              items.push(canonical);
+            }
+            itemCursor = itemPage.nextCursor;
+          } while (itemCursor !== null);
+        }
+        const ids = new Set<string>();
+        for (const canonical of items) {
+          requireValue(!ids.has(canonical.id), "cursor");
+          requireValue(canonical.threadId === undefined || canonical.threadId === target.threadId, "identity");
+          requireValue(canonical.turnId === undefined || canonical.turnId === turn.id, "identity");
+          ids.add(canonical.id);
+        }
+        turns.push({ ...turn, id: turn.id, items, itemsView: "full" });
+      }
+      cursor = page.nextCursor;
+    } while (cursor !== null);
+    requireValue(Date.now() < deadlineAt, "deadline");
+    return { state: "complete", identity: target, turns, pages, bytes };
+  } catch (error) {
+    if (error instanceof ReadFailure) return error.reason === "unsupported"
+      ? { state: "legacy-fallback", reason: "unsupported" }
+      : { state: "unknown", reason: error.reason };
+    return { state: "unknown", reason: "malformed" };
+  }
+}
+
+export interface CodexHistoryDeliveryTarget {
+  clientId: string;
+  /** Exact native input frozen at admission, including attachments and markers. */
+  content: ObjectValue[];
+  /** Null explicitly means the native turn is not yet known; never omit it. */
+  turnId: string | null;
+  itemId?: string;
+}
+export type CodexHistoryDeliveryResult =
+  | { state: "found"; identity: CodexHistoryIdentity; turnId: string; item: CodexHistoryItem }
+  | Exclude<CodexHistoryResult, { state: "complete" }>;
+
+function normalizedContent(content: ObjectValue[]): ObjectValue[] {
+  return content.map((input) => {
+    if (input.type === "text") return { ...input, text_elements: input.text_elements ?? [] };
+    if (input.type === "image" || input.type === "localImage") return { ...input, detail: input.detail ?? null };
+    return input;
+  });
+}
+
+/** Absence, even after complete traversal, never authorizes resend or deletion. */
+export function findCodexHistoryDelivery(history: CodexHistoryResult, target: CodexHistoryDeliveryTarget): CodexHistoryDeliveryResult {
+  if (history.state !== "complete") return history;
+  if (!nonempty(target.clientId) || !validContent(target.content)
+      || !(target.turnId === null || nonempty(target.turnId))
+      || !(target.itemId === undefined || nonempty(target.itemId))) return { state: "unknown", reason: "malformed" };
+  const candidates = history.turns.flatMap((turn) => turn.items
+    .filter((entry) => entry.type === "userMessage" && entry.clientId === target.clientId)
+    .map((entry) => ({ turnId: turn.id, item: entry })));
+  if (!candidates.length) return { state: "unknown", reason: "not-observed" };
+  if (candidates.length !== 1) return { state: "unknown", reason: "conflicting-record" };
+  const match = candidates[0];
+  if ((target.turnId !== null && target.turnId !== match.turnId)
+      || (target.itemId !== undefined && target.itemId !== match.item.id)
+      || !isDeepStrictEqual(normalizedContent(target.content), normalizedContent(match.item.content as ObjectValue[]))) {
+    return { state: "unknown", reason: "conflicting-record" };
+  }
+  return { state: "found", identity: history.identity, ...match };
+}

--- a/src/lib/runtime/codexHistoryReader.ts
+++ b/src/lib/runtime/codexHistoryReader.ts
@@ -267,7 +267,12 @@ export type CodexHistoryDeliveryResult =
 
 function normalizedContent(content: ObjectValue[]): ObjectValue[] {
   return content.map((input) => {
-    if (input.type === "text") return { ...input, text_elements: input.text_elements ?? [] };
+    if (input.type === "text") return {
+      ...input,
+      text_elements: ((input.text_elements ?? []) as ObjectValue[]).map(span => ({
+        ...span, placeholder: span.placeholder ?? null,
+      })),
+    };
     if (input.type === "image" || input.type === "localImage") return { ...input, detail: input.detail ?? null };
     return input;
   });


### PR DESCRIPTION
Native Codex delivery reconciliation needs bounded canonical history with preserved client, payload and turn identity. This adds an injected-RPC reader and original-key lookup for #1557 under #1629, based on `22ca45579f01bb0088b753cc2cf7b84c93422f58`.

Only three new files are included: the reader, its named tests and an integration note. Metadata binds thread/path identity; turns and items paginate with byte/page/deadline bounds. Summary/partial items require full item traversal. Unsupported pagination can request the established legacy fallback; incomplete history, missing records, identity mismatch and transport errors remain unknown.

Codex 0.154 serializes omitted text-span placeholders as null. The reader normalizes those equivalent forms while preserving text, ranges, explicit placeholder strings, original keys, turn fences and attachments. A credential-free native round-trip regression fails on the original reader and passes with the fix; changed placeholders and ranges remain unknown. Seam coverage also checks both omission/null directions and frozen-input preservation.

Validation: 17 focused tests and 159 assertions pass under Bun 1.4.0, including a credential-free real Codex 0.154.0 Responses fixture, second turns/items pages, full/summary equivalence, native shared-history cutoff, cold app-server replacement, and a negative control that removes the exact persisted native history row. Removing it leaves that original key unknown while another key remains found. Aggregate Unicode bytes, large tool items, wrong identities, malformed pages and exhausted budgets are covered. TypeScript and the full-diff privacy gate pass. ESLint's documented baseline plugin crash is not counted as green.

The compressed-rollout fixture retains Codex's native SQLite history projection. It proves pagination works in that state; rebuilding a missing projection from compressed files and compression-worker scheduling remain unverified. Existing CI does not invoke this new named test or install its optional CLI, so native fixture evidence is local.

**Integration remains owed:** after voice releases the host file, the integration worker must wire this into session materialization and original-key delivery lookup, preserve existing account/generation/lifecycle fences and deadlines, and prove Viewer host replacement without another send. No existing host, journal, HTTP, UI, voice or queue files changed. This PR does not complete or close #1557 or #1629. No merge or deployment is included.
