### PR TITLE
fix(board): scale task-band cards with the camera, route review connectors, pan on wheel (#1639)

### DIFF
--- a/scripts/capture-board-geometry.ts
+++ b/scripts/capture-board-geometry.ts
@@ -419,6 +419,7 @@ async function main(): Promise<void> {
     const scanned = (seeded: string) => scannedPaths.find((candidate) => candidate === seeded || candidate.endsWith(path.basename(seeded))) ?? seeded;
     const implementer = scanned(tasks[0]!.members[0]!.path);
     const sibling = scanned(tasks[1]!.members[2]!.path);
+    const sibling2 = scanned(tasks[1]!.members[0]!.path);
 
     for (const viewportSize of [{ width: 1400, height: 900, tag: "wide" }, { width: 830, height: 600, tag: "narrow" }]) {
       const context = await browser.newContext({ viewport: { width: viewportSize.width, height: viewportSize.height }, reducedMotion: "reduce" });
@@ -454,14 +455,26 @@ async function main(): Promise<void> {
         /* 1. The frame is as tall as what it holds. */
         const overhang = flowBand.rect.y + flowBand.rect.h - flowBand.paintedBottom;
         must(overhang <= 72 * r.camera.z + 8, `${label}: the review-loop band hangs ${Math.round(overhang)}px below its last painted surface (band ${Math.round(flowBand.rect.h)}px tall, ${flowBand.members} surfaces)`);
-        /* 2. No stranded connector. A settled review loop used to draw its two
-              cycle arcs at fixed board-pixel offsets that landed nowhere near
-              the band's counter-scaled cards, leaving a squiggle floating in
-              the band's empty space. Every connector the band draws must now
-              stay within its painted content, none dangling below it. */
+        /* 2. The review connector attaches to the ACTUAL cards. It used to be
+              drawn at fixed board-pixel offsets that landed nowhere near the
+              band's cards, leaving a squiggle in the empty space. Now its two
+              endpoints touch the implementer card and the reviewer deck as they
+              are placed — including when the deck wrapped to a later row — and
+              nothing dangles below the band's content. */
         const deck = r.decks[0];
         const impl = r.nodes.find((node) => node.key === implementer);
         if (!deck || !impl) { must(false, `${label}: deck or implementer not found (deck ${Boolean(deck)}, implementer ${Boolean(impl)})`); return; }
+        const deckBox = deck.painted ?? deck.shell;
+        const nearRect = (pt: { x: number; y: number }, rc: Rect, tol = 22) => pt.x >= rc.x - tol && pt.x <= rc.x + rc.w + tol && pt.y >= rc.y - tol && pt.y <= rc.y + rc.h + tol;
+        /* Both endpoints must be on screen to judge attachment; a band taller
+           than the viewport pushes the reviewer deck past the fold, where it is
+           virtualized to a stale rect. Wrapped-row attachment is proven at that
+           density by the unit test instead. */
+        const onScreen = (rc: Rect) => rc.x + rc.w > 4 && rc.x < r.canvas.w - 4 && rc.y + rc.h > 4 && rc.y < r.canvas.h - 4;
+        if (onScreen(impl.rect) && onScreen(deckBox)) {
+          const connector = r.paths.find((p) => !p.closed && ((nearRect(p.start, impl.rect) && nearRect(p.end, deckBox)) || (nearRect(p.start, deckBox) && nearRect(p.end, impl.rect))));
+          must(connector !== undefined, `${label}: no review connector runs between the implementer card and its reviewer deck (impl at ${Math.round(impl.rect.x)},${Math.round(impl.rect.y)}, deck at ${Math.round(deckBox.x)},${Math.round(deckBox.y)})`);
+        }
         const strandMargin = 24 * r.camera.z + 12;
         const stranded = r.paths.filter((p) => p.bbox.y > flowBand.paintedBottom + strandMargin && p.bbox.y < flowBand.rect.y + flowBand.rect.h);
         must(stranded.length === 0, `${label}: ${stranded.length} connector path(s) dangle below the band's content (paintedBottom ${Math.round(flowBand.paintedBottom)}, band bottom ${Math.round(flowBand.rect.y + flowBand.rect.h)})`);
@@ -492,42 +505,47 @@ async function main(): Promise<void> {
       frames.nearSelected = { camera: r.camera, band: r.bands.find((band) => band.task === flowTask), decks: r.decks, node: r.nodes.find((node) => node.key === implementer) };
       arcChecks(r, `${tag} near selected`);
 
-      /* ---- Zoom coherence: every surface in a band scales with the camera. */
+      /* ---- Physical card scaling within one presentation mode. The operator's
+         actual complaint: a card must change size when the zoom changes. Two
+         intermediate zooms (0.8 → 0.4), both showing summary tiles, so the
+         presentation is fixed and only the camera moves. On screen every card
+         must halve, and the review deck must scale by the identical factor —
+         one coherent geometry, cards AND frames AND connectors together. */
       await page.keyboard.press("Escape");
-      await page.waitForTimeout(300);
+      await zoomTo(page, 0.8, center);
+      await page.waitForTimeout(500);
       r = await read(page);
-      const tileAt1 = r.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0).map((node) => ({ key: node.key, w: node.rect.w }));
-      const deckAt1 = r.decks[0]?.shell.w ?? 0;
-      await zoomTo(page, 0.5, center);
+      const tileAtBig = r.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0).map((node) => ({ key: node.key, w: node.rect.w }));
+      const deckAtBig = r.decks[0]?.shell.w ?? 0;
+      const bandWBig = r.bands.find((b) => b.task === flowTask)?.rect.w ?? 0;
+      await zoomTo(page, 0.4, center);
       await page.waitForTimeout(600);
       r = await read(page);
       await page.screenshot({ path: path.join(OUT_DIR, `${tag}-intermediate.png`) });
-      const tileAt05 = r.nodes.filter((node) => node.presentation === "summary");
-      const ratios = tileAt1.map((tile) => { const now = tileAt05.find((node) => node.key === tile.key); return now && now.rect.w > 0 ? now.rect.w / tile.w : null; }).filter((v): v is number => v !== null);
-      const deckRatio = r.decks[0] && deckAt1 ? r.decks[0].shell.w / deckAt1 : null;
-      frames.intermediate = { camera: r.camera, tileRatios: ratios, deckRatio };
-      /* Coherence, not a specific magnitude: the band deliberately keeps its
-         surfaces screen-constant (semantic zoom swaps chip/summary/native), so
-         what must hold is that every surface in a band obeys ONE scaling law.
-         On the base build the review deck rode the raw camera scale while its
-         sibling summary tiles held still — two coordinate systems in one row. */
+      const tileAtSmall = r.nodes.filter((node) => node.presentation === "summary");
+      const ratios = tileAtBig.map((tile) => { const now = tileAtSmall.find((node) => node.key === tile.key); return now && now.rect.w > 0 ? now.rect.w / tile.w : null; }).filter((v): v is number => v !== null);
+      const deckRatio = r.decks[0] && deckAtBig ? r.decks[0].shell.w / deckAtBig : null;
+      const bandRatio = bandWBig ? (r.bands.find((b) => b.task === flowTask)?.rect.w ?? 0) / bandWBig : null;
       const tileR = ratios.length ? ratios.reduce((a, b) => a + b, 0) / ratios.length : null;
-      must(ratios.length > 0 && Math.max(...ratios) - Math.min(...ratios) < 0.06, `${tag}: sibling tiles scaled by different amounts between 100% and 50% (${ratios.map((v) => v.toFixed(2)).join(", ")}×)`);
-      if (deckRatio !== null && tileR !== null) must(near(deckRatio, tileR, 0.08), `${tag}: the deck scaled ${deckRatio.toFixed(2)}× while its band's tiles scaled ${tileR.toFixed(2)}× — two coordinate systems in one band`);
-      /* The toolbar's own zoom-in, through a real click: the deck and the tiles
-         stay coherent with each other across that framing too. */
+      frames.intermediate = { from: 0.8, to: 0.4, tileRatios: ratios, deckRatio, bandRatio };
+      /* Physical: on screen the card halves (0.4 / 0.8 = 0.5). The base build,
+         which divided sizes by the zoom, held the tiles constant (ratio ~1). */
+      must(tileR !== null && near(tileR, 0.5, 0.06), `${tag}: a summary tile scaled ${tileR?.toFixed(2)}× on screen between 80% and 40% zoom — cards do not follow the camera`);
+      must(ratios.length > 0 && Math.max(...ratios) - Math.min(...ratios) < 0.06, `${tag}: sibling tiles scaled unevenly (${ratios.map((v) => v.toFixed(2)).join(", ")}×)`);
+      /* Coherent: the deck and the band frame scale by the same factor. */
+      if (deckRatio !== null && tileR !== null) must(near(deckRatio, tileR, 0.08), `${tag}: the deck scaled ${deckRatio.toFixed(2)}× while its tiles scaled ${tileR.toFixed(2)}× — two coordinate systems in one band`);
+      if (bandRatio !== null && tileR !== null) must(near(bandRatio, tileR, 0.08), `${tag}: the band frame scaled ${bandRatio.toFixed(2)}× while its cards scaled ${tileR.toFixed(2)}×`);
+      /* The toolbar's own zoom-in, through a real click, scales the cards too. */
       const before = r;
-      const deckBefore = before.decks[0]?.shell.w ?? 0;
       const tilesBefore = before.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0);
       await page.$eval('[aria-label="Zoom in (+)"]', (el) => (el as HTMLButtonElement).click());
       await page.waitForTimeout(500);
       r = await read(page);
       const plusRatios = tilesBefore.map((node) => { const now = r.nodes.find((entry) => entry.key === node.key); return now && now.rect.w > 0 ? now.rect.w / node.rect.w : null; }).filter((v): v is number => v !== null);
-      const plusDeck = r.decks[0] && deckBefore ? r.decks[0].shell.w / deckBefore : null;
       const plusTile = plusRatios.length ? plusRatios.reduce((a, b) => a + b, 0) / plusRatios.length : null;
-      frames.toolbarZoom = { from: before.camera.z, to: r.camera.z, tileRatios: plusRatios, deckRatio: plusDeck };
-      must(plusRatios.length > 0 && Math.max(...plusRatios) - Math.min(...plusRatios) < 0.06, `${tag}: the toolbar zoom scaled sibling tiles unevenly (${plusRatios.map((v) => v.toFixed(2)).join(", ")}×)`);
-      if (plusDeck !== null && plusTile !== null) must(near(plusDeck, plusTile, 0.08), `${tag}: after the toolbar zoom the deck scaled ${plusDeck.toFixed(2)}× while tiles scaled ${plusTile.toFixed(2)}×`);
+      const cameraRatio = r.camera.z / before.camera.z;
+      frames.toolbarZoom = { from: before.camera.z, to: r.camera.z, tileRatios: plusRatios, cameraRatio };
+      must(plusTile !== null && near(plusTile, cameraRatio, 0.06), `${tag}: the toolbar zoom went ${before.camera.z.toFixed(2)}→${r.camera.z.toFixed(2)} (×${cameraRatio.toFixed(2)}) but tiles scaled ${plusTile?.toFixed(2)}×`);
 
       /* ---- Overview: still one geometry. */
       await zoomTo(page, 0.15, center);
@@ -543,43 +561,57 @@ async function main(): Promise<void> {
       const chrome = (BAND_HEADER + BAND_PAD * 3 + BAND_ROWGAP) / r.camera.z;
       must(r.bands.filter((band) => band.members > 0 && band.rect.y >= 0 && band.rect.y + band.rect.h <= r.canvas.h).every((band) => band.rect.y + band.rect.h - band.paintedBottom <= chrome), `${tag} overview: a band hangs far below its content`);
 
-      /* ---- Click-to-open from the intermediate scale: the clicked card is
-              the one framed, and the camera settles once. */
-      await zoomTo(page, 0.5, center);
-      await page.waitForTimeout(500);
-      let target: { x: number; y: number } | null = null;
-      for (let attempt = 0; attempt < 30; attempt += 1) {
-        const node = (await read(page)).nodes.find((entry) => entry.key === sibling);
-        const canvasH = (await read(page)).canvas.h;
-        if (node && node.rect.h > 0) {
-          const delta = node.rect.y + node.rect.h / 2 - canvasH / 2;
-          if (Math.abs(delta) < 40) { target = await visiblePoint(page, `[data-scheme-summary="${sibling}"]`); break; }
+      /* ---- Click-to-open frames the EXACT clicked conversation, from every
+              zoom entry and on a repeat open. A click must land the operator on
+              the card they clicked, opened as its reader and settled once. */
+      const bringOnScreen = async (key: string): Promise<{ x: number; y: number } | null> => {
+        for (let attempt = 0; attempt < 30; attempt += 1) {
+          const reading = await read(page);
+          const node = reading.nodes.find((entry) => entry.key === key);
+          if (node && node.rect.h > 0 && node.rect.w > 0) {
+            const delta = node.rect.y + node.rect.h / 2 - reading.canvas.h / 2;
+            if (Math.abs(delta) < 50) {
+              return (await visiblePoint(page, `[data-scheme-chip="${key}"]`))
+                ?? (await visiblePoint(page, `[data-scheme-summary="${key}"]`))
+                ?? (await visiblePoint(page, `[data-scheme-node="${key}"]`));
+            }
+          }
           const at = await canvasPoint(page, 0.02, 0.5);
           await page.mouse.move(at.x, at.y);
-          await page.mouse.wheel(0, Math.max(-500, Math.min(500, delta)));
-        } else {
-          const at = await canvasPoint(page, 0.02, 0.5);
-          await page.mouse.move(at.x, at.y);
-          await page.mouse.wheel(0, 400);
+          await page.mouse.wheel(0, node && node.rect.h > 0 ? Math.max(-500, Math.min(500, node.rect.y + node.rect.h / 2 - (await read(page)).canvas.h / 2)) : 400);
+          await page.waitForTimeout(150);
         }
-        await page.waitForTimeout(160);
-      }
-      must(target !== null, `${tag}: the sibling tile could not be brought to the middle of the viewport at 50%`);
-      if (target) {
-        const before = await read(page);
-        await page.mouse.click(target.x, target.y);
-        await page.waitForTimeout(900);
+        return null;
+      };
+      const openAndVerify = async (entryZoom: number, key: string, label: string) => {
+        await page.keyboard.press("Escape");
+        await zoomTo(page, entryZoom, center);
+        await page.waitForTimeout(300);
+        const point = await bringOnScreen(key);
+        must(point !== null, `${tag} ${label}: could not bring ${key.slice(-24)} on screen at ${Math.round(entryZoom * 100)}%`);
+        if (!point) return;
+        await page.mouse.click(point.x, point.y);
+        await page.waitForTimeout(1_000);
         const settled1 = await read(page);
         await page.waitForTimeout(700);
         const settled2 = await read(page);
-        await page.screenshot({ path: path.join(OUT_DIR, `${tag}-after-click.png`) });
-        const node = settled2.nodes.find((entry) => entry.key === sibling);
-        frames.click = { before: before.camera, after: settled2.camera, node };
-        must(node !== undefined && node.rect.y >= 0 && node.rect.y + Math.min(node.rect.h, 120) <= settled2.canvas.h && node.rect.x >= -1 && node.rect.x + node.rect.w <= settled2.canvas.w + 1, `${tag}: after the click the conversation sits at ${node ? `${Math.round(node.rect.x)},${Math.round(node.rect.y)} ${Math.round(node.rect.w)}×${Math.round(node.rect.h)}` : "nowhere"} in a ${settled2.canvas.w}×${settled2.canvas.h} viewport`);
-        must(near(settled1.camera.y, settled2.camera.y, 1) && near(settled1.camera.z, settled2.camera.z, 0.001), `${tag}: the camera kept moving after the click settled (${settled1.camera.y.toFixed(0)}→${settled2.camera.y.toFixed(0)}, z ${settled1.camera.z.toFixed(2)}→${settled2.camera.z.toFixed(2)})`);
-        must(node !== undefined && node.presentation === "native", `${tag}: the clicked conversation opened as ${node?.presentation ?? "nothing"}, not as its reader`);
-        must(node !== undefined && node.rect.w * node.rect.h > 0.2 * settled2.canvas.w * settled2.canvas.h, `${tag}: the opened conversation covers ${node ? Math.round(100 * node.rect.w * node.rect.h / (settled2.canvas.w * settled2.canvas.h)) : 0}% of the viewport — too little to read`);
-      }
+        const node = settled2.nodes.find((entry) => entry.key === key);
+        (frames as Record<string, unknown>)[`click_${label}`] = { entryZoom, after: settled2.camera, node: node ? { presentation: node.presentation, rect: node.rect } : null };
+        /* The EXACT clicked conversation is on screen, as its reader. */
+        must(node !== undefined && node.presentation === "native", `${tag} ${label}: the clicked conversation opened as ${node?.presentation ?? "nothing"}, not as its reader`);
+        must(node !== undefined && node.rect.y >= -1 && node.rect.y + Math.min(node.rect.h, 140) <= settled2.canvas.h + 1 && node.rect.x >= -1 && node.rect.x + node.rect.w <= settled2.canvas.w + 1, `${tag} ${label}: the clicked conversation sits at ${node ? `${Math.round(node.rect.x)},${Math.round(node.rect.y)} ${Math.round(node.rect.w)}×${Math.round(node.rect.h)}` : "nowhere"} in ${settled2.canvas.w}×${settled2.canvas.h}`);
+        must(node !== undefined && node.rect.w * node.rect.h > 0.18 * settled2.canvas.w * settled2.canvas.h, `${tag} ${label}: the opened conversation covers ${node ? Math.round(100 * node.rect.w * node.rect.h / (settled2.canvas.w * settled2.canvas.h)) : 0}% of the viewport`);
+        /* And the camera has settled — one framing, not a drift. */
+        must(near(settled1.camera.y, settled2.camera.y, 1.5) && near(settled1.camera.z, settled2.camera.z, 0.001), `${tag} ${label}: the camera kept moving after the click settled (${settled1.camera.y.toFixed(0)}→${settled2.camera.y.toFixed(0)}, z ${settled1.camera.z.toFixed(2)}→${settled2.camera.z.toFixed(2)})`);
+      };
+      await openAndVerify(0.15, sibling, "overview-entry");
+      await openAndVerify(0.5, sibling, "intermediate-entry");
+      await openAndVerify(0.95, sibling, "near-entry");
+      /* Repeat opens: a different card, then back — each frames its own exact
+         conversation, never the one opened before. */
+      await openAndVerify(0.5, sibling2, "repeat-other");
+      await openAndVerify(0.5, sibling, "repeat-back");
+      await page.screenshot({ path: path.join(OUT_DIR, `${tag}-after-click.png`) });
 
       /* ---- Wheel routing, through Chromium's input pipeline.
 

--- a/scripts/capture-board-geometry.ts
+++ b/scripts/capture-board-geometry.ts
@@ -1,0 +1,671 @@
+/**
+ * Rendered acceptance for the board geometry defects reported on 2026-09-10
+ * (huge nearly empty task frame, squiggle review-loop arcs, cards that do not
+ * scale with the camera, a click that flies past the clicked card, a wheel
+ * that dies over band controls and collapsed cards), in a real browser against
+ * the production build:
+ *
+ *   bun run build && bun scripts/capture-board-geometry.ts
+ *
+ * Every reading is taken from the live DOM through real pointer and wheel
+ * input (Playwright's Chromium input pipeline), at a wide and a narrow
+ * viewport and at overview / intermediate / near zoom, and every check is one
+ * that reads red on the base commit and green on the fix — so this is a
+ * negative control, never a screenshot gallery.
+ *
+ * Everything runs against a synthetic home under the temp root: its own HOME,
+ * XDG dirs, TMPDIR, viewer state dir and provider homes. Nothing here touches
+ * the operator's live state and no real path appears in a frame.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { chromium, type Browser, type Page } from "playwright-core";
+
+import { createCaptureDirectory } from "./capture-directory";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const BASE = createCaptureDirectory({ envName: "BOARD_CAPTURE_DIR", prefix: "llv-issue-1641", raw: process.env.BOARD_CAPTURE_DIR, repoRoot });
+const HOME = path.join(BASE, "home");
+const OUT_DIR = path.join(BASE, "out");
+const STATE_DIR = path.join(HOME, ".config", "agent-log-viewer", "state");
+const PROJECT_NAME = "harbor";
+const REPO_DIR = path.join(HOME, "Projects", PROJECT_NAME);
+
+const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
+
+/* Band chrome sizes mirrored from taskBands BAND, for the overview allowance. */
+const BAND_HEADER = 48;
+const BAND_PAD = 16;
+const BAND_ROWGAP = 32;
+
+interface Seeded { path: string; title: string; busy: boolean }
+interface SeededTask { id: string; title: string; members: Seeded[] }
+
+/** Invented corpus: five tasks; the first holds a finished implement→review
+    loop (implementer + two reviewer rounds) so the board draws a round deck
+    and its cycle arcs inside a band. */
+const TASKS: { title: string; roles: string[]; busy: number[] }[] = [
+  { title: "Fix delivery recovery after a lost acknowledgement", roles: ["implementer", "helper", "helper"], busy: [1, 2] },
+  { title: "Repair board zoom and connector geometry", roles: ["builder", "reviewer", "critic", "designer", "scribe"], busy: [0, 1] },
+  { title: "Release notes for the September train", roles: ["writer", "editor"], busy: [] },
+  { title: "Voice boundary refuses to guess", roles: ["builder", "reviewer", "tester", "tester", "tester", "auditor"], busy: [0] },
+  { title: "Docs for the runtime host succession", roles: ["writer", "reviewer", "editor"], busy: [] },
+];
+
+function git(cwd: string, ...args: string[]): void {
+  const result = Bun.spawnSync(["git", ...args], { cwd, env: { ...process.env, HOME: path.join(BASE, "git-home"), GIT_AUTHOR_NAME: "demo", GIT_AUTHOR_EMAIL: "demo@example.invalid", GIT_COMMITTER_NAME: "demo", GIT_COMMITTER_EMAIL: "demo@example.invalid" } });
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+}
+
+function writeConversation(folder: string, id: string, title: string, body: string, busy: boolean, stamp: string): string {
+  const lines: unknown[] = [
+    { type: "user", uuid: `${id}-u1`, timestamp: stamp, cwd: REPO_DIR, sessionId: id, message: { role: "user", content: `${title}.` } },
+    { type: "assistant", uuid: `${id}-a1`, timestamp: stamp, cwd: REPO_DIR, sessionId: id, message: { role: "assistant", model: "claude-sonnet-4-5", content: [{ type: "text", text: body }] } },
+  ];
+  if (busy) lines.push({ type: "user", uuid: `${id}-u2`, timestamp: stamp, cwd: REPO_DIR, sessionId: id, message: { role: "user", content: "Continue with the next step." } });
+  else lines.push({ type: "result", subtype: "success", uuid: `${id}-r1`, timestamp: stamp, cwd: REPO_DIR, sessionId: id, is_error: false, duration_ms: 1200, num_turns: 1, result: body });
+  const file = path.join(folder, `${id}.jsonl`);
+  fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n", "utf8");
+  return file;
+}
+
+function seedHome(): { tasks: SeededTask[]; reviewers: Seeded[] } {
+  for (const dir of [REPO_DIR, OUT_DIR, path.join(BASE, "git-home"), path.join(BASE, "tmp", `claude-${process.getuid?.() ?? 1000}`), path.join(BASE, "tmux"), STATE_DIR, path.join(HOME, ".codex/sessions")]) fs.mkdirSync(dir, { recursive: true });
+  git(REPO_DIR, "init", "--initial-branch=main", ".");
+  fs.writeFileSync(path.join(REPO_DIR, "README.md"), "# harbor\n", "utf8");
+  git(REPO_DIR, "add", "README.md");
+  git(REPO_DIR, "commit", "-m", "harbor: first commit");
+  const folder = path.join(HOME, ".claude/projects", projectSlug(REPO_DIR));
+  fs.mkdirSync(folder, { recursive: true });
+  const tasks: SeededTask[] = [];
+  let serial = 0;
+  for (const [index, spec] of TASKS.entries()) {
+    const members: Seeded[] = [];
+    for (const [slot, role] of spec.roles.entries()) {
+      serial += 1;
+      const id = `${String(serial).padStart(8, "0")}-1641-4000-8000-000000000000`;
+      const title = `${role}: ${spec.title.toLowerCase()}`;
+      const busy = spec.busy.includes(slot);
+      const stamp = `2100-01-02T1${index % 9}:${String(10 + slot).padStart(2, "0")}:05.000Z`;
+      const body = `Working on it: ${title}. ` + "The transcript carries enough lines to make a reader scroll. ".repeat(400);
+      members.push({ path: writeConversation(folder, id, title, body, busy, stamp), title, busy });
+    }
+    tasks.push({ id: `task-1641-${String(index).padStart(2, "0")}`, title: spec.title, members });
+  }
+  /* Two reviewer rounds for the first task's implementer. */
+  const reviewers: Seeded[] = [];
+  for (const round of [1, 2]) {
+    serial += 1;
+    const id = `${String(serial).padStart(8, "0")}-1641-4000-8000-000000000000`;
+    const title = `reviewer round ${round}: fix delivery recovery`;
+    reviewers.push({ path: writeConversation(folder, id, title, `Round ${round} review. ` + "Finding text. ".repeat(30), false, `2100-01-02T12:${String(20 + round)}:05.000Z`), title, busy: false });
+  }
+  return { tasks, reviewers };
+}
+
+function seedState(project: string, tasks: SeededTask[], reviewers: Seeded[]): void {
+  const rows = tasks.map((task, index) => ({
+    id: task.id,
+    project,
+    status: "assigned",
+    text: `${task.title}\nInvented fixture task ${index + 1} for the geometry capture.`,
+    placement: "unplaced",
+    assignments: [...task.members, ...(index === 0 ? reviewers : [])].map((member) => ({ path: member.path, conversationId: null, panePid: null, state: "delivered", error: null, at: `2100-01-02T10:00:${String(index).padStart(2, "0")}.000Z` })),
+    createdAt: `2100-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+    updatedAt: `2100-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+  }));
+  fs.writeFileSync(path.join(STATE_DIR, "tasks.json"), JSON.stringify({ tasks: rows }, null, 2) + "\n", "utf8");
+  const implementer = tasks[0]!.members[0]!;
+  const round = (n: number, reviewer: Seeded, verdict: "REQUEST_CHANGES" | "APPROVE", findingsCount: number) => ({
+    n, reviewerPath: reviewer.path, reviewerConversationId: null, reviewerBindingId: `binding-${n}`, reviewerRole: { engine: "claude", model: "opus", effort: "high" },
+    accountId: null, attemptedAccounts: [], autoRetryCount: 0, sessionId: null, reviewerPid: null, reviewerIdentity: null, reviewerPane: null,
+    findingsPath: null, triggeredBy: "marker", readyNote: null, reviewHeadSha: "0".repeat(40), verdict, findingsCount,
+    startedAt: `2100-01-02T12:${String(20 + n)}:00.000Z`, spawnStartedAt: null, launchId: null, launchLeaseUntil: null, relayStartedAt: null,
+    relayRetryCount: 0, relayDeliveryAttempt: 0, relayDeliveryTransport: null, relayRetryAt: null, relayRetryRequiresIdempotency: false,
+    relayDelivery: null, relayPendingSettlement: null, relayHold: null, reviewedAt: `2100-01-02T12:${String(20 + n)}:30.000Z`, terminalAt: `2100-01-02T12:${String(20 + n)}:30.000Z`, relayedAt: null, error: null,
+  });
+  const flows = [{
+    id: "flow-1641-review",
+    template: "implement-review-loop",
+    project,
+    cwd: REPO_DIR,
+    implementerPath: implementer.path,
+    implementerConversationId: null,
+    roles: { implementer: { engine: "claude", model: "opus", effort: "high" }, reviewer: { engine: "claude", model: "opus", effort: "high" } },
+    reviewerFallback: null,
+    baseRef: "0".repeat(40),
+    headRef: null,
+    targetSha: null,
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "approved",
+    pausedState: null,
+    stateDetail: null,
+    rounds: [round(1, reviewers[0]!, "REQUEST_CHANGES", 2), round(2, reviewers[1]!, "APPROVE", 3)],
+    createdAt: "2100-01-02T12:20:00.000Z",
+    closedAt: null,
+  }];
+  fs.writeFileSync(path.join(STATE_DIR, "flows.json"), JSON.stringify({ schemaVersion: 3, flows }, null, 2) + "\n", "utf8");
+}
+
+function buildEnvironment(port: number): NodeJS.ProcessEnv {
+  const config = path.join(HOME, ".config");
+  const inherited = { ...process.env };
+  for (const name of Object.keys(inherited)) if (name.startsWith("LLV_") || name.startsWith("__NEXT_PRIVATE")) delete inherited[name];
+  return {
+    ...inherited,
+    NODE_ENV: "production",
+    HOME,
+    TMPDIR: path.join(BASE, "tmp"),
+    TMUX_TMPDIR: path.join(BASE, "tmux"),
+    XDG_CONFIG_HOME: config,
+    XDG_CACHE_HOME: path.join(BASE, "cache"),
+    XDG_RUNTIME_DIR: path.join(BASE, "runtime"),
+    LLV_STATE_DIR: STATE_DIR,
+    LLV_CLAUDE_HOME: path.join(HOME, ".claude"),
+    LLV_CODEX_HOME: path.join(HOME, ".codex"),
+    LLV_ACCOUNT_CONTROLLER_DISABLED: "1",
+    LLV_REAPER_ENABLED: "0",
+    NEXT_TELEMETRY_DISABLED: "1",
+    PORT: String(port),
+    TZ: "UTC", LANG: "C.UTF-8", LC_ALL: "C.UTF-8", USER: "demo", LOGNAME: "demo", SHELL: "/bin/sh",
+  };
+}
+
+const CAPTURE_BUN = process.env.BOARD_CAPTURE_BUN?.trim() || process.execPath;
+
+function startServer(port: number): ChildProcess {
+  return spawn(CAPTURE_BUN, ["--bun", "node_modules/.bin/next", "start", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: repoRoot, env: buildEnvironment(port), stdio: ["ignore", "inherit", "inherit"],
+  });
+}
+
+async function waitForServer(url: string, child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`production server exited with ${child.exitCode}`);
+    try { if ((await fetch(`${url}/api/files`)).ok) return; } catch { /* booting */ }
+    await Bun.sleep(400);
+  }
+  throw new Error("production server did not become ready");
+}
+
+interface FilesPayload { files?: { path?: string; project?: string }[]; tasks?: { id: string }[] }
+
+async function waitForBoard(baseUrl: string, expectTasks: boolean): Promise<{ project: string; cards: number }> {
+  const deadline = Date.now() + 180_000;
+  let cards = 0;
+  while (Date.now() < deadline) {
+    const payload = await (await fetch(`${baseUrl}/api/files`)).json() as FilesPayload;
+    const files = payload.files ?? [];
+    cards = files.length;
+    const project = files.find((file) => file.project)?.project;
+    if (project && cards > 0 && (!expectTasks || (payload.tasks ?? []).length > 0)) return { project, cards };
+    await Bun.sleep(2_000);
+  }
+  throw new Error(`scan never produced a board window; last saw ${cards} cards`);
+}
+
+async function stop(server: ChildProcess | null): Promise<void> {
+  if (!server) return;
+  server.kill("SIGTERM");
+  const deadline = Date.now() + 20_000;
+  while (server.exitCode === null && Date.now() < deadline) await Bun.sleep(200);
+  if (server.exitCode === null) server.kill("SIGKILL");
+}
+
+const seedInit = () => {
+  Object.defineProperty(globalThis, "EventSource", { configurable: true, value: undefined });
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("llv_lang", "en");
+  localStorage.setItem("llvSound", "0");
+  localStorage.setItem("llvSchemeMode", "select");
+};
+
+/* ------------------------------------------------------------------------- */
+/* In-page readings                                                           */
+/* ------------------------------------------------------------------------- */
+
+interface Rect { x: number; y: number; w: number; h: number }
+interface Reading {
+  camera: { x: number; y: number; z: number };
+  canvas: Rect;
+  bands: { id: string; task: string | null; rect: Rect; paintedBottom: number; paintedRight: number; members: number }[];
+  nodes: { key: string; presentation: string | null; rect: Rect; band: string | null }[];
+  decks: { key: string; shell: Rect; painted: Rect | null }[];
+  /** Every connector path drawn in the world: its endpoints and bbox. */
+  paths: { start: { x: number; y: number }; end: { x: number; y: number }; bbox: Rect; closed: boolean }[];
+}
+
+/** Runs inside the page. Screen coordinates are relative to the board canvas. */
+function readBoard(): Reading {
+  const viewport = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!;
+  const canvasRect = viewport.getBoundingClientRect();
+  const rel = (r: DOMRect): Rect => ({ x: r.x - canvasRect.x, y: r.y - canvasRect.y, w: r.width, h: r.height });
+  const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
+  const m = /translate\(([-\d.e+]+)px, ([-\d.e+]+)px\) scale\(([\d.e+-]+)\)/.exec(world.style.transform)!;
+  const camera = { x: parseFloat(m[1]!), y: parseFloat(m[2]!), z: parseFloat(m[3]!) };
+  const bandOf = (el: Element | null): string | null => el?.closest("[data-scheme-band]")?.getAttribute("data-scheme-band") ?? null;
+  const nodeEls = Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-node]"));
+  const nodes = nodeEls.map((el) => ({ key: el.getAttribute("data-scheme-node")!, presentation: el.getAttribute("data-scheme-node-presentation"), rect: rel(el.getBoundingClientRect()), band: null as string | null }));
+  const decks = nodeEls.filter((el) => el.getAttribute("data-scheme-node")!.startsWith("deck::")).map((el) => {
+    const chip = el.querySelector<HTMLElement>("[data-review-deck-collapsed]");
+    return { key: el.getAttribute("data-scheme-node")!, shell: rel(el.getBoundingClientRect()), painted: chip ? rel(chip.getBoundingClientRect()) : null };
+  });
+  const bands = Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-band]")).map((band) => {
+    const rect = rel(band.getBoundingClientRect());
+    const bandId = band.getAttribute("data-scheme-band");
+    /* What the band visibly holds: every node shell inside its box (a collapsed
+       deck counted at its chip, never the shell it reserves), plus the mirror
+       tiles and the «+ Agent» add row — every painted surface, so an empty
+       frame below the content cannot hide behind an uncounted control. */
+    let paintedBottom = rect.y;
+    let paintedRight = rect.x;
+    let members = 0;
+    for (const node of nodes) {
+      const inside = node.rect.x >= rect.x - 1 && node.rect.x + node.rect.w <= rect.x + rect.w + 1 && node.rect.y >= rect.y - 1 && node.rect.y + node.rect.h <= rect.y + rect.h + 1;
+      if (!inside) continue;
+      node.band = bandId;
+      members += 1;
+      const deck = decks.find((entry) => entry.key === node.key);
+      const painted = deck?.painted ?? node.rect;
+      paintedBottom = Math.max(paintedBottom, painted.y + painted.h);
+      paintedRight = Math.max(paintedRight, painted.x + painted.w);
+    }
+    for (const el of Array.from(band.querySelectorAll<HTMLElement>("[data-scheme-band-add], [data-scheme-mirror], [data-scheme-continuation]"))) {
+      const r = rel(el.getBoundingClientRect());
+      if (r.w <= 0 || r.h <= 0) continue;
+      paintedBottom = Math.max(paintedBottom, r.y + r.h);
+      paintedRight = Math.max(paintedRight, r.x + r.w);
+    }
+    return { id: bandId!, task: band.getAttribute("data-scheme-band-task"), rect, paintedBottom, paintedRight, members };
+  });
+  const paths: Reading["paths"] = [];
+  for (const svg of Array.from(world.querySelectorAll("svg"))) {
+    for (const el of Array.from(svg.querySelectorAll("path"))) {
+      const d = el.getAttribute("d") ?? "";
+      const numbers = d.replace(/[A-Za-z,]/g, " ").trim().split(/\s+/).map(Number).filter((n) => Number.isFinite(n));
+      if (numbers.length < 4) continue;
+      const box = el.getBoundingClientRect();
+      if (box.width === 0 && box.height === 0) continue;
+      const toScreen = (wx: number, wy: number) => ({ x: camera.x + wx * camera.z, y: camera.y + wy * camera.z });
+      paths.push({ start: toScreen(numbers[0]!, numbers[1]!), end: toScreen(numbers[numbers.length - 2]!, numbers[numbers.length - 1]!), bbox: rel(box), closed: /z\s*$/i.test(d) });
+    }
+  }
+  return { camera, canvas: { x: 0, y: 0, w: canvasRect.width, h: canvasRect.height }, bands, nodes, decks, paths };
+}
+
+const read = (page: Page) => page.evaluate(readBoard);
+
+async function canvasPoint(page: Page, fx: number, fy: number): Promise<{ x: number; y: number }> {
+  return page.evaluate(([fx, fy]) => {
+    const box = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
+    return { x: box.x + box.width * fx, y: box.y + box.height * fy };
+  }, [fx, fy] as const);
+}
+
+/** Ctrl+wheel — the event a trackpad pinch delivers — dispatched at the
+    element under the pointer so the camera's own listener reads it. Chromium's
+    input pipeline turns a modifier wheel into browser zoom before the page
+    sees it, which is why this one gesture is synthesized. */
+async function zoomTo(page: Page, target: number, at: { x: number; y: number }): Promise<number> {
+  await page.mouse.move(at.x, at.y);
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const current = (await read(page)).camera.z;
+    if (Math.abs(current - target) / target < 0.01) return current;
+    const deltaY = -Math.log(target / current) / 0.0022;
+    await page.evaluate(([x, y, delta]) => {
+      const el = document.elementFromPoint(x, y) ?? document.body;
+      el.dispatchEvent(new WheelEvent("wheel", { deltaY: delta, ctrlKey: true, bubbles: true, cancelable: true, clientX: x, clientY: y }));
+    }, [at.x, at.y, deltaY] as const);
+    await page.waitForTimeout(250);
+  }
+  return (await read(page)).camera.z;
+}
+
+/** A point inside both the element and the board viewport, or null. */
+async function visiblePoint(page: Page, selector: string): Promise<{ x: number; y: number } | null> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector<HTMLElement>(sel);
+    const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const left = Math.max(r.left, canvas.left + 2), right = Math.min(r.right, canvas.right - 2);
+    const top = Math.max(r.top, canvas.top + 2), bottom = Math.min(r.bottom, canvas.bottom - 2);
+    if (right - left < 4 || bottom - top < 4) return null;
+    return { x: (left + right) / 2, y: (top + bottom) / 2 };
+  }, selector);
+}
+
+/** The first element matching the selector whose centre lands inside the board
+    viewport — DOM order may put an off-screen match first. */
+async function firstVisiblePoint(page: Page, selector: string): Promise<{ x: number; y: number } | null> {
+  return page.evaluate((sel) => {
+    const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
+    for (const el of Array.from(document.querySelectorAll<HTMLElement>(sel))) {
+      const r = el.getBoundingClientRect();
+      const left = Math.max(r.left, canvas.left + 2), right = Math.min(r.right, canvas.right - 2);
+      const top = Math.max(r.top, canvas.top + 2), bottom = Math.min(r.bottom, canvas.bottom - 2);
+      if (right - left < 4 || bottom - top < 4) continue;
+      return { x: (left + right) / 2, y: (top + bottom) / 2 };
+    }
+    return null;
+  }, selector);
+}
+
+async function elementCenter(page: Page, selector: string): Promise<{ x: number; y: number } | null> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector<HTMLElement>(sel);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) return null;
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  }, selector);
+}
+
+/** A plain wheel at a screen point; reports how the camera and the nearest
+    scrolling feed answered it. */
+async function wheelAt(page: Page, at: { x: number; y: number }, deltaY = 240): Promise<{ cameraDy: number; feedDy: number }> {
+  const before = await page.evaluate(() => Array.from(document.querySelectorAll<HTMLElement>("[data-log-feed-scroller]")).map((el) => el.scrollTop));
+  const cam0 = (await read(page)).camera;
+  await page.mouse.move(at.x, at.y);
+  await page.mouse.wheel(0, deltaY);
+  await page.waitForTimeout(350);
+  const cam1 = (await read(page)).camera;
+  const after = await page.evaluate(() => Array.from(document.querySelectorAll<HTMLElement>("[data-log-feed-scroller]")).map((el) => el.scrollTop));
+  const feedDy = Math.max(0, ...after.map((v, i) => Math.abs(v - (before[i] ?? 0))));
+  return { cameraDy: cam1.y - cam0.y, feedDy };
+}
+
+const near = (a: number, b: number, tol: number) => Math.abs(a - b) <= tol;
+
+/* ------------------------------------------------------------------------- */
+
+async function main(): Promise<void> {
+  const { tasks, reviewers } = seedHome();
+  const failures: string[] = [];
+  const must = (ok: boolean, message: string) => { if (!ok) failures.push(message); };
+  const port = 3_000 + (process.pid % 900);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let server: ChildProcess | null = null;
+  let browser: Browser | null = null;
+  const report: Record<string, unknown> = { commit: Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot }).stdout.toString().trim() };
+  try {
+    /* The project key is the scan's own. A throwaway boot names it; the
+       state (tasks and the review flow) is then written and the server booted
+       again on a fresh state directory, so the flow is present at first read. */
+    server = startServer(port);
+    await waitForServer(baseUrl, server);
+    const { project } = await waitForBoard(baseUrl, false);
+    await stop(server);
+    server = null;
+    fs.rmSync(STATE_DIR, { recursive: true, force: true });
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    seedState(project, tasks, reviewers);
+    server = startServer(port);
+    await waitForServer(baseUrl, server);
+    await waitForBoard(baseUrl, true);
+    await Bun.sleep(4_000);
+    const flowsLoaded = ((await (await fetch(`${baseUrl}/api/files`)).json()) as { flows?: unknown[] }).flows?.length ?? 0;
+    must(flowsLoaded === 1, `the server loaded ${flowsLoaded} flows; the review loop is not on the board`);
+    browser = await chromium.launch({ args: ["--no-sandbox", "--disable-dev-shm-usage"] });
+
+    const scannedPaths = ((await (await fetch(`${baseUrl}/api/files`)).json()) as FilesPayload).files!.map((file) => file.path!);
+    const scanned = (seeded: string) => scannedPaths.find((candidate) => candidate === seeded || candidate.endsWith(path.basename(seeded))) ?? seeded;
+    const implementer = scanned(tasks[0]!.members[0]!.path);
+    const sibling = scanned(tasks[1]!.members[2]!.path);
+
+    for (const viewportSize of [{ width: 1400, height: 900, tag: "wide" }, { width: 830, height: 600, tag: "narrow" }]) {
+      const context = await browser.newContext({ viewport: { width: viewportSize.width, height: viewportSize.height }, reducedMotion: "reduce" });
+      await context.addInitScript(seedInit);
+      const page = await context.newPage();
+      await page.goto(`${baseUrl}/#p=${encodeURIComponent(project)}`, { waitUntil: "domcontentloaded", timeout: 120_000 });
+      await page.waitForSelector("[data-scheme-band]", { timeout: 120_000 });
+      await page.waitForTimeout(2_500);
+      const tag = viewportSize.tag;
+      const frames: Record<string, unknown> = {};
+      const center = await canvasPoint(page, 0.5, 0.5);
+
+
+      /** Plain wheel (real input) until the flow band's header sits under the toolbar. */
+      const panToBand = async (taskId: string) => {
+        for (let attempt = 0; attempt < 30; attempt += 1) {
+          const bands = (await read(page)).bands;
+          const band = bands.find((entry) => entry.task === taskId);
+          if (!band) return false;
+          const delta = band.rect.y - 72;
+          if (Math.abs(delta) < 3) return true;
+          const at = await canvasPoint(page, 0.02, 0.5);
+          await page.mouse.move(at.x, at.y);
+          await page.mouse.wheel(0, Math.max(-600, Math.min(600, delta)));
+          await page.waitForTimeout(160);
+        }
+        return false;
+      };
+      const flowTask = tasks[0]!.id;
+      const arcChecks = (r: Reading, label: string) => {
+        const flowBand = r.bands.find((band) => band.task === flowTask);
+        if (!flowBand) { must(false, `${label}: the review-loop task has no band`); return; }
+        /* 1. The frame is as tall as what it holds. */
+        const overhang = flowBand.rect.y + flowBand.rect.h - flowBand.paintedBottom;
+        must(overhang <= 72 * r.camera.z + 8, `${label}: the review-loop band hangs ${Math.round(overhang)}px below its last painted surface (band ${Math.round(flowBand.rect.h)}px tall, ${flowBand.members} surfaces)`);
+        /* 2. No stranded connector. A settled review loop used to draw its two
+              cycle arcs at fixed board-pixel offsets that landed nowhere near
+              the band's counter-scaled cards, leaving a squiggle floating in
+              the band's empty space. Every connector the band draws must now
+              stay within its painted content, none dangling below it. */
+        const deck = r.decks[0];
+        const impl = r.nodes.find((node) => node.key === implementer);
+        if (!deck || !impl) { must(false, `${label}: deck or implementer not found (deck ${Boolean(deck)}, implementer ${Boolean(impl)})`); return; }
+        const strandMargin = 24 * r.camera.z + 12;
+        const stranded = r.paths.filter((p) => p.bbox.y > flowBand.paintedBottom + strandMargin && p.bbox.y < flowBand.rect.y + flowBand.rect.h);
+        must(stranded.length === 0, `${label}: ${stranded.length} connector path(s) dangle below the band's content (paintedBottom ${Math.round(flowBand.paintedBottom)}, band bottom ${Math.round(flowBand.rect.y + flowBand.rect.h)})`);
+        for (const p of r.paths.filter((path) => !path.closed && path.bbox.h > 4 && path.bbox.w > 4)) {
+          const reach = Math.hypot(p.end.x - p.start.x, p.end.y - p.start.y);
+          must(p.bbox.w <= Math.abs(p.end.x - p.start.x) + reach * 0.6 + 40, `${label}: a connector folds back on itself (endpoints ${Math.round(Math.abs(p.end.x - p.start.x))}px apart, bbox ${Math.round(p.bbox.w)}px wide)`);
+        }
+        must(deck.painted === null || deck.shell.h <= deck.painted.h + 12, `${label}: the collapsed deck reserves ${Math.round(deck.shell.h)}px for a ${Math.round(deck.painted?.h ?? 0)}px chip`);
+        must(r.bands.every((band) => band.rect.x + band.rect.w <= r.canvas.w + 1), `${label}: a band runs past the right edge of the viewport`);
+      };
+
+      /* ---- Near zoom, nothing selected: the operator's screenshot. */
+      await zoomTo(page, 1, center);
+      await page.keyboard.press("Escape");
+      must(await panToBand(flowTask), `${tag}: the review-loop band could not be brought under the toolbar at 100%`);
+      await page.waitForTimeout(300);
+      let r = await read(page);
+      await page.screenshot({ path: path.join(OUT_DIR, `${tag}-near.png`) });
+      frames.near = { camera: r.camera, band: r.bands.find((band) => band.task === flowTask), decks: r.decks, arcs: r.paths.filter((p) => !p.closed).slice(0, 12) };
+      arcChecks(r, `${tag} near`);
+
+      /* ---- The implementer opened: the reader sits where the tile was. */
+      const implTile = await visiblePoint(page, `[data-scheme-node="${implementer}"]`);
+      must(implTile !== null, `${tag}: the implementer tile is not on screen at 100%`);
+      if (implTile) { await page.mouse.click(implTile.x, implTile.y); await page.waitForTimeout(1_500); }
+      r = await read(page);
+      await page.screenshot({ path: path.join(OUT_DIR, `${tag}-near-selected.png`) });
+      frames.nearSelected = { camera: r.camera, band: r.bands.find((band) => band.task === flowTask), decks: r.decks, node: r.nodes.find((node) => node.key === implementer) };
+      arcChecks(r, `${tag} near selected`);
+
+      /* ---- Zoom coherence: every surface in a band scales with the camera. */
+      await page.keyboard.press("Escape");
+      await page.waitForTimeout(300);
+      r = await read(page);
+      const tileAt1 = r.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0).map((node) => ({ key: node.key, w: node.rect.w }));
+      const deckAt1 = r.decks[0]?.shell.w ?? 0;
+      await zoomTo(page, 0.5, center);
+      await page.waitForTimeout(600);
+      r = await read(page);
+      await page.screenshot({ path: path.join(OUT_DIR, `${tag}-intermediate.png`) });
+      const tileAt05 = r.nodes.filter((node) => node.presentation === "summary");
+      const ratios = tileAt1.map((tile) => { const now = tileAt05.find((node) => node.key === tile.key); return now && now.rect.w > 0 ? now.rect.w / tile.w : null; }).filter((v): v is number => v !== null);
+      const deckRatio = r.decks[0] && deckAt1 ? r.decks[0].shell.w / deckAt1 : null;
+      frames.intermediate = { camera: r.camera, tileRatios: ratios, deckRatio };
+      /* Coherence, not a specific magnitude: the band deliberately keeps its
+         surfaces screen-constant (semantic zoom swaps chip/summary/native), so
+         what must hold is that every surface in a band obeys ONE scaling law.
+         On the base build the review deck rode the raw camera scale while its
+         sibling summary tiles held still — two coordinate systems in one row. */
+      const tileR = ratios.length ? ratios.reduce((a, b) => a + b, 0) / ratios.length : null;
+      must(ratios.length > 0 && Math.max(...ratios) - Math.min(...ratios) < 0.06, `${tag}: sibling tiles scaled by different amounts between 100% and 50% (${ratios.map((v) => v.toFixed(2)).join(", ")}×)`);
+      if (deckRatio !== null && tileR !== null) must(near(deckRatio, tileR, 0.08), `${tag}: the deck scaled ${deckRatio.toFixed(2)}× while its band's tiles scaled ${tileR.toFixed(2)}× — two coordinate systems in one band`);
+      /* The toolbar's own zoom-in, through a real click: the deck and the tiles
+         stay coherent with each other across that framing too. */
+      const before = r;
+      const deckBefore = before.decks[0]?.shell.w ?? 0;
+      const tilesBefore = before.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0);
+      await page.$eval('[aria-label="Zoom in (+)"]', (el) => (el as HTMLButtonElement).click());
+      await page.waitForTimeout(500);
+      r = await read(page);
+      const plusRatios = tilesBefore.map((node) => { const now = r.nodes.find((entry) => entry.key === node.key); return now && now.rect.w > 0 ? now.rect.w / node.rect.w : null; }).filter((v): v is number => v !== null);
+      const plusDeck = r.decks[0] && deckBefore ? r.decks[0].shell.w / deckBefore : null;
+      const plusTile = plusRatios.length ? plusRatios.reduce((a, b) => a + b, 0) / plusRatios.length : null;
+      frames.toolbarZoom = { from: before.camera.z, to: r.camera.z, tileRatios: plusRatios, deckRatio: plusDeck };
+      must(plusRatios.length > 0 && Math.max(...plusRatios) - Math.min(...plusRatios) < 0.06, `${tag}: the toolbar zoom scaled sibling tiles unevenly (${plusRatios.map((v) => v.toFixed(2)).join(", ")}×)`);
+      if (plusDeck !== null && plusTile !== null) must(near(plusDeck, plusTile, 0.08), `${tag}: after the toolbar zoom the deck scaled ${plusDeck.toFixed(2)}× while tiles scaled ${plusTile.toFixed(2)}×`);
+
+      /* ---- Overview: still one geometry. */
+      await zoomTo(page, 0.15, center);
+      await page.waitForTimeout(600);
+      r = await read(page);
+      await page.screenshot({ path: path.join(OUT_DIR, `${tag}-overview.png`) });
+      frames.overview = { camera: r.camera, bands: r.bands.map((band) => ({ id: band.id, h: band.rect.h, members: band.members, overhang: band.rect.y + band.rect.h - band.paintedBottom })) };
+      /* The counter-scaled band chrome (header + pads + one row gap) grows as
+         1/zoom, so the allowance does too; a regression that reserved a full
+         deck box would add ~810/zoom on top and blow past it. Only bands fully
+         inside the viewport are judged — a virtualized off-screen band reports
+         no members and a meaningless painted bottom. */
+      const chrome = (BAND_HEADER + BAND_PAD * 3 + BAND_ROWGAP) / r.camera.z;
+      must(r.bands.filter((band) => band.members > 0 && band.rect.y >= 0 && band.rect.y + band.rect.h <= r.canvas.h).every((band) => band.rect.y + band.rect.h - band.paintedBottom <= chrome), `${tag} overview: a band hangs far below its content`);
+
+      /* ---- Click-to-open from the intermediate scale: the clicked card is
+              the one framed, and the camera settles once. */
+      await zoomTo(page, 0.5, center);
+      await page.waitForTimeout(500);
+      let target: { x: number; y: number } | null = null;
+      for (let attempt = 0; attempt < 30; attempt += 1) {
+        const node = (await read(page)).nodes.find((entry) => entry.key === sibling);
+        const canvasH = (await read(page)).canvas.h;
+        if (node && node.rect.h > 0) {
+          const delta = node.rect.y + node.rect.h / 2 - canvasH / 2;
+          if (Math.abs(delta) < 40) { target = await visiblePoint(page, `[data-scheme-summary="${sibling}"]`); break; }
+          const at = await canvasPoint(page, 0.02, 0.5);
+          await page.mouse.move(at.x, at.y);
+          await page.mouse.wheel(0, Math.max(-500, Math.min(500, delta)));
+        } else {
+          const at = await canvasPoint(page, 0.02, 0.5);
+          await page.mouse.move(at.x, at.y);
+          await page.mouse.wheel(0, 400);
+        }
+        await page.waitForTimeout(160);
+      }
+      must(target !== null, `${tag}: the sibling tile could not be brought to the middle of the viewport at 50%`);
+      if (target) {
+        const before = await read(page);
+        await page.mouse.click(target.x, target.y);
+        await page.waitForTimeout(900);
+        const settled1 = await read(page);
+        await page.waitForTimeout(700);
+        const settled2 = await read(page);
+        await page.screenshot({ path: path.join(OUT_DIR, `${tag}-after-click.png`) });
+        const node = settled2.nodes.find((entry) => entry.key === sibling);
+        frames.click = { before: before.camera, after: settled2.camera, node };
+        must(node !== undefined && node.rect.y >= 0 && node.rect.y + Math.min(node.rect.h, 120) <= settled2.canvas.h && node.rect.x >= -1 && node.rect.x + node.rect.w <= settled2.canvas.w + 1, `${tag}: after the click the conversation sits at ${node ? `${Math.round(node.rect.x)},${Math.round(node.rect.y)} ${Math.round(node.rect.w)}×${Math.round(node.rect.h)}` : "nowhere"} in a ${settled2.canvas.w}×${settled2.canvas.h} viewport`);
+        must(near(settled1.camera.y, settled2.camera.y, 1) && near(settled1.camera.z, settled2.camera.z, 0.001), `${tag}: the camera kept moving after the click settled (${settled1.camera.y.toFixed(0)}→${settled2.camera.y.toFixed(0)}, z ${settled1.camera.z.toFixed(2)}→${settled2.camera.z.toFixed(2)})`);
+        must(node !== undefined && node.presentation === "native", `${tag}: the clicked conversation opened as ${node?.presentation ?? "nothing"}, not as its reader`);
+        must(node !== undefined && node.rect.w * node.rect.h > 0.2 * settled2.canvas.w * settled2.canvas.h, `${tag}: the opened conversation covers ${node ? Math.round(100 * node.rect.w * node.rect.h / (settled2.canvas.w * settled2.canvas.h)) : 0}% of the viewport — too little to read`);
+      }
+
+      /* ---- Wheel routing, through Chromium's input pipeline.
+
+         The board pans over everything but a scroll container it can hand the
+         wheel to. Pan probes run with the reader CLOSED and the board at an
+         intermediate scale, so every band control is short and on screen; the
+         feed probe then opens a reader and scrolls its text. */
+      const wheel: Record<string, { cameraDy: number; feedDy: number }> = {};
+      const panTopMemberBand = async () => {
+        for (let attempt = 0; attempt < 30; attempt += 1) {
+          const bands = (await read(page)).bands.filter((entry) => entry.members > 0);
+          if (!bands.length) return false;
+          const top = bands.reduce((a, b) => (a.rect.y < b.rect.y ? a : b));
+          const delta = top.rect.y - 88;
+          if (Math.abs(delta) < 4) return true;
+          const at = await canvasPoint(page, 0.02, 0.5);
+          await page.mouse.move(at.x, at.y);
+          await page.mouse.wheel(0, Math.max(-600, Math.min(600, delta)));
+          await page.waitForTimeout(150);
+        }
+        return true;
+      };
+      await page.keyboard.press("Escape");
+      await zoomTo(page, 0.5, center);
+      const bandBackground = async () => {
+        const reading = await read(page);
+        const band = reading.bands.find((entry) => entry.members > 0 && entry.rect.y + 40 >= 0 && entry.rect.y + 80 < reading.canvas.h);
+        if (!band) return null;
+        const c = await canvasPoint(page, 0, 0);
+        return { x: c.x + band.rect.x + 6, y: c.y + Math.min(band.rect.y + band.rect.h - 12, band.rect.y + 120) };
+      };
+      const panProbes: [string, () => Promise<{ x: number; y: number } | null>][] = [
+        ["band background", bandBackground],
+        ["Details", () => firstVisiblePoint(page, "[data-scheme-band-details]")],
+        ["+ Agent", () => firstVisiblePoint(page, "[data-scheme-band-add]")],
+        ["collapsed card", () => firstVisiblePoint(page, "[data-scheme-summary]")],
+      ];
+      for (const [name, locate] of panProbes) {
+        await panTopMemberBand();
+        const at = await locate();
+        if (!at) { wheel[name] = { cameraDy: Number.NaN, feedDy: Number.NaN }; must(false, `${tag}: wheel probe "${name}" has no target on screen`); continue; }
+        wheel[name] = await wheelAt(page, at);
+      }
+
+      /* The open reader keeps the wheel for its own text. Near zoom so the
+         selected conversation is its native reader; the wheel scrolls UP, away
+         from the feed's pinned tail, and the camera must not move. */
+      await zoomTo(page, 1, center);
+      await panTopMemberBand();
+      const summary = await firstVisiblePoint(page, "[data-scheme-summary]");
+      if (summary) { await page.mouse.click(summary.x, summary.y); await page.waitForTimeout(1_400); }
+      let feed: { x: number; y: number } | null = null;
+      for (let pan = 0; pan < 24 && !feed; pan += 1) {
+        feed = await firstVisiblePoint(page, '[data-scheme-node-presentation="native"] [data-log-feed-scroller]');
+        if (feed) break;
+        const at = await canvasPoint(page, 0.02, 0.5);
+        await page.mouse.move(at.x, at.y);
+        await page.mouse.wheel(0, 300);
+        await page.waitForTimeout(150);
+      }
+      if (!feed) { wheel["open reader feed"] = { cameraDy: Number.NaN, feedDy: Number.NaN }; must(false, `${tag}: the open reader's feed is not on screen`); }
+      else wheel["open reader feed"] = await wheelAt(page, feed, -300);
+      frames.wheel = wheel;
+      for (const name of ["band background", "Details", "+ Agent", "collapsed card"]) {
+        const got = wheel[name]!;
+        must(got.cameraDy < -100, `${tag}: a wheel over ${name} moved the camera ${Math.round(got.cameraDy)}px — the board did not pan`);
+      }
+      must(wheel["open reader feed"]!.feedDy > 20 && Math.abs(wheel["open reader feed"]!.cameraDy) < 1, `${tag}: a wheel over the open reader's text scrolled the feed ${Math.round(wheel["open reader feed"]!.feedDy)}px and moved the camera ${Math.round(wheel["open reader feed"]!.cameraDy)}px`);
+
+      report[tag] = frames;
+      await context.close();
+    }
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+    await stop(server);
+  }
+  report.failures = failures;
+  fs.writeFileSync(path.join(OUT_DIR, "measurements.json"), JSON.stringify(report, null, 2) + "\n", "utf8");
+  console.log(`measurements: ${path.join(OUT_DIR, "measurements.json")}`);
+  console.log(`frames: ${OUT_DIR}`);
+  if (failures.length) {
+    process.exitCode = 1;
+    console.error(`board geometry acceptance FAILED (${failures.length}):\n  ${failures.join("\n  ")}`);
+  } else {
+    console.log("board geometry acceptance passed at wide and narrow viewports across overview, intermediate and near zoom.");
+  }
+}
+
+await main();

--- a/scripts/capture-board-geometry.ts
+++ b/scripts/capture-board-geometry.ts
@@ -7,11 +7,15 @@
  *
  *   bun run build && bun scripts/capture-board-geometry.ts
  *
- * Every reading is taken from the live DOM through real pointer and wheel
- * input (Playwright's Chromium input pipeline), at a wide and a narrow
- * viewport and at overview / intermediate / near zoom, and every check is one
- * that reads red on the base commit and green on the fix — so this is a
- * negative control, never a screenshot gallery.
+ * Every reading is taken from the live DOM, and every input goes through
+ * Playwright's Chromium input pipeline — real pointer clicks, real wheel,
+ * real Control+wheel for the pinch path, real keyboard for the zoom keys, a
+ * real viewport resize and a real reload for the restore path — at a wide and
+ * a narrow viewport and at overview / intermediate / near zoom. One probe per
+ * camera mutation path: wheel/pinch, toolbar, absolute 100%, fit current, fit
+ * all, click-to-open, keyboard navigation, resize, restore. Every check is one
+ * that reads red on the base commit and green on the fix — a negative control,
+ * never a screenshot gallery.
  *
  * Everything runs against a synthetic home under the temp root: its own HOME,
  * XDG dirs, TMPDIR, viewer state dir and provider homes. Nothing here touches
@@ -35,10 +39,13 @@ const REPO_DIR = path.join(HOME, "Projects", PROJECT_NAME);
 
 const projectSlug = (cwd: string) => cwd.replace(/[^A-Za-z0-9]/g, "-");
 
-/* Band chrome sizes mirrored from taskBands BAND, for the overview allowance. */
+/* Band chrome sizes mirrored from taskBands BAND, for the overview allowance,
+   and the two band framings the fit buttons land on. */
 const BAND_HEADER = 48;
 const BAND_PAD = 16;
 const BAND_ROWGAP = 32;
+const BAND_FIT_CURRENT_Z = 0.58;
+const BAND_FIT_ALL_Z = 0.2;
 
 interface Seeded { path: string; title: string; busy: boolean }
 interface SeededTask { id: string; title: string; members: Seeded[] }
@@ -232,14 +239,20 @@ const seedInit = () => {
 /* ------------------------------------------------------------------------- */
 
 interface Rect { x: number; y: number; w: number; h: number }
+interface Pt { x: number; y: number }
 interface Reading {
   camera: { x: number; y: number; z: number };
   canvas: Rect;
+  /** The world box (the transformed layer) in board pixels. */
+  world: { w: number; h: number };
   bands: { id: string; task: string | null; rect: Rect; paintedBottom: number; paintedRight: number; members: number }[];
   nodes: { key: string; presentation: string | null; rect: Rect; band: string | null }[];
-  decks: { key: string; shell: Rect; painted: Rect | null }[];
-  /** Every connector path drawn in the world: its endpoints and bbox. */
-  paths: { start: { x: number; y: number }; end: { x: number; y: number }; bbox: Rect; closed: boolean }[];
+  decks: { key: string; shell: Rect; painted: Rect | null; expanded: boolean }[];
+  /** The ⟳ flow hubs on the board, as painted. */
+  hubs: { flow: string; rect: Rect }[];
+  /** Every connector path drawn in the world: endpoints, bbox and a screen-
+      space sampling along it, so "on the connector" can be measured. */
+  paths: { start: Pt; end: Pt; bbox: Rect; closed: boolean; samples: Pt[] }[];
 }
 
 /** Runs inside the page. Screen coordinates are relative to the board canvas. */
@@ -250,12 +263,12 @@ function readBoard(): Reading {
   const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
   const m = /translate\(([-\d.e+]+)px, ([-\d.e+]+)px\) scale\(([\d.e+-]+)\)/.exec(world.style.transform)!;
   const camera = { x: parseFloat(m[1]!), y: parseFloat(m[2]!), z: parseFloat(m[3]!) };
-  const bandOf = (el: Element | null): string | null => el?.closest("[data-scheme-band]")?.getAttribute("data-scheme-band") ?? null;
+  const toScreen = (wx: number, wy: number): Pt => ({ x: camera.x + wx * camera.z, y: camera.y + wy * camera.z });
   const nodeEls = Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-node]"));
   const nodes = nodeEls.map((el) => ({ key: el.getAttribute("data-scheme-node")!, presentation: el.getAttribute("data-scheme-node-presentation"), rect: rel(el.getBoundingClientRect()), band: null as string | null }));
   const decks = nodeEls.filter((el) => el.getAttribute("data-scheme-node")!.startsWith("deck::")).map((el) => {
     const chip = el.querySelector<HTMLElement>("[data-review-deck-collapsed]");
-    return { key: el.getAttribute("data-scheme-node")!, shell: rel(el.getBoundingClientRect()), painted: chip ? rel(chip.getBoundingClientRect()) : null };
+    return { key: el.getAttribute("data-scheme-node")!, shell: rel(el.getBoundingClientRect()), painted: chip ? rel(chip.getBoundingClientRect()) : null, expanded: Boolean(el.querySelector("[data-review-deck-collapse]")) };
   });
   const bands = Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-band]")).map((band) => {
     const rect = rel(band.getBoundingClientRect());
@@ -285,51 +298,61 @@ function readBoard(): Reading {
     }
     return { id: bandId!, task: band.getAttribute("data-scheme-band-task"), rect, paintedBottom, paintedRight, members };
   });
+  /* The ⟳ hub buttons: by their data attribute, or — on a build predating it —
+     by the glyph they carry, so the base commit can be measured too. */
+  const hubEls = Array.from(document.querySelectorAll<HTMLElement>("[data-flow-hub]"));
+  const hubs = (hubEls.length ? hubEls : Array.from(document.querySelectorAll<HTMLElement>("button[data-scheme-ui]")).filter((el) => (el.textContent ?? "").includes("⟳")))
+    .map((el) => ({ flow: el.getAttribute("data-flow-hub") ?? "", rect: rel(el.getBoundingClientRect()) }));
   const paths: Reading["paths"] = [];
   for (const svg of Array.from(world.querySelectorAll("svg"))) {
-    for (const el of Array.from(svg.querySelectorAll("path"))) {
+    for (const el of Array.from(svg.querySelectorAll<SVGPathElement>("path"))) {
       const d = el.getAttribute("d") ?? "";
       const numbers = d.replace(/[A-Za-z,]/g, " ").trim().split(/\s+/).map(Number).filter((n) => Number.isFinite(n));
       if (numbers.length < 4) continue;
       const box = el.getBoundingClientRect();
       if (box.width === 0 && box.height === 0) continue;
-      const toScreen = (wx: number, wy: number) => ({ x: camera.x + wx * camera.z, y: camera.y + wy * camera.z });
-      paths.push({ start: toScreen(numbers[0]!, numbers[1]!), end: toScreen(numbers[numbers.length - 2]!, numbers[numbers.length - 1]!), bbox: rel(box), closed: /z\s*$/i.test(d) });
+      const samples: Pt[] = [];
+      try {
+        const length = el.getTotalLength();
+        for (let i = 0; i <= 80; i += 1) {
+          const point = el.getPointAtLength((length * i) / 80);
+          samples.push(toScreen(point.x, point.y));
+        }
+      } catch { /* not a measurable path */ }
+      paths.push({ start: toScreen(numbers[0]!, numbers[1]!), end: toScreen(numbers[numbers.length - 2]!, numbers[numbers.length - 1]!), bbox: rel(box), closed: /z\s*$/i.test(d), samples });
     }
   }
-  return { camera, canvas: { x: 0, y: 0, w: canvasRect.width, h: canvasRect.height }, bands, nodes, decks, paths };
+  return { camera, canvas: { x: 0, y: 0, w: canvasRect.width, h: canvasRect.height }, world: { w: world.offsetWidth, h: world.offsetHeight }, bands, nodes, decks, hubs, paths };
 }
 
 const read = (page: Page) => page.evaluate(readBoard);
 
-async function canvasPoint(page: Page, fx: number, fy: number): Promise<{ x: number; y: number }> {
+async function canvasPoint(page: Page, fx: number, fy: number): Promise<Pt> {
   return page.evaluate(([fx, fy]) => {
     const box = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
     return { x: box.x + box.width * fx, y: box.y + box.height * fy };
   }, [fx, fy] as const);
 }
 
-/** Ctrl+wheel — the event a trackpad pinch delivers — dispatched at the
-    element under the pointer so the camera's own listener reads it. Chromium's
-    input pipeline turns a modifier wheel into browser zoom before the page
-    sees it, which is why this one gesture is synthesized. */
-async function zoomTo(page: Page, target: number, at: { x: number; y: number }): Promise<number> {
+/** Control+wheel through Chromium's real input pipeline — the event a trackpad
+    pinch delivers — with the pointer at `at`, repeated until the camera reads
+    within 1% of the target. */
+async function zoomTo(page: Page, target: number, at: Pt): Promise<number> {
   await page.mouse.move(at.x, at.y);
-  for (let attempt = 0; attempt < 8; attempt += 1) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
     const current = (await read(page)).camera.z;
     if (Math.abs(current - target) / target < 0.01) return current;
     const deltaY = -Math.log(target / current) / 0.0022;
-    await page.evaluate(([x, y, delta]) => {
-      const el = document.elementFromPoint(x, y) ?? document.body;
-      el.dispatchEvent(new WheelEvent("wheel", { deltaY: delta, ctrlKey: true, bubbles: true, cancelable: true, clientX: x, clientY: y }));
-    }, [at.x, at.y, deltaY] as const);
+    await page.keyboard.down("Control");
+    await page.mouse.wheel(0, deltaY);
+    await page.keyboard.up("Control");
     await page.waitForTimeout(250);
   }
   return (await read(page)).camera.z;
 }
 
 /** A point inside both the element and the board viewport, or null. */
-async function visiblePoint(page: Page, selector: string): Promise<{ x: number; y: number } | null> {
+async function visiblePoint(page: Page, selector: string): Promise<Pt | null> {
   return page.evaluate((sel) => {
     const el = document.querySelector<HTMLElement>(sel);
     const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
@@ -344,7 +367,7 @@ async function visiblePoint(page: Page, selector: string): Promise<{ x: number; 
 
 /** The first element matching the selector whose centre lands inside the board
     viewport — DOM order may put an off-screen match first. */
-async function firstVisiblePoint(page: Page, selector: string): Promise<{ x: number; y: number } | null> {
+async function firstVisiblePoint(page: Page, selector: string): Promise<Pt | null> {
   return page.evaluate((sel) => {
     const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
     for (const el of Array.from(document.querySelectorAll<HTMLElement>(sel))) {
@@ -358,31 +381,97 @@ async function firstVisiblePoint(page: Page, selector: string): Promise<{ x: num
   }, selector);
 }
 
-async function elementCenter(page: Page, selector: string): Promise<{ x: number; y: number } | null> {
-  return page.evaluate((sel) => {
-    const el = document.querySelector<HTMLElement>(sel);
-    if (!el) return null;
-    const r = el.getBoundingClientRect();
-    if (r.width <= 0 || r.height <= 0) return null;
-    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
-  }, selector);
-}
-
-/** A plain wheel at a screen point; reports how the camera and the nearest
-    scrolling feed answered it. */
-async function wheelAt(page: Page, at: { x: number; y: number }, deltaY = 240): Promise<{ cameraDy: number; feedDy: number }> {
-  const before = await page.evaluate(() => Array.from(document.querySelectorAll<HTMLElement>("[data-log-feed-scroller]")).map((el) => el.scrollTop));
+/** A plain wheel at a screen point; reports how the camera, the nearest
+    conversation feed and any generic scroll box under the pointer answered. */
+async function wheelAt(page: Page, at: Pt, deltaY = 240): Promise<{ cameraDy: number; feedDy: number; scrollerDy: number }> {
+  const scrollTops = () => page.evaluate(([x, y]) => {
+    const feeds = Array.from(document.querySelectorAll<HTMLElement>("[data-log-feed-scroller]")).map((el) => el.scrollTop);
+    /* The generic scroll box under the pointer, found without any selector the
+       board could special-case: the nearest ancestor that overflows vertically
+       in an auto/scroll container. */
+    let scroller = 0;
+    for (let el = document.elementFromPoint(x, y) as HTMLElement | null; el; el = el.parentElement) {
+      if (el.hasAttribute("data-log-feed-scroller")) break;
+      const overflowY = getComputedStyle(el).overflowY;
+      if (el.scrollHeight > el.clientHeight + 1 && (overflowY === "auto" || overflowY === "scroll")) { scroller = el.scrollTop; break; }
+    }
+    return { feeds, scroller };
+  }, [at.x, at.y] as const);
+  const before = await scrollTops();
   const cam0 = (await read(page)).camera;
   await page.mouse.move(at.x, at.y);
   await page.mouse.wheel(0, deltaY);
   await page.waitForTimeout(350);
   const cam1 = (await read(page)).camera;
-  const after = await page.evaluate(() => Array.from(document.querySelectorAll<HTMLElement>("[data-log-feed-scroller]")).map((el) => el.scrollTop));
-  const feedDy = Math.max(0, ...after.map((v, i) => Math.abs(v - (before[i] ?? 0))));
-  return { cameraDy: cam1.y - cam0.y, feedDy };
+  const after = await scrollTops();
+  const feedDy = Math.max(0, ...after.feeds.map((v, i) => Math.abs(v - (before.feeds[i] ?? 0))));
+  return { cameraDy: cam1.y - cam0.y, feedDy, scrollerDy: Math.abs(after.scroller - before.scroller) };
+}
+
+/** A real click at the centre of a toolbar control. Playwright's own `click`
+    scrolls the target into view first, and the board viewport answers any
+    scroll by resetting itself (a focused runtime control must never scroll the
+    camera's origin), so the two fight; the mouse click needs no scrolling. The
+    browser's own hit test decides who receives it — the element under the
+    point is recorded so an intercepting overlay would show in the report. */
+async function clickControl(page: Page, selector: string): Promise<string | null> {
+  const target = await page.evaluate((sel) => {
+    const el = document.querySelector<HTMLElement>(sel);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const x = r.x + r.width / 2, y = r.y + r.height / 2;
+    const hit = document.elementFromPoint(x, y);
+    return { x, y, hitIsTarget: hit === el || el.contains(hit), hit: hit ? `${hit.tagName.toLowerCase()}${hit.getAttribute("aria-label") ? `[${hit.getAttribute("aria-label")}]` : ""}` : "none" };
+  }, selector);
+  if (!target) return `no control matches ${selector}`;
+  await page.mouse.click(target.x, target.y);
+  return target.hitIsTarget ? null : `${selector} is covered by ${target.hit}`;
+}
+
+/** The shell's attention island covers the board toolbar's right end at narrow
+    desktop widths (#1643) — a shell defect, not board geometry. A toolbar probe
+    it covers is recorded under this key and the same camera path is proven
+    through its keyboard equivalent instead, so the cover is never silent and
+    never counted as a geometry failure. */
+const ATTENTION_COVER = /\[\d+ waiting\]/;
+
+/** Hands keyboard focus back to the page. A toolbar button keeps focus after
+    a real click and the board's zoom keys defer to a focused control, exactly
+    as they defer to a focused input; the probes press keys as an operator
+    whose focus is on the board, not on the button they just clicked. */
+const blurActive = (page: Page) => page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+
+/** Plain wheel (real input) downward from the current position until the
+    first element matching the selector has a point inside the board viewport.
+    A surface outside the viewport is virtualized to a zero rect, so it cannot
+    be steered at: the search walks down in steps shorter than the viewport and
+    reads the real rect once the surface is drawn. */
+async function bringSelectorOnScreen(page: Page, selector: string): Promise<Pt | null> {
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    const point = await firstVisiblePoint(page, selector);
+    /* Visible AND the browser's own hit test agrees — a control that has just
+       entered at the bottom of the viewport can sit under the minimap, and a
+       click there would drive the camera instead of the control. */
+    if (point && await page.evaluate(([x, y, sel]) => { const hit = document.elementFromPoint(x, y); const el = document.querySelector(sel); return Boolean(hit && el && (hit === el || el.contains(hit))); }, [point.x, point.y, selector] as const)) return point;
+    const target = await page.evaluate((sel) => {
+      const el = document.querySelector<HTMLElement>(sel);
+      const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) return null;
+      return r.top + r.height / 2 - (canvas.top + canvas.height / 2);
+    }, selector);
+    const at = await canvasPoint(page, 0.02, 0.5);
+    await page.mouse.move(at.x, at.y);
+    await page.mouse.wheel(0, target === null ? 250 : Math.max(-500, Math.min(500, target)));
+    await page.waitForTimeout(150);
+  }
+  return null;
 }
 
 const near = (a: number, b: number, tol: number) => Math.abs(a - b) <= tol;
+const inside = (pt: Pt, rc: Rect) => pt.x >= rc.x && pt.x <= rc.x + rc.w && pt.y >= rc.y && pt.y <= rc.y + rc.h;
+const overlaps = (a: Rect, b: Rect, slack = 0) => a.x + slack < b.x + b.w && b.x + slack < a.x + a.w && a.y + slack < b.y + b.h && b.y + slack < a.y + a.h;
 
 /* ------------------------------------------------------------------------- */
 
@@ -432,6 +521,13 @@ async function main(): Promise<void> {
       const frames: Record<string, unknown> = {};
       const center = await canvasPoint(page, 0.5, 0.5);
 
+      /** The document rule of the band board: whenever the band stack fits the
+          viewport horizontally, the camera's left edge is the viewport's — no
+          dead canvas beside the bands. Asserted after every camera path. */
+      const documentRule = (r: Reading, label: string) => {
+        if (r.world.w * r.camera.z <= r.canvas.w + 0.5) must(near(r.camera.x, 0, 1), `${label}: the band stack fits the viewport but the camera sits at x=${r.camera.x.toFixed(1)} — ${Math.round(Math.abs(r.camera.x))}px of dead canvas beside the bands`);
+        else must(r.camera.x <= 0.5 && r.camera.x + r.world.w * r.camera.z >= r.canvas.w - 0.5, `${label}: the band stack is wider than the viewport yet the camera shows past its edge (x=${r.camera.x.toFixed(1)}, stack ${Math.round(r.world.w * r.camera.z)}px in ${r.canvas.w}px)`);
+      };
 
       /** Plain wheel (real input) until the flow band's header sits under the toolbar. */
       const panToBand = async (taskId: string) => {
@@ -465,7 +561,7 @@ async function main(): Promise<void> {
         const impl = r.nodes.find((node) => node.key === implementer);
         if (!deck || !impl) { must(false, `${label}: deck or implementer not found (deck ${Boolean(deck)}, implementer ${Boolean(impl)})`); return; }
         const deckBox = deck.painted ?? deck.shell;
-        const nearRect = (pt: { x: number; y: number }, rc: Rect, tol = 22) => pt.x >= rc.x - tol && pt.x <= rc.x + rc.w + tol && pt.y >= rc.y - tol && pt.y <= rc.y + rc.h + tol;
+        const nearRect = (pt: Pt, rc: Rect, tol = 22) => pt.x >= rc.x - tol && pt.x <= rc.x + rc.w + tol && pt.y >= rc.y - tol && pt.y <= rc.y + rc.h + tol;
         /* Both endpoints must be on screen to judge attachment; a band taller
            than the viewport pushes the reviewer deck past the fold, where it is
            virtualized to a stale rect. Wrapped-row attachment is proven at that
@@ -474,6 +570,20 @@ async function main(): Promise<void> {
         if (onScreen(impl.rect) && onScreen(deckBox)) {
           const connector = r.paths.find((p) => !p.closed && ((nearRect(p.start, impl.rect) && nearRect(p.end, deckBox)) || (nearRect(p.start, deckBox) && nearRect(p.end, impl.rect))));
           must(connector !== undefined, `${label}: no review connector runs between the implementer card and its reviewer deck (impl at ${Math.round(impl.rect.x)},${Math.round(impl.rect.y)}, deck at ${Math.round(deckBox.x)},${Math.round(deckBox.y)})`);
+          /* 3. The ⟳ hub — the clickable face of the same relationship — sits
+                ON that connector, and covers no card but the two it joins. The
+                free board's corridor formula put it level with arcs that are
+                not drawn here: straddling the deck chip on a wide board, inside
+                an unrelated helper card once the deck wrapped on a narrow one. */
+          const hub = r.hubs[0];
+          if (!hub) must(false, `${label}: the review loop has no ⟳ hub on the board`);
+          else if (connector) {
+            const hubCenter = { x: hub.rect.x + hub.rect.w / 2, y: hub.rect.y + hub.rect.h / 2 };
+            const gap = Math.min(...connector.samples.map((pt) => Math.hypot(pt.x - hubCenter.x, pt.y - hubCenter.y)));
+            must(gap <= 4 + 3 * r.camera.z, `${label}: the ⟳ hub sits ${Math.round(gap)}px off the review connector`);
+            const covered = r.nodes.filter((node) => node.key !== impl.key && node.key !== deck.key && node.rect.w > 0 && onScreen(node.rect) && overlaps(hub.rect, node.rect, 1));
+            must(covered.length === 0, `${label}: the ⟳ hub covers ${covered.length} card(s) that are not its endpoints (hub at ${Math.round(hubCenter.x)},${Math.round(hubCenter.y)}; first ${covered[0]?.key.slice(-24)})`);
+          }
         }
         const strandMargin = 24 * r.camera.z + 12;
         const stranded = r.paths.filter((p) => p.bbox.y > flowBand.paintedBottom + strandMargin && p.bbox.y < flowBand.rect.y + flowBand.rect.h);
@@ -482,8 +592,9 @@ async function main(): Promise<void> {
           const reach = Math.hypot(p.end.x - p.start.x, p.end.y - p.start.y);
           must(p.bbox.w <= Math.abs(p.end.x - p.start.x) + reach * 0.6 + 40, `${label}: a connector folds back on itself (endpoints ${Math.round(Math.abs(p.end.x - p.start.x))}px apart, bbox ${Math.round(p.bbox.w)}px wide)`);
         }
-        must(deck.painted === null || deck.shell.h <= deck.painted.h + 12, `${label}: the collapsed deck reserves ${Math.round(deck.shell.h)}px for a ${Math.round(deck.painted?.h ?? 0)}px chip`);
+        must(deck.painted === null || deck.shell.h <= deck.painted.h + 1, `${label}: the collapsed deck reserves ${Math.round(deck.shell.h)}px for a ${Math.round(deck.painted?.h ?? 0)}px chip`);
         must(r.bands.every((band) => band.rect.x + band.rect.w <= r.canvas.w + 1), `${label}: a band runs past the right edge of the viewport`);
+        documentRule(r, label);
       };
 
       /* ---- Near zoom, nothing selected: the operator's screenshot. */
@@ -493,8 +604,60 @@ async function main(): Promise<void> {
       await page.waitForTimeout(300);
       let r = await read(page);
       await page.screenshot({ path: path.join(OUT_DIR, `${tag}-near.png`) });
-      frames.near = { camera: r.camera, band: r.bands.find((band) => band.task === flowTask), decks: r.decks, arcs: r.paths.filter((p) => !p.closed).slice(0, 12) };
+      frames.near = { camera: r.camera, band: r.bands.find((band) => band.task === flowTask), decks: r.decks, hubs: r.hubs, arcs: r.paths.filter((p) => !p.closed).slice(0, 12).map(({ samples: _samples, ...rest }) => rest) };
       arcChecks(r, `${tag} near`);
+
+      /* ---- Deck disclosure, both directions, on the settled (terminal) deck.
+              A manual expand must re-open the deck's full footprint in its
+              band — the band grows and nothing overlaps — and the collapse
+              that follows must hand the chip height back. The toggle is a real
+              click on the chip and on the deck's fold control; the layout
+              hears it through the deck-disclosure event. */
+      {
+        const before = r;
+        const deckKey = before.decks[0]?.key;
+        const bandNodes = (reading: Reading) => reading.nodes.filter((node) => node.band === (reading.bands.find((band) => band.task === flowTask)?.id ?? "") && node.rect.w > 0 && node.rect.h > 0);
+        const noOverlap = (reading: Reading, label: string) => {
+          const list = bandNodes(reading);
+          for (let i = 0; i < list.length; i += 1) for (let j = i + 1; j < list.length; j += 1) must(!overlaps(list[i]!.rect, list[j]!.rect, 2), `${label}: ${list[i]!.key.slice(-20)} overlaps ${list[j]!.key.slice(-20)} after a deck toggle`);
+        };
+        /* On the narrow board the review band is taller than the viewport at
+           100%, so the chip is wheeled into view first. */
+        const chip = await bringSelectorOnScreen(page, "[data-review-deck-collapsed]");
+        r = await read(page);
+        if (!chip || !deckKey) must(false, `${tag}: the collapsed deck chip could not be brought on screen to expand`);
+        else {
+          await page.mouse.click(chip.x, chip.y);
+          await page.waitForTimeout(1_500);
+          const expanded = await read(page);
+          await page.screenshot({ path: path.join(OUT_DIR, `${tag}-deck-expanded.png`) });
+          const deckNow = expanded.decks.find((entry) => entry.key === deckKey);
+          const bandNow = expanded.bands.find((band) => band.task === flowTask);
+          const bandBefore = before.bands.find((band) => band.task === flowTask)!;
+          must(deckNow?.expanded === true, `${tag}: clicking the chip did not expand the deck`);
+          must((deckNow?.shell.h ?? 0) > 300 * expanded.camera.z, `${tag}: the expanded deck reserves only ${Math.round(deckNow?.shell.h ?? 0)}px — the band did not re-open its footprint`);
+          must((bandNow?.rect.h ?? 0) > bandBefore.rect.h + 200 * expanded.camera.z, `${tag}: the band grew from ${Math.round(bandBefore.rect.h)} to ${Math.round(bandNow?.rect.h ?? 0)}px on expand — the deck does not fit`);
+          must(deckNow !== undefined && bandNow !== undefined && deckNow.shell.y + deckNow.shell.h <= bandNow.rect.y + bandNow.rect.h + 1, `${tag}: the expanded deck spills below its band`);
+          noOverlap(expanded, `${tag} deck expanded`);
+          documentRule(expanded, `${tag} deck expanded`);
+          const fold = await bringSelectorOnScreen(page, "[data-review-deck-collapse]");
+          if (!fold) must(false, `${tag}: the expanded deck's fold control is not on screen`);
+          else {
+            await page.mouse.click(fold.x, fold.y);
+            await page.waitForTimeout(1_600);
+            const collapsed = await read(page);
+            const deckBack = collapsed.decks.find((entry) => entry.key === deckKey);
+            const bandBack = collapsed.bands.find((band) => band.task === flowTask);
+            must(deckBack?.painted !== null && deckBack !== undefined && deckBack.shell.h <= deckBack.painted!.h + 1, `${tag}: after collapsing again the deck reserves ${Math.round(deckBack?.shell.h ?? 0)}px for its chip`);
+            must(near(bandBack?.rect.h ?? 0, bandBefore.rect.h, 2), `${tag}: the band did not return to ${Math.round(bandBefore.rect.h)}px after collapse (now ${Math.round(bandBack?.rect.h ?? 0)})`);
+            noOverlap(collapsed, `${tag} deck collapsed`);
+          }
+          frames.disclosure = { bandBefore: bandBefore.rect.h, bandExpanded: bandNow?.rect.h, deckExpanded: deckNow?.shell.h };
+        }
+        await panToBand(flowTask);
+        r = await read(page);
+        arcChecks(r, `${tag} near after disclosure round-trip`);
+      }
 
       /* ---- The implementer opened: the reader sits where the tile was. */
       const implTile = await visiblePoint(page, `[data-scheme-node="${implementer}"]`);
@@ -535,17 +698,54 @@ async function main(): Promise<void> {
       /* Coherent: the deck and the band frame scale by the same factor. */
       if (deckRatio !== null && tileR !== null) must(near(deckRatio, tileR, 0.08), `${tag}: the deck scaled ${deckRatio.toFixed(2)}× while its tiles scaled ${tileR.toFixed(2)}× — two coordinate systems in one band`);
       if (bandRatio !== null && tileR !== null) must(near(bandRatio, tileR, 0.08), `${tag}: the band frame scaled ${bandRatio.toFixed(2)}× while its cards scaled ${tileR.toFixed(2)}×`);
-      /* The toolbar's own zoom-in, through a real click, scales the cards too. */
-      const before = r;
-      const tilesBefore = before.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0);
-      await page.$eval('[aria-label="Zoom in (+)"]', (el) => (el as HTMLButtonElement).click());
-      await page.waitForTimeout(500);
-      r = await read(page);
-      const plusRatios = tilesBefore.map((node) => { const now = r.nodes.find((entry) => entry.key === node.key); return now && now.rect.w > 0 ? now.rect.w / node.rect.w : null; }).filter((v): v is number => v !== null);
-      const plusTile = plusRatios.length ? plusRatios.reduce((a, b) => a + b, 0) / plusRatios.length : null;
-      const cameraRatio = r.camera.z / before.camera.z;
-      frames.toolbarZoom = { from: before.camera.z, to: r.camera.z, tileRatios: plusRatios, cameraRatio };
-      must(plusTile !== null && near(plusTile, cameraRatio, 0.06), `${tag}: the toolbar zoom went ${before.camera.z.toFixed(2)}→${r.camera.z.toFixed(2)} (×${cameraRatio.toFixed(2)}) but tiles scaled ${plusTile?.toFixed(2)}×`);
+      documentRule(r, `${tag} after pinch zoom`);
+
+      /* ---- Every other camera mutation path, each through real input, each
+              scaling the cards by exactly the camera's own factor and each
+              landing on the document rule: the toolbar buttons (a real click),
+              absolute 100% (the «1» key), fit current («0»), fit all (Shift+0),
+              and the zoom keys. */
+      const tilesOf = (reading: Reading) => reading.nodes.filter((node) => node.presentation === "summary" && node.rect.w > 0);
+      const scaledLike = (before: Reading, after: Reading, label: string) => {
+        const pairs = tilesOf(before).map((node) => { const now = after.nodes.find((entry) => entry.key === node.key); return now && now.rect.w > 0 ? now.rect.w / node.rect.w : null; }).filter((v): v is number => v !== null);
+        const tile = pairs.length ? pairs.reduce((a, b) => a + b, 0) / pairs.length : null;
+        const cameraRatio = after.camera.z / before.camera.z;
+        (frames as Record<string, unknown>)[`path_${label}`] = { from: before.camera, to: after.camera, tileRatios: pairs, cameraRatio };
+        must(tile !== null && near(tile, cameraRatio, 0.06), `${tag} ${label}: the camera went ${before.camera.z.toFixed(2)}→${after.camera.z.toFixed(2)} (×${cameraRatio.toFixed(2)}) but tiles scaled ${tile?.toFixed(2)}×`);
+        documentRule(after, `${tag} ${label}`);
+      };
+      const shellCovered: string[] = [];
+      const mutate = async (label: string, act: () => Promise<string | null | void>) => {
+        const before = await read(page);
+        const covered = await act();
+        if (covered && ATTENTION_COVER.test(covered)) { shellCovered.push(`${label}: ${covered}`); return before; }
+        if (covered) must(false, `${tag} ${label}: ${covered}`);
+        await page.waitForTimeout(600);
+        const after = await read(page);
+        scaledLike(before, after, label);
+        return after;
+      };
+      await mutate("toolbar zoom in", () => clickControl(page, '[aria-label="Zoom in (+)"]'));
+      await mutate("toolbar zoom out", () => clickControl(page, '[aria-label="Zoom out (−)"]'));
+      await blurActive(page);
+      let after = await mutate("absolute 100% (1)", () => page.keyboard.press("1"));
+      must(near(after.camera.z, 1, 0.001), `${tag}: the «1» key left the camera at ${after.camera.z.toFixed(3)}`);
+      after = await mutate("fit current (0)", () => page.keyboard.press("0"));
+      must(near(after.camera.z, BAND_FIT_CURRENT_Z, 0.001) && near(after.camera.y, 0, 1), `${tag}: fit current framed z=${after.camera.z.toFixed(2)} y=${after.camera.y.toFixed(0)}`);
+      await mutate("zoom key +", () => page.keyboard.press("+"));
+      await mutate("zoom key -", () => page.keyboard.press("-"));
+      /* Fit all drops to the chip presentation on purpose, so the tile ratio
+         does not apply; the camera and the document rule do. */
+      {
+        const covered = await clickControl(page, '[aria-label^="Fit all content"]');
+        if (covered && ATTENTION_COVER.test(covered)) { shellCovered.push(`fit all: ${covered}`); await blurActive(page); await page.keyboard.press("Shift+0"); }
+        else if (covered) must(false, `${tag} fit all: ${covered}`);
+      }
+      await page.waitForTimeout(600);
+      after = await read(page);
+      must(near(after.camera.z, BAND_FIT_ALL_Z, 0.001) && near(after.camera.y, 0, 1), `${tag}: fit all framed z=${after.camera.z.toFixed(2)} y=${after.camera.y.toFixed(0)}`);
+      documentRule(after, `${tag} fit all`);
+      frames.shellCoveredToolbar = shellCovered;
 
       /* ---- Overview: still one geometry. */
       await zoomTo(page, 0.15, center);
@@ -553,19 +753,32 @@ async function main(): Promise<void> {
       r = await read(page);
       await page.screenshot({ path: path.join(OUT_DIR, `${tag}-overview.png`) });
       frames.overview = { camera: r.camera, bands: r.bands.map((band) => ({ id: band.id, h: band.rect.h, members: band.members, overhang: band.rect.y + band.rect.h - band.paintedBottom })) };
-      /* The counter-scaled band chrome (header + pads + one row gap) grows as
-         1/zoom, so the allowance does too; a regression that reserved a full
-         deck box would add ~810/zoom on top and blow past it. Only bands fully
-         inside the viewport are judged — a virtualized off-screen band reports
-         no members and a meaningless painted bottom. */
-      const chrome = (BAND_HEADER + BAND_PAD * 3 + BAND_ROWGAP) / r.camera.z;
+      /* The band chrome (header + pads + one row gap) scales with the camera,
+         so the allowance does too; a regression that reserved a full deck box
+         would add ~810 × zoom on top and blow past it. Only bands fully inside
+         the viewport are judged — a virtualized off-screen band reports no
+         members and a meaningless painted bottom. */
+      const chrome = (BAND_HEADER + BAND_PAD * 3 + BAND_ROWGAP) * r.camera.z + 4;
       must(r.bands.filter((band) => band.members > 0 && band.rect.y >= 0 && band.rect.y + band.rect.h <= r.canvas.h).every((band) => band.rect.y + band.rect.h - band.paintedBottom <= chrome), `${tag} overview: a band hangs far below its content`);
+      documentRule(r, `${tag} overview`);
 
       /* ---- Click-to-open frames the EXACT clicked conversation, from every
               zoom entry and on a repeat open. A click must land the operator on
-              the card they clicked, opened as its reader and settled once. */
-      const bringOnScreen = async (key: string): Promise<{ x: number; y: number } | null> => {
-        for (let attempt = 0; attempt < 30; attempt += 1) {
+              the card they clicked, opened as its reader, framed the way the
+              camera promised — head near the top, whole when it fits, inside
+              the viewport across — and settled once. */
+      /** Wheel the conversation's surface to the middle of the viewport. A
+          surface outside the viewport is virtualized to a zero rect and gives
+          no direction, so the search first returns to the top of the stack
+          and then walks down in steps shorter than the viewport. */
+      const bringOnScreen = async (key: string): Promise<Pt | null> => {
+        const at = await canvasPoint(page, 0.02, 0.5);
+        const measurable = async () => { const node = (await read(page)).nodes.find((entry) => entry.key === key); return Boolean(node && node.rect.h > 0 && node.rect.w > 0); };
+        if (!(await measurable())) {
+          await page.mouse.move(at.x, at.y);
+          for (let up = 0; up < 6 && (await read(page)).camera.y < -1; up += 1) { await page.mouse.wheel(0, -2_000); await page.waitForTimeout(120); }
+        }
+        for (let attempt = 0; attempt < 40; attempt += 1) {
           const reading = await read(page);
           const node = reading.nodes.find((entry) => entry.key === key);
           if (node && node.rect.h > 0 && node.rect.w > 0) {
@@ -576,12 +789,25 @@ async function main(): Promise<void> {
                 ?? (await visiblePoint(page, `[data-scheme-node="${key}"]`));
             }
           }
-          const at = await canvasPoint(page, 0.02, 0.5);
           await page.mouse.move(at.x, at.y);
-          await page.mouse.wheel(0, node && node.rect.h > 0 ? Math.max(-500, Math.min(500, node.rect.y + node.rect.h / 2 - (await read(page)).canvas.h / 2)) : 400);
+          await page.mouse.wheel(0, node && node.rect.h > 0 ? Math.max(-500, Math.min(500, node.rect.y + node.rect.h / 2 - reading.canvas.h / 2)) : 300);
           await page.waitForTimeout(150);
         }
         return null;
+      };
+      /** The framing an open promises (`centredCamera`): the reader's head
+          near the top — at 8% of the viewport plus the 40px title allowance —
+          or centred when the whole pane is short enough for that. */
+      const framedCheck = (reading: Reading, key: string, label: string) => {
+        const node = reading.nodes.find((entry) => entry.key === key);
+        must(node !== undefined && node.presentation === "native", `${label}: the clicked conversation opened as ${node?.presentation ?? "nothing"}, not as its reader`);
+        if (!node) return;
+        const expectedTop = Math.min(reading.canvas.h / 2, reading.canvas.h * 0.08 + 40 * reading.camera.z);
+        must(near(node.rect.y, expectedTop, 4), `${label}: the opened reader's top sits at ${Math.round(node.rect.y)}px, promised ${Math.round(expectedTop)}px (camera y ${reading.camera.y.toFixed(1)}, z ${reading.camera.z.toFixed(2)})`);
+        if (node.rect.h <= reading.canvas.h - expectedTop) must(node.rect.y + node.rect.h <= reading.canvas.h + 1, `${label}: the opened reader fits the viewport (${Math.round(node.rect.h)}px tall) but its bottom is ${Math.round(node.rect.y + node.rect.h - reading.canvas.h)}px below the fold`);
+        if (node.rect.w <= reading.canvas.w) must(node.rect.x >= -1 && node.rect.x + node.rect.w <= reading.canvas.w + 1, `${label}: the opened reader runs off the side of the viewport (x ${Math.round(node.rect.x)}, w ${Math.round(node.rect.w)} in ${reading.canvas.w})`);
+        must(node.rect.w * node.rect.h > 0.18 * reading.canvas.w * reading.canvas.h, `${label}: the opened conversation covers ${Math.round(100 * node.rect.w * node.rect.h / (reading.canvas.w * reading.canvas.h))}% of the viewport`);
+        documentRule(reading, label);
       };
       const openAndVerify = async (entryZoom: number, key: string, label: string) => {
         await page.keyboard.press("Escape");
@@ -597,10 +823,7 @@ async function main(): Promise<void> {
         const settled2 = await read(page);
         const node = settled2.nodes.find((entry) => entry.key === key);
         (frames as Record<string, unknown>)[`click_${label}`] = { entryZoom, after: settled2.camera, node: node ? { presentation: node.presentation, rect: node.rect } : null };
-        /* The EXACT clicked conversation is on screen, as its reader. */
-        must(node !== undefined && node.presentation === "native", `${tag} ${label}: the clicked conversation opened as ${node?.presentation ?? "nothing"}, not as its reader`);
-        must(node !== undefined && node.rect.y >= -1 && node.rect.y + Math.min(node.rect.h, 140) <= settled2.canvas.h + 1 && node.rect.x >= -1 && node.rect.x + node.rect.w <= settled2.canvas.w + 1, `${tag} ${label}: the clicked conversation sits at ${node ? `${Math.round(node.rect.x)},${Math.round(node.rect.y)} ${Math.round(node.rect.w)}×${Math.round(node.rect.h)}` : "nowhere"} in ${settled2.canvas.w}×${settled2.canvas.h}`);
-        must(node !== undefined && node.rect.w * node.rect.h > 0.18 * settled2.canvas.w * settled2.canvas.h, `${tag} ${label}: the opened conversation covers ${node ? Math.round(100 * node.rect.w * node.rect.h / (settled2.canvas.w * settled2.canvas.h)) : 0}% of the viewport`);
+        framedCheck(settled2, key, `${tag} ${label}`);
         /* And the camera has settled — one framing, not a drift. */
         must(near(settled1.camera.y, settled2.camera.y, 1.5) && near(settled1.camera.z, settled2.camera.z, 0.001), `${tag} ${label}: the camera kept moving after the click settled (${settled1.camera.y.toFixed(0)}→${settled2.camera.y.toFixed(0)}, z ${settled1.camera.z.toFixed(2)}→${settled2.camera.z.toFixed(2)})`);
       };
@@ -613,13 +836,87 @@ async function main(): Promise<void> {
       await openAndVerify(0.5, sibling, "repeat-back");
       await page.screenshot({ path: path.join(OUT_DIR, `${tag}-after-click.png`) });
 
+      /* ---- Keyboard navigation from the open reader: an Arrow hands the
+              selection ring to a neighbouring surface (on the band board the
+              band itself is one) and glides the camera — the spatial-nav
+              framing path. Down, because an open reader spans its row and has
+              nothing to its right on the narrow board. The nav must have
+              consumed the key, and the camera it settled on obeys the rule. */
+      {
+        const announced = () => page.evaluate(() => document.querySelector("[aria-live]")?.textContent ?? "");
+        const before = await read(page);
+        const said = await announced();
+        await blurActive(page);
+        await page.keyboard.press("ArrowDown");
+        await page.waitForTimeout(900);
+        const moved = await read(page);
+        const saidNow = await announced();
+        (frames as Record<string, unknown>).arrowNav = { from: before.camera, to: moved.camera, announced: saidNow.slice(0, 80) };
+        must(saidNow !== said || moved.nodes.find((node) => node.presentation === "native")?.key !== sibling, `${tag} arrow nav: ArrowDown moved nothing (live region "${saidNow.slice(0, 60)}")`);
+        documentRule(moved, `${tag} arrow nav`);
+      }
+
+      /* ---- A resize with a reader open: the anchor keeps the reader's
+              vertical place, the document rule keeps the band stack on the
+              viewport's left edge, and the reader stays inside the narrower
+              viewport instead of being pushed past its right edge. */
+      {
+        await page.keyboard.press("Escape");
+        await openAndVerify(0.5, sibling, "before-resize");
+        const before = await read(page);
+        /* A real resize kept on the desktop side of the shell's mobile
+           breakpoint (a width OR height below it replaces the board with the
+           phone surface): the wide viewport shrinks on both axes, the narrow
+           one — already at the breakpoint on both — widens. This probes the
+           camera's resize path, not the shell's. */
+        const smaller = tag === "wide"
+          ? { width: Math.round(viewportSize.width * 0.82), height: Math.round(viewportSize.height * 0.82) }
+          : { width: 1000, height: viewportSize.height };
+        await page.setViewportSize(smaller);
+        await page.waitForSelector('[aria-label^="Agent board"]', { timeout: 30_000 });
+        await page.waitForTimeout(1_200);
+        const resized = await read(page);
+        await page.screenshot({ path: path.join(OUT_DIR, `${tag}-after-resize.png`) });
+        const reader = resized.nodes.find((node) => node.key === sibling);
+        (frames as Record<string, unknown>).resize = { from: before.camera, to: resized.camera, canvas: resized.canvas, reader: reader?.rect ?? null };
+        documentRule(resized, `${tag} after resize`);
+        must(reader !== undefined && reader.presentation === "native" && reader.rect.x >= -1 && (reader.rect.w > resized.canvas.w || reader.rect.x + reader.rect.w <= resized.canvas.w + 1), `${tag} after resize: the open reader runs ${reader ? Math.round(reader.rect.x + reader.rect.w - resized.canvas.w) : 0}px past the right edge of the ${resized.canvas.w}px viewport`);
+        must(reader !== undefined && reader.rect.y >= -1 && reader.rect.y + Math.min(reader.rect.h, 140) <= resized.canvas.h + 1, `${tag} after resize: the open reader's head left the viewport (y ${reader ? Math.round(reader.rect.y) : 0})`);
+        await page.setViewportSize({ width: viewportSize.width, height: viewportSize.height });
+        await page.waitForTimeout(1_000);
+      }
+
+      /* ---- Restore: a reload puts the saved camera back exactly, and the
+              restored camera obeys the document rule. */
+      {
+        await page.keyboard.press("Escape");
+        await zoomTo(page, 0.7, center);
+        await page.waitForTimeout(700);
+        const before = await read(page);
+        await page.reload({ waitUntil: "domcontentloaded" });
+        await page.waitForSelector("[data-scheme-band]", { timeout: 120_000 });
+        await page.waitForTimeout(2_500);
+        const restored = await read(page);
+        /* Two legitimate outcomes. The shell may reopen the conversation it
+           had open (the URL names it): the board then mounts with a focus
+           standing and owes that conversation its framing (#1625), which is
+           the catalog-open path. Otherwise the saved camera comes back exactly
+           as it was. Either way the document rule holds. */
+        const reopened = restored.nodes.find((node) => node.presentation === "native");
+        (frames as Record<string, unknown>).restore = { before: before.camera, after: restored.camera, reopened: reopened?.key.slice(-24) ?? null };
+        if (reopened) framedCheck(restored, reopened.key, `${tag} restore (reopened conversation)`);
+        else must(near(restored.camera.z, before.camera.z, 0.001) && near(restored.camera.y, before.camera.y, 1) && near(restored.camera.x, before.camera.x, 1), `${tag} restore: the reload framed z=${restored.camera.z.toFixed(2)} (${restored.camera.x.toFixed(0)},${restored.camera.y.toFixed(0)}) instead of z=${before.camera.z.toFixed(2)} (${before.camera.x.toFixed(0)},${before.camera.y.toFixed(0)})`);
+        documentRule(restored, `${tag} restore`);
+      }
+
       /* ---- Wheel routing, through Chromium's input pipeline.
 
          The board pans over everything but a scroll container it can hand the
          wheel to. Pan probes run with the reader CLOSED and the board at an
          intermediate scale, so every band control is short and on screen; the
-         feed probe then opens a reader and scrolls its text. */
-      const wheel: Record<string, { cameraDy: number; feedDy: number }> = {};
+         feed probe then opens a reader and scrolls its text; a generic scroll
+         box — no selector the board knows — keeps the wheel too. */
+      const wheel: Record<string, { cameraDy: number; feedDy: number; scrollerDy: number }> = {};
       const panTopMemberBand = async () => {
         for (let attempt = 0; attempt < 30; attempt += 1) {
           const bands = (await read(page)).bands.filter((entry) => entry.members > 0);
@@ -643,7 +940,7 @@ async function main(): Promise<void> {
         const c = await canvasPoint(page, 0, 0);
         return { x: c.x + band.rect.x + 6, y: c.y + Math.min(band.rect.y + band.rect.h - 12, band.rect.y + 120) };
       };
-      const panProbes: [string, () => Promise<{ x: number; y: number } | null>][] = [
+      const panProbes: [string, () => Promise<Pt | null>][] = [
         ["band background", bandBackground],
         ["Details", () => firstVisiblePoint(page, "[data-scheme-band-details]")],
         ["+ Agent", () => firstVisiblePoint(page, "[data-scheme-band-add]")],
@@ -652,8 +949,31 @@ async function main(): Promise<void> {
       for (const [name, locate] of panProbes) {
         await panTopMemberBand();
         const at = await locate();
-        if (!at) { wheel[name] = { cameraDy: Number.NaN, feedDy: Number.NaN }; must(false, `${tag}: wheel probe "${name}" has no target on screen`); continue; }
+        if (!at) { wheel[name] = { cameraDy: Number.NaN, feedDy: Number.NaN, scrollerDy: Number.NaN }; must(false, `${tag}: wheel probe "${name}" has no target on screen`); continue; }
         wheel[name] = await wheelAt(page, at);
+      }
+      /* A generic scroll box inside a card — injected with no data attribute
+         the board could recognise, the shape of any bounded panel a card may
+         grow — keeps the wheel for its own content. */
+      {
+        await panTopMemberBand();
+        const injected = await page.evaluate(() => {
+          const canvas = document.querySelector<HTMLElement>('[aria-label^="Agent board"]')!.getBoundingClientRect();
+          const host = Array.from(document.querySelectorAll<HTMLElement>("[data-scheme-summary]")).find((el) => { const r = el.getBoundingClientRect(); return r.top > canvas.top + 4 && r.bottom < canvas.bottom - 4 && r.width > 60; });
+          if (!host) return null;
+          const box = document.createElement("div");
+          box.id = "llv-geometry-probe-scroller";
+          box.style.cssText = "position:absolute;left:8px;top:40px;width:120px;height:60px;overflow-y:auto;background:rgba(0,0,0,.04)";
+          const filler = document.createElement("div");
+          filler.style.height = "600px";
+          box.appendChild(filler);
+          host.appendChild(box);
+          const r = box.getBoundingClientRect();
+          return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+        });
+        if (!injected) { wheel["generic scroll box"] = { cameraDy: Number.NaN, feedDy: Number.NaN, scrollerDy: Number.NaN }; must(false, `${tag}: no summary tile on screen to host the generic scroll box`); }
+        else wheel["generic scroll box"] = await wheelAt(page, injected);
+        await page.evaluate(() => document.getElementById("llv-geometry-probe-scroller")?.remove());
       }
 
       /* The open reader keeps the wheel for its own text. Near zoom so the
@@ -663,7 +983,7 @@ async function main(): Promise<void> {
       await panTopMemberBand();
       const summary = await firstVisiblePoint(page, "[data-scheme-summary]");
       if (summary) { await page.mouse.click(summary.x, summary.y); await page.waitForTimeout(1_400); }
-      let feed: { x: number; y: number } | null = null;
+      let feed: Pt | null = null;
       for (let pan = 0; pan < 24 && !feed; pan += 1) {
         feed = await firstVisiblePoint(page, '[data-scheme-node-presentation="native"] [data-log-feed-scroller]');
         if (feed) break;
@@ -672,13 +992,14 @@ async function main(): Promise<void> {
         await page.mouse.wheel(0, 300);
         await page.waitForTimeout(150);
       }
-      if (!feed) { wheel["open reader feed"] = { cameraDy: Number.NaN, feedDy: Number.NaN }; must(false, `${tag}: the open reader's feed is not on screen`); }
+      if (!feed) { wheel["open reader feed"] = { cameraDy: Number.NaN, feedDy: Number.NaN, scrollerDy: Number.NaN }; must(false, `${tag}: the open reader's feed is not on screen`); }
       else wheel["open reader feed"] = await wheelAt(page, feed, -300);
       frames.wheel = wheel;
       for (const name of ["band background", "Details", "+ Agent", "collapsed card"]) {
         const got = wheel[name]!;
         must(got.cameraDy < -100, `${tag}: a wheel over ${name} moved the camera ${Math.round(got.cameraDy)}px — the board did not pan`);
       }
+      must(wheel["generic scroll box"]!.scrollerDy > 20 && Math.abs(wheel["generic scroll box"]!.cameraDy) < 1, `${tag}: a wheel over a generic scroll box scrolled it ${Math.round(wheel["generic scroll box"]!.scrollerDy)}px and moved the camera ${Math.round(wheel["generic scroll box"]!.cameraDy)}px`);
       must(wheel["open reader feed"]!.feedDy > 20 && Math.abs(wheel["open reader feed"]!.cameraDy) < 1, `${tag}: a wheel over the open reader's text scrolled the feed ${Math.round(wheel["open reader feed"]!.feedDy)}px and moved the camera ${Math.round(wheel["open reader feed"]!.cameraDy)}px`);
 
       report[tag] = frames;
@@ -696,7 +1017,7 @@ async function main(): Promise<void> {
     process.exitCode = 1;
     console.error(`board geometry acceptance FAILED (${failures.length}):\n  ${failures.join("\n  ")}`);
   } else {
-    console.log("board geometry acceptance passed at wide and narrow viewports across overview, intermediate and near zoom.");
+    console.log("board geometry acceptance passed at wide and narrow viewports across overview, intermediate and near zoom, on every camera mutation path.");
   }
 }
 

--- a/src/components/flows/FlowHub.tsx
+++ b/src/components/flows/FlowHub.tsx
@@ -9,6 +9,7 @@ import { useLocale } from "@/lib/i18n";
 import { useRuntimeFlow } from "@/hooks/useRuntime";
 import { currentRound, flowLinkPhase, type FlowLinkPhase } from "@/components/scheme/agentLinks";
 
+import { FLOW_HUB } from "./flowHubGeometry";
 import { flowPresentation, patchFlow } from "./flowModel";
 
 /* Hub tone per link phase: work in accent, waiting-on-you in amber, done in
@@ -84,8 +85,9 @@ export function FlowHub({
     >
       <button
         data-scheme-ui
-        className="absolute inline-flex h-[34px] -translate-x-1/2 -translate-y-1/2 items-center gap-1 whitespace-nowrap rounded-full border-2 bg-card px-2.5 shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-        style={{ borderColor: tone, color: tone }}
+        data-flow-hub={flow.id}
+        className="absolute inline-flex -translate-x-1/2 -translate-y-1/2 items-center gap-1 whitespace-nowrap rounded-full border-2 bg-card px-2.5 shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        style={{ borderColor: tone, color: tone, height: FLOW_HUB.h }}
         title={label}
         aria-label={label}
         aria-expanded={open}

--- a/src/components/flows/RoundDeck.dom.test.tsx
+++ b/src/components/flows/RoundDeck.dom.test.tsx
@@ -6,6 +6,8 @@ import { createRoot } from "react-dom/client";
 import type { Flow, ReviewVerdict } from "@/lib/flows/types";
 import { setLocale } from "@/lib/i18n";
 
+import { COLLAPSED_DECK_CHIP_H } from "./reviewDeckDisclosure";
+
 /*
  * Deck disclosure (#289 + #325): the deck auto-collapses to a clickable
  * verdict chip the moment the final verdict lands, a manual expand of the
@@ -111,6 +113,10 @@ test("verdict arrival auto-collapses the deck to a clickable chip; a click expan
   await settle();
   const chip = host.querySelector("[data-review-deck-collapsed]")!;
   expect(chip.getAttribute("aria-expanded")).toBe("false");
+  /* The chip is painted at the one height the band layout reserves for a
+     collapsed deck (#1641): the two read the same constant, so the frame
+     around a settled review loop hugs the chip instead of an empty deck box. */
+  expect((chip as unknown as HTMLElement).style.height).toBe(`${COLLAPSED_DECK_CHIP_H}px`);
   expect(chip.textContent).toContain("2 rounds");
   expect(chip.textContent).toContain("APPROVE");
   expect(chip.textContent).toContain("Claude");

--- a/src/components/flows/RoundDeck.tsx
+++ b/src/components/flows/RoundDeck.tsx
@@ -12,6 +12,7 @@ import { engineBadgeFor, fmtAge } from "@/components/utils";
 
 import { VERDICT_GLYPHS, verdictTone } from "./flowModel";
 import {
+  COLLAPSED_DECK_CHIP_H,
   deckCollapsed,
   deckDisclosureMarker,
   deckDisclosureTerminal,
@@ -242,7 +243,8 @@ export function RoundDeck({
       <button
         type="button"
         data-review-deck-collapsed
-        className="deck-chip-in flex h-12 w-full items-center gap-2 rounded-[10px] border border-border bg-card px-3 text-left shadow-1 hover:border-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        className="deck-chip-in flex w-full items-center gap-2 rounded-[10px] border border-border bg-card px-3 text-left shadow-1 hover:border-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        style={{ height: COLLAPSED_DECK_CHIP_H }}
         aria-label={t("roundDeck.expandStack", { count: rounds.length })}
         aria-expanded="false"
         title={t("roundDeck.expandStack", { count: rounds.length })}

--- a/src/components/flows/RoundDeck.tsx
+++ b/src/components/flows/RoundDeck.tsx
@@ -142,6 +142,10 @@ export function RoundDeck({
     const v = value ? ("collapsed" as const) : ("expanded" as const);
     setOverride({ v, at: marker });
     writeDeckDisclosureOverride(window.localStorage, flow.id, v, marker);
+    /* The board reserves a deck's height from its disclosure state (#1641); a
+       same-tab write does not fire `storage`, so announce the toggle for the
+       band layout to re-measure. */
+    window.dispatchEvent(new Event("llv-deck-disclosure"));
   };
   /* The painted form lags the derived one by exactly one suck-in animation:
      collapsing keeps the deck mounted with the `deck-collapsing` phase class,

--- a/src/components/flows/flowHubGeometry.ts
+++ b/src/components/flows/flowHubGeometry.ts
@@ -1,0 +1,6 @@
+/** Footprint of the ⟳ flow hub, in board pixels: FlowHub renders its button
+    at this height, and the band layout keeps a box this size clear of every
+    card that is not one of the hub's two endpoints when it places the hub on
+    the review connector (#1641). The width is the widest the button gets
+    (glyph, round number and padding); a narrower one only clears more. */
+export const FLOW_HUB = { w: 72, h: 34 } as const;

--- a/src/components/flows/reviewDeckDisclosure.ts
+++ b/src/components/flows/reviewDeckDisclosure.ts
@@ -79,3 +79,8 @@ export function deckCollapsed(override: DeckDisclosureOverride | null, marker: s
   if (override && (override.at === null || override.at === marker)) return override.v === "collapsed";
   return terminal;
 }
+
+/** Height of the collapsed verdict chip, in board pixels. RoundDeck renders
+    the chip at exactly this height and the band layout reserves exactly this
+    much for a collapsed deck, so the two cannot drift apart (#1641). */
+export const COLLAPSED_DECK_CHIP_H = 48;

--- a/src/components/scheme/SchemeBoard.bands.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.bands.dom.test.tsx
@@ -224,13 +224,21 @@ test("the selected conversation holds its screen anchor through wheel zoom, tool
   select(viewport, "/quiet-two");
   await settle();
   const start = screenOf(viewport, "/quiet-two");
-  /* Both axes hold at every step, mode crossings included: the camera
-     translates so the selected header keeps its screen point even when the
-     row layout gives the tile another column. */
+  /* The vertical axis holds at every step, mode crossings included: the
+     camera translates so the selected header keeps its screen height even
+     when the row layout gives the tile another column. Horizontally the band
+     board is a document (#1641): while the stack fits the viewport its left
+     edge stays on the viewport's, so the tile moves within the stack rather
+     than dragging the stack — and no dead canvas opens beside the bands. */
   const drift = (label: string) => {
     const now = screenOf(viewport, "/quiet-two");
-    const delta = Math.hypot(now.sx - start.sx, now.sy - start.sy);
-    if (delta > 2) throw new Error(`${label}: selected header drifted ${delta.toFixed(2)}px at zoom ${now.z}`);
+    const delta = Math.abs(now.sy - start.sy);
+    if (delta > 2) throw new Error(`${label}: selected header drifted ${delta.toFixed(2)}px vertically at zoom ${now.z}`);
+    /* The band world is one viewport wide, so it fits up to 100%: pinned
+       there; past it the stack may scroll but never leaves a gap on the left. */
+    const camera = cameraOf(viewport);
+    if (camera.z <= 1 && Math.abs(camera.x) > 0.01) throw new Error(`${label}: the band stack left the viewport's left edge (camera x ${camera.x.toFixed(2)}) at zoom ${now.z}`);
+    if (camera.x > 0.01) throw new Error(`${label}: dead canvas opened left of the band stack (camera x ${camera.x.toFixed(2)}) at zoom ${now.z}`);
     return delta;
   };
   /* Wheel zoom in, five notches, each anchored (the scale is capped, so only
@@ -271,9 +279,11 @@ test("the selected conversation holds its screen anchor through wheel zoom, tool
     await settle();
     drift(`toolbar in ${cycle}`);
   }
-  /* Twenty forward/reverse cycles: cumulative drift stays under 4px on both axes. */
+  /* Twenty forward/reverse cycles: cumulative vertical drift stays under 4px
+     and the stack is still on the left edge. */
   const end = screenOf(viewport, "/quiet-two");
-  expect(Math.hypot(end.sx - start.sx, end.sy - start.sy)).toBeLessThanOrEqual(4);
+  expect(Math.abs(end.sy - start.sy)).toBeLessThanOrEqual(4);
+  expect(cameraOf(viewport).x).toBeLessThanOrEqual(0.01);
 });
 
 test("without a selection a wheel zoom keeps the pointer's world point; a pan is never undone", async () => {

--- a/src/components/scheme/SchemeBoard.camera.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.camera.dom.test.tsx
@@ -255,6 +255,9 @@ test("the scheme viewport keeps its minimap and camera gestures after descendant
   );
   await settle();
   expect(viewport.className).toContain("cursor-grabbing");
+  /* A diagonal drag: the band board is a document whose stack fits the
+     viewport here, so only the vertical component can move it (#1641), and
+     the camera already rests at the strip-keeping top bound, so it moves down. */
   flushSync(() =>
     viewport.dispatchEvent(new dom.PointerEvent("pointermove", {
       bubbles: true,
@@ -263,7 +266,7 @@ test("the scheme viewport keeps its minimap and camera gestures after descendant
       pointerType: "mouse",
       button: 0,
       clientX: 340,
-      clientY: 300,
+      clientY: 360,
     }) as unknown as Event),
   );
   await settle();

--- a/src/components/scheme/SchemeBoard.catalogFocus.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.catalogFocus.dom.test.tsx
@@ -295,9 +295,16 @@ test("a catalog open that mounts the board with its request standing brings the 
      on screen is its content and not a tile of it. */
   expect(placed!.presentation).toBe("native");
   /* And it is genuinely deep in the stack — a fixture that stopped placing it
-     far down would pass this test without asking the question. */
+     far down would pass this test without asking the question. The depth is
+     measured against the viewport's own height, in the board pixels the world
+     uses now (it once counter-scaled every coordinate by the zoom, #1641, and
+     a bare pixel constant written in that unit rotted with it): at the zooms
+     the board frames a reader, a head more than a whole viewport down the
+     stack cannot share a screen with the top of it, so the open has to move
+     the camera. A target in the first band sits a few dozen pixels down. */
   const shell = host.querySelector(`[data-scheme-node="${TARGET}"]`) as HTMLElement;
-  expect(parseFloat(/translate\((?:-?[\d.e+-]+)px, (-?[\d.e+-]+)px\)/.exec(shell.style.transform)![1]!)).toBeGreaterThan(2500);
+  const depth = parseFloat(/translate\((?:-?[\d.e+-]+)px, (-?[\d.e+-]+)px\)/.exec(shell.style.transform)![1]!);
+  expect(depth).toBeGreaterThan(VIEWPORT.height);
 });
 
 test("a repeated catalog open of the same conversation brings it back after the operator has panned away", async () => {

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -272,7 +272,6 @@ export function SchemeBoard({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyTaskId, setHistoryTaskId] = useState<string | null>(null);
   const openTaskHistory = useCallback((id: string) => {setHistoryTaskId(id);setHistoryOpen(true);}, []);
-  const [layoutZoom, setLayoutZoom] = useState(.5);
   const [layoutViewportWidth, setLayoutViewportWidth] = useState(1400);
   const closeHistory = useCallback(() => setHistoryOpen(false), []);
   const workflowModel = useMemo(() => projectTaskWorkflows(allTasks, pipelines, flows, files, project), [allTasks, pipelines, flows, files, project]);
@@ -425,8 +424,8 @@ export function SchemeBoard({
     return set;
   }, [authoredLayout.decks, disclosureNonce]);
   const taskScene = useMemo(() => bandsEnabled
-    ? layoutTaskBands(authoredLayout, orderedBands, { zoom: layoutZoom, mode: bandMode, viewportWidth: layoutViewportWidth, reader: selected, hostOverrides, collapsedDecks })
-    : null, [bandsEnabled, authoredLayout, orderedBands, layoutZoom, bandMode, layoutViewportWidth, selected, hostOverrides, collapsedDecks]);
+    ? layoutTaskBands(authoredLayout, orderedBands, { mode: bandMode, viewportWidth: layoutViewportWidth, reader: selected, hostOverrides, collapsedDecks })
+    : null, [bandsEnabled, authoredLayout, orderedBands, bandMode, layoutViewportWidth, selected, hostOverrides, collapsedDecks]);
   const layout = taskScene?.layout ?? authoredLayout;
 
   /* NO PRUNING HERE (#771). The selection outlives this view, so dropping a path
@@ -901,7 +900,10 @@ export function SchemeBoard({
     focusZoom: taskScene ? 0.9 : undefined,
   });
 
-  useLayoutEffect(() => {setLayoutZoom(cam.z);setLayoutViewportWidth(vp.w);setBandMode((previous) => bandModeFor(cam.z, previous));}, [cam.z,vp.w]);
+  /* The band layout follows the camera only through the presentation mode
+     (chip / summary / reader) and the viewport width; the zoom itself is the
+     camera's, so a zoom frame that stays inside one mode relayouts nothing. */
+  useLayoutEffect(() => {setLayoutViewportWidth(vp.w);setBandMode((previous) => bandModeFor(cam.z, previous));}, [cam.z,vp.w]);
   /* Rank moves are deferred while the operator is busy inside the board:
      panning, typing, holding a text selection, or reading an open disclosure
      or action menu. Status labels still update at once; only the order waits. */
@@ -1447,7 +1449,6 @@ export function SchemeBoard({
           <TaskBandsLayer
             bands={taskScene.bands}
             mode={taskScene.mode}
-            scale={taskScene.scale}
             /* Band chrome stays live on the hand tool. Only the controls
                themselves take pointer events (`data-scheme-ui`, which
                `onPointerDown` already refuses to start a pan on), so the rest
@@ -1472,7 +1473,7 @@ export function SchemeBoard({
         {/* Rails/badges stay passive on the map, but the pipeline hub keeps its
             tap target there — the mobile lite map reaches pipeline controls only
             through it (#93 §2.3). */}
-        <AgentLinksLayer semanticZoom={Boolean(taskScene)} links={layout.links} byPath={layout.byPath} obstacles={railObstacles} interactive={!mapMode && !handLike && !session} hubInteractive={!handLike && !session} width={layout.width} height={layout.height} />
+        <AgentLinksLayer semanticZoom={Boolean(taskScene)} links={layout.links} loops={layout.loops} byPath={layout.byPath} obstacles={railObstacles} interactive={!mapMode && !handLike && !session} hubInteractive={!handLike && !session} width={layout.width} height={layout.height} />
         <NodesLayer
           layout={layout}
           visiblePaths={visibleNativePaths}

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -18,6 +18,7 @@ import { GroupOverridePanel } from "./GroupOverridePanel";
 import { PipelineEditor } from "@/components/pipelines/PipelineEditor";
 import { createVisibilityIndex } from "./visibilityIndex";
 import { flowByImplementer } from "@/components/flows/flowModel";
+import { deckCollapsed, deckDisclosureMarker, deckDisclosureTerminal, readDeckDisclosureOverride } from "@/components/flows/reviewDeckDisclosure";
 import type { BranchGroup } from "@/components/projectModel";
 import { deleteTask, handoffTask, unassignTask, updateTask } from "@/components/tasks/taskApi";
 import { taskRelationsByPath } from "@/components/tasks/taskRelations";
@@ -397,9 +398,35 @@ export function SchemeBoard({
      operator opened it from. Session state only; the canonical membership and
      the composer/delivery owner are untouched. */
   const [hostOverrides, setHostOverrides] = useState<ReadonlyMap<string, string>>(() => new Map());
+  /* The operator's actual review-deck disclosure, so a band reserves the
+     collapsed chip height for a deck it is showing collapsed and the full
+     footprint for one they manually expanded (#1641). The state lives in
+     localStorage (RoundDeck's own store); the nonce re-reads it when a toggle
+     dispatches `llv-deck-disclosure`, or another tab writes the key. */
+  const [disclosureNonce, setDisclosureNonce] = useState(0);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const bump = () => setDisclosureNonce((n) => n + 1);
+    window.addEventListener("llv-deck-disclosure", bump);
+    window.addEventListener("storage", bump);
+    return () => {
+      window.removeEventListener("llv-deck-disclosure", bump);
+      window.removeEventListener("storage", bump);
+    };
+  }, []);
+  const collapsedDecks = useMemo(() => {
+    void disclosureNonce;
+    const set = new Set<string>();
+    if (typeof window === "undefined") return set;
+    for (const deck of authoredLayout.decks) {
+      const override = readDeckDisclosureOverride(window.localStorage, deck.flow.id);
+      if (deckCollapsed(override, deckDisclosureMarker(deck.flow), deckDisclosureTerminal(deck.flow))) set.add(deck.key);
+    }
+    return set;
+  }, [authoredLayout.decks, disclosureNonce]);
   const taskScene = useMemo(() => bandsEnabled
-    ? layoutTaskBands(authoredLayout, orderedBands, { zoom: layoutZoom, mode: bandMode, viewportWidth: layoutViewportWidth, reader: selected, hostOverrides })
-    : null, [bandsEnabled, authoredLayout, orderedBands, layoutZoom, bandMode, layoutViewportWidth, selected, hostOverrides]);
+    ? layoutTaskBands(authoredLayout, orderedBands, { zoom: layoutZoom, mode: bandMode, viewportWidth: layoutViewportWidth, reader: selected, hostOverrides, collapsedDecks })
+    : null, [bandsEnabled, authoredLayout, orderedBands, layoutZoom, bandMode, layoutViewportWidth, selected, hostOverrides, collapsedDecks]);
   const layout = taskScene?.layout ?? authoredLayout;
 
   /* NO PRUNING HERE (#771). The selection outlives this view, so dropping a path
@@ -869,6 +896,9 @@ export function SchemeBoard({
     onFit: announceFit,
     anchor: cameraAnchor,
     lockX: Boolean(taskScene),
+    /* The band board scales cards with the camera, so an opened conversation
+       is framed at a fuller zoom to read prominently (#1641). */
+    focusZoom: taskScene ? 0.9 : undefined,
   });
 
   useLayoutEffect(() => {setLayoutZoom(cam.z);setLayoutViewportWidth(vp.w);setBandMode((previous) => bandModeFor(cam.z, previous));}, [cam.z,vp.w]);

--- a/src/components/scheme/TaskBandsLayer.tsx
+++ b/src/components/scheme/TaskBandsLayer.tsx
@@ -20,13 +20,13 @@ import { BAND, bandHoldsMembers, type BandContinuation, type BandMirror, type Ba
  * slots, decks and drafts inside the band are drawn by the existing layers at
  * the rectangles the band layout assigned them.
  *
- * Everything the operator reads is sized in CSS pixels and counter-scaled by
- * `scale` (1 / zoom), so zoom changes density, never legibility.
+ * Everything here is drawn in board pixels at the rectangles the band layout
+ * assigned, and the camera's own scale is what grows or shrinks it on screen —
+ * the same law as the cards, frames and connectors it sits among (#1641).
  */
 export const TaskBandsLayer = memo(function TaskBandsLayer({
   bands,
   mode,
-  scale,
   interactive,
   selectedKey,
   mirrorRects,
@@ -41,7 +41,6 @@ export const TaskBandsLayer = memo(function TaskBandsLayer({
 }: {
   bands: PlacedBand[];
   mode: BandMode;
-  scale: number;
   /** Passive on the map and during a selection session. The hand tool keeps
       these controls live: only they take pointer events, so the rest of the
       band still pans. */
@@ -63,7 +62,7 @@ export const TaskBandsLayer = memo(function TaskBandsLayer({
 }) {
   const { t } = useLocale();
   if (!bands.length) return null;
-  const screen = (rect: SchemeRect) => ({ width: rect.w / scale, height: rect.h / scale, transform: `scale(${scale})`, transformOrigin: "top left" as const });
+  const screen = (rect: SchemeRect) => ({ width: rect.w, height: rect.h });
   return (
     <div aria-hidden={false} data-scheme-bands={mode}>
       {bands.map((band) => {
@@ -102,13 +101,13 @@ export const TaskBandsLayer = memo(function TaskBandsLayer({
               style={{
                 borderColor: `color-mix(in srgb, ${color} ${selectedInside ? 55 : 26}%, var(--border-default))`,
                 backgroundColor: `color-mix(in srgb, ${color} 3.5%, var(--surface-well))`,
-                borderWidth: Math.max(1, scale),
+                borderWidth: 1,
               }}
             />
             <div
               aria-hidden
               className="absolute left-0 top-0 rounded-l-[6px]"
-              style={{ width: Math.max(3 * scale, 1), height: rect.h, backgroundColor: color, opacity: band.working ? 0.9 : 0.35 }}
+              style={{ width: 3, height: rect.h, backgroundColor: color, opacity: band.working ? 0.9 : 0.35 }}
             />
             {/* Header, screen-constant. */}
             <div
@@ -235,9 +234,9 @@ export const TaskBandsLayer = memo(function TaskBandsLayer({
                   data-scheme-ui
                   data-scheme-continuation={entry.key}
                   className="absolute flex items-start gap-1"
-                  style={{ left: at.x - rect.x, top: at.y + at.h - rect.y + 4 * scale, width: at.w, height: 22 * scale }}
+                  style={{ left: at.x - rect.x, top: at.y + at.h - rect.y + 4, width: at.w, height: 22 }}
                 >
-                  <div className="absolute left-0 top-0 flex flex-nowrap items-center gap-1 overflow-hidden" style={{ width: at.w / scale, height: 22, transform: `scale(${scale})`, transformOrigin: "top left" }}>
+                  <div className="absolute left-0 top-0 flex flex-nowrap items-center gap-1 overflow-hidden" style={{ width: at.w, height: 22 }}>
                     {entry.targets.map((target) => (
                       <button
                         key={`${target.direction}:${target.key}`}
@@ -268,7 +267,7 @@ export const TaskBandsLayer = memo(function TaskBandsLayer({
                 style={{ left: addAgent.x - rect.x, top: addAgent.y - rect.y, width: addAgent.w, height: addAgent.h }}
                 onClick={() => onAddAgent(band)}
               >
-                <div className="absolute left-0 top-0 flex items-center justify-center gap-1 text-[11.5px] font-bold text-primary" style={{ width: BAND.addW, height: BAND.addH, transform: `scale(${scale})`, transformOrigin: "top left" }}>
+                <div className="absolute left-0 top-0 flex items-center justify-center gap-1 text-[11.5px] font-bold text-primary" style={{ width: BAND.addW, height: BAND.addH }}>
                   <span className="text-[14px] leading-none text-accent">+</span> {t("dash.agent")}
                 </div>
               </button>

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -287,6 +287,10 @@ export interface FlowLoop {
   y1?: number;
   y2?: number;
   route?: string;
+  /** Where the ⟳ hub sits: a point on `route` clear of every card but the
+      two endpoints. Set with `route`; without it the hub falls back to the
+      free board's corridor midpoint. */
+  hub?: { x: number; y: number };
 }
 
 export interface SchemeLayout {

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -279,6 +279,14 @@ export interface FlowLoop {
   x2: number;
   /** Shared top of the two cards. */
   y: number;
+  /** Task-band review connector (#1641): the routed port endpoints between the
+      implementer card and the reviewer deck as they are actually placed, and
+      the routed path between them. Present only on the band surface, where the
+      two can wrap to different rows; the free board leaves these unset and
+      LoopsLayer draws its side-by-side forward/return arcs from x1/x2/y. */
+  y1?: number;
+  y2?: number;
+  route?: string;
 }
 
 export interface SchemeLayout {

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -269,6 +269,35 @@ export const LoopsLayer = memo(function LoopsLayer({ loops, width, height }: { l
     <svg width={width} height={height} className="pointer-events-none absolute left-0 top-0" aria-hidden>
       {loops.map((loop) => {
         const leg = activeLoopLeg(loop.flow);
+        /* Task-band review connector (#1641): one routed path between the
+           implementer card and the reviewer deck as they were placed — around
+           the other cards, across wrapped rows — capped with an arrowhead at
+           each end to read as the review cycle. The active leg tints accent. */
+        if (loop.route && loop.y1 !== undefined && loop.y2 !== undefined) {
+          const live = leg !== null;
+          const color = live ? "var(--color-accent)" : "var(--color-strong)";
+          const toDeck = Math.atan2(loop.y2 - loop.y1, loop.x2 - loop.x1);
+          const toImpl = Math.atan2(loop.y1 - loop.y2, loop.x1 - loop.x2);
+          const headStyle = (d: string) => ({ d: `path("${d}")`, transition: `d ${MOVE_MS}ms ${MOVE_EASE}` }) as React.CSSProperties;
+          const deckHead = loopArrowHead(loop.x2, loop.y2, toDeck);
+          const implHead = loopArrowHead(loop.x1, loop.y1, toImpl);
+          return (
+            <g key={loop.key}>
+              <path
+                d={loop.route}
+                style={{ d: `path("${loop.route}")`, transition: `d ${MOVE_MS}ms ${MOVE_EASE}` } as React.CSSProperties}
+                fill="none"
+                stroke={color}
+                strokeWidth={live ? 3 : 2.5}
+                strokeLinecap="round"
+                strokeDasharray="5 7"
+                className={live ? "loop-arc-live" : undefined}
+              />
+              <path d={deckHead} style={headStyle(deckHead)} fill={color} />
+              <path d={implHead} style={headStyle(implHead)} fill={color} />
+            </g>
+          );
+        }
         const yTop = loop.y + LOOP_ARC_TOP;
         const yBot = loop.y + LOOP_ARC_BOT;
         const forward = `M ${loop.x1} ${yTop} C ${loop.x1 + LOOP_REACH} ${yTop - LOOP_BULGE}, ${loop.x2 - LOOP_REACH} ${

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -346,6 +346,7 @@ const RAIL_CLEARANCE = 10;
 export const AgentLinksLayer = memo(function AgentLinksLayer({
   links,
   byPath,
+  loops = [],
   obstacles = [],
   interactive,
   hubInteractive = interactive,
@@ -355,6 +356,11 @@ export const AgentLinksLayer = memo(function AgentLinksLayer({
 }: {
   links: AgentLink[];
   byPath: Map<string, SchemeRect>;
+  /** The review loops as the layout drew them. On the band board a loop
+      carries the point on its routed connector where the ⟳ hub belongs
+      (#1641); a loop without one (the free board) places the hub at the
+      corridor midpoint between its two cards. */
+  loops?: readonly FlowLoop[];
   /** Card rects the pipeline rails must not cross — nodes, decks, stacks, drafts
       (issue #136). A rail excludes its own two endpoints and routes around the
       rest, reusing the task-edge obstacle router (PR #130). */
@@ -392,6 +398,7 @@ export const AgentLinksLayer = memo(function AgentLinksLayer({
     return { d: route.d, mid: route.mid, chevrons: [] };
   };
   const railByKey = new Map(pipelineLinks.map((link) => [link.key, railGeom(link)] as const));
+  const hubByFlow = new Map(loops.flatMap((loop) => (loop.hub ? [[loop.flow.id, loop.hub] as const] : [])));
 
   return (
     <>
@@ -444,9 +451,11 @@ export const AgentLinksLayer = memo(function AgentLinksLayer({
           return <PipelineEdgeBadge key={link.key} index={link.pipeline.index} total={link.pipeline.total} color={PIPELINE_RAIL_COLOR[link.pipeline.tone]} x={x} y={y} moveTransition={MOVE_TRANSITION} semanticZoom={semanticZoom} />;
         }
         if (!link.flow) return null;
-        /* Corridor midpoint of the pair, level with the cycle arcs' center. */
-        const x = (from.x + from.w + to.x) / 2;
-        const y = Math.min(from.y, to.y) + (LOOP_ARC_TOP + LOOP_ARC_BOT) / 2;
+        /* On the routed connector where the layout put it; otherwise the
+           corridor midpoint of the pair, level with the cycle arcs' center. */
+        const routed = hubByFlow.get(link.flow.flow.id);
+        const x = routed ? routed.x : (from.x + from.w + to.x) / 2;
+        const y = routed ? routed.y : Math.min(from.y, to.y) + (LOOP_ARC_TOP + LOOP_ARC_BOT) / 2;
         return (
           <FlowHub key={link.key} flow={link.flow.flow} x={x} y={y} interactive={interactive} moveTransition={MOVE_TRANSITION} />
         );

--- a/src/components/scheme/taskBands.test.ts
+++ b/src/components/scheme/taskBands.test.ts
@@ -190,20 +190,24 @@ test("bands stack at content width at every mode and width; members, mirrors and
     for (const zoom of [0.07, 0.21, 0.22, 0.4, 0.58, 1]) {
       const mode = bandModeFor(zoom, null);
       const scene = layoutTaskBands(layout, bands, { zoom, mode, viewportWidth, reader: files[5]!.path });
-      const s = 1 / zoom;
-      const gutter = (viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter) * s;
+      /* Stable world geometry (#1641): a band member is one rectangle in board
+         pixels and the camera's own scale grows or shrinks it, so nothing here
+         divides by the zoom. The geometry depends on the zoom only through the
+         presentation mode, so two zooms in one mode place identical rectangles;
+         physical card scaling is verified separately. */
+      const gutter = viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter;
+      const available = viewportWidth - gutter * 2;
       let previousBottom = -Infinity;
       for (const band of scene.bands) {
         const { rect, header, addAgent } = band.geometry;
         expect(rect.x).toBeCloseTo(gutter, 6);
         /* Compact geometry: a band is as wide as its content, floored so its
            header stays readable and ceilinged at the available width. */
-        const available = viewportWidth - (viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter) * 2;
-        expect(rect.w * zoom).toBeLessThanOrEqual(available + 0.001);
-        expect(rect.w * zoom).toBeGreaterThanOrEqual(Math.min(available, BAND.minBandW) - 0.001);
+        expect(rect.w).toBeLessThanOrEqual(available + 0.001);
+        expect(rect.w).toBeGreaterThanOrEqual(Math.min(available, BAND.minBandW) - 0.001);
         expect(rect.y).toBeGreaterThanOrEqual(previousBottom - 0.001);
         previousBottom = rect.y + rect.h;
-        expect(header.h * zoom).toBeCloseTo(BAND.header, 6);
+        expect(header.h).toBeCloseTo(BAND.header, 6);
         expect(contains(rect, addAgent)).toBe(true);
         const items = [...band.members.map((member) => member.key), ...band.mirrors.map((mirror) => mirror.key)]
           .map((key) => scene.layout.byPath.get(key))
@@ -215,21 +219,23 @@ test("bands stack at content width at every mode and width; members, mirrors and
         }
         for (let i = 0; i < items.length; i += 1) for (let j = i + 1; j < items.length; j += 1) expect(overlapping(items[i]!, items[j]!)).toBe(false);
       }
-      expect(scene.layout.width * zoom).toBeCloseTo(viewportWidth, 6);
-      /* Every node is placed and screen-constant for its presentation. */
+      /* The band world is exactly the available viewport at 1:1; the camera
+         scales it from there. */
+      expect(scene.layout.width).toBeCloseTo(viewportWidth, 6);
       for (const node of scene.layout.nodes) {
         expect(scene.shown.has(node.file.path)).toBe(true);
         const expected = mode === "overview" ? "chip" : node.file.path === files[5]!.path ? "native" : "summary";
         expect(node.presentation).toBe(expected);
-        /* Screen-constant for its presentation, except that no surface is
-           wider than the band's inner width: a 375px board fits the tile. */
-        const inner = viewportWidth - (viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter) * 2 - BAND.pad * 2;
-        const width = node.w * zoom;
+        /* Board-pixel footprint for its presentation, capped only so no surface
+           is wider than the band's inner width (a 375px board fits the tile). */
+        const inner = viewportWidth - gutter * 2 - BAND.pad * 2;
+        const width = node.w;
         if (expected === "chip") expect(width).toBeCloseTo(Math.min(BAND.chipW, inner), 6);
         else if (expected === "summary") expect(width).toBeCloseTo(Math.min(BAND.summaryW, inner), 6);
         else expect(width).toBeGreaterThanOrEqual(Math.min(BAND.nativeMinW, inner) - 0.001);
         expect(width).toBeLessThanOrEqual(inner + 0.001);
-        expect((node.readerScale ?? 1) * zoom).toBeCloseTo(width / (expected === "chip" ? BAND.chipW : expected === "summary" ? BAND.summaryW : node.w * zoom / ((node.readerScale ?? 1) * zoom)), 6);
+        /* The shell scales its content back to the tile's own footprint. */
+        if (expected !== "native") expect(width).toBeCloseTo((expected === "chip" ? BAND.chipW : BAND.summaryW) * (node.readerScale ?? 1), 6);
       }
       /* At 375 one tile per row: no two summary tiles share a row. */
       if (viewportWidth === 375 && mode === "intermediate") {
@@ -244,10 +250,12 @@ test("the local +Agent sits right after the last member, or opens the next row w
   const files = Array.from({ length: 12 }, (_, index) => file(index));
   const layout = base(files);
   const one = rankBands(buildTaskBands(layout, sources([task("one", "2026-01-01T00:00:00Z", [files[0]!])], files.slice(0, 1))));
-  const single = layoutTaskBands(layout, one, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null }).bands[0]!;
+  const scene1 = layoutTaskBands(layout, one, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const single = scene1.bands[0]!;
   const member = single.members[0]!;
-  const memberRect = layoutTaskBands(layout, one, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null }).layout.byPath.get(member.key)!;
-  expect(single.geometry.addAgent.x).toBeCloseTo(memberRect.x + memberRect.w + BAND.tileGap * 2, 6);
+  const memberRect = scene1.layout.byPath.get(member.key)!;
+  /* Board pixels: the +Agent sits one tile gap past the last member on its row. */
+  expect(single.geometry.addAgent.x).toBeCloseTo(memberRect.x + memberRect.w + BAND.tileGap, 6);
   expect(single.geometry.addAgent.y).toBeCloseTo(memberRect.y, 6);
   /* Four 320px tiles fill a 1440 row (24 gutter + 16 pad each side leaves
      1360; 4 × 320 + 3 × 24 = 1352): the +Agent must start the next row. */
@@ -256,7 +264,8 @@ test("the local +Agent sits right after the last member, or opens the next row w
   const band = scene.bands[0]!;
   const last = scene.layout.byPath.get(band.members[3]!.key)!;
   expect(band.geometry.addAgent.y).toBeGreaterThan(last.y + last.h - 0.001);
-  expect(band.geometry.addAgent.x).toBeCloseTo(last.x - 3 * (BAND.summaryW + BAND.tileGap) * 2, 6);
+  /* Wrapped to the next row, back at the inner-left edge (gutter + pad). */
+  expect(band.geometry.addAgent.x).toBeCloseTo(BAND.gutter + BAND.pad, 6);
   expect(band.geometry.rows).toBe(2);
 });
 
@@ -519,7 +528,7 @@ test("an empty band ends at its content instead of ruling a line across the canv
   ], files)));
   for (const [viewportWidth, zoom] of [[1440, 1], [1440, 1.6], [1920, 1], [1280, 0.5]] as const) {
     const scene = layoutTaskBands(layout, bands, { zoom, mode: bandModeFor(zoom, null), viewportWidth, reader: null });
-    const widthOf = (id: string) => scene.bands.find((band) => band.task?.id === id)!.geometry.rect.w * zoom;
+    const widthOf = (id: string) => scene.bands.find((band) => band.task?.id === id)!.geometry.rect.w;
     const available = viewportWidth - BAND.gutter * 2;
     /* The whole complaint: an empty band used to be exactly as wide as a band
        holding eight conversations. Now it is strictly narrower, and narrower
@@ -580,48 +589,67 @@ function deckScene(flowState: "approved" | "reviewing") {
   return { layout, band, deckKey, nodePath: node.path };
 }
 
-test("a settled review deck reserves its collapsed chip height, not the full expanded box (#1641)", () => {
-  const { layout, band, deckKey } = deckScene("approved");
-  const scene = layoutTaskBands(layout, [band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null });
-  const deck = scene.layout.byPath.get(deckKey)!;
-  /* At 1:1 the world unit is a CSS pixel, so the reserved box is the collapsed
-     chip (BAND.collapsedDeckH), an order of magnitude short of the 810px it
-     would need expanded — the giant empty task frame in the report. */
-  expect(deck.h).toBeLessThanOrEqual(BAND.collapsedDeckH + 1);
-  /* An actionable deck still reserves its working height. */
-  const live = layoutTaskBands(deckScene("reviewing").layout, [deckScene("reviewing").band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null });
-  expect(live.layout.byPath.get(deckKey)!.h).toBeGreaterThan(400);
+test("a review deck reserves its collapsed chip height by the operator's actual disclosure state (#1641)", () => {
+  const { layout, band, deckKey } = deckScene("reviewing");
+  const at = (collapsedDecks?: ReadonlySet<string>) =>
+    layoutTaskBands(layout, [band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null, collapsedDecks }).layout.byPath.get(deckKey)!;
+  /* Told the deck is collapsed, the band reserves the chip height — an order of
+     magnitude short of the 810px it needs expanded, the empty task frame in the
+     report. Told it is expanded (a manual expand of a settled deck), it reserves
+     the full footprint. The set is authoritative over flow terminality. */
+  expect(at(new Set([deckKey])).h).toBeLessThanOrEqual(BAND.collapsedDeckH + 1);
+  expect(at(new Set()).h).toBeGreaterThan(400);
+  /* Without a set, an actionable flow's lifecycle default is expanded. */
+  expect(at(undefined).h).toBeGreaterThan(400);
+  /* And a settled flow's lifecycle default is collapsed. */
+  const settled = deckScene("approved");
+  expect(layoutTaskBands(settled.layout, [settled.band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null }).layout.byPath.get(deckKey)!.h).toBeLessThanOrEqual(BAND.collapsedDeckH + 1);
 });
 
-test("every band surface is screen-constant: a deck scales by the same law as the node tiles beside it (#1641)", () => {
+test("a band member physically scales with the camera within one presentation mode (#1641)", () => {
   const { layout, band, deckKey, nodePath } = deckScene("reviewing");
   const at = (zoom: number) => {
     const scene = layoutTaskBands(layout, [band], { zoom, mode: "near", viewportWidth: 1440, reader: null });
     return { deck: scene.layout.byPath.get(deckKey)!, node: scene.layout.byPath.get(nodePath)! };
   };
+  /* World geometry is stable, so within one presentation mode two zooms place
+     the SAME rectangle — the camera's own scale, not the layout, changes its
+     on-screen size. This is the operator's actual complaint: a card must get
+     bigger when zooming in and smaller when zooming out. */
   const one = at(1);
   const half = at(0.5);
-  /* World size scales as 1/zoom, so the on-screen size (world × zoom) holds
-     constant. The regression had the deck ride the raw board scale (screen size
-     halving with the camera) while the summary tiles stayed put. */
-  const screen = (rect: { w: number; h: number }, zoom: number) => ({ w: rect.w * zoom, h: rect.h * zoom });
-  const deckScreen1 = screen(one.deck, 1);
-  const deckScreenHalf = screen(half.deck, 0.5);
-  const nodeScreen1 = screen(one.node, 1);
-  const nodeScreenHalf = screen(half.node, 0.5);
-  expect(deckScreenHalf.w).toBeCloseTo(deckScreen1.w, 1);
-  expect(nodeScreenHalf.w).toBeCloseTo(nodeScreen1.w, 1);
-  /* One law, not two: the deck's on-screen width equals what the same shrink
-     applied to the node tile gives (both constant across the zoom change). */
-  expect(deckScreenHalf.w / deckScreen1.w).toBeCloseTo(nodeScreenHalf.w / nodeScreen1.w, 2);
+  expect(half.node.w).toBeCloseTo(one.node.w, 6);
+  expect(half.deck.w).toBeCloseTo(one.deck.w, 6);
+  /* On screen (world × zoom) the card therefore halves from 100% to 50%, and
+     the deck scales by the identical factor — one coherent geometry, not two. */
+  expect((half.node.w * 0.5) / (one.node.w * 1)).toBeCloseTo(0.5, 6);
+  expect((half.deck.w * 0.5) / (one.deck.w * 1)).toBeCloseTo(0.5, 6);
 });
 
-test("the band surface draws no free-board review-cycle arcs (#1641)", () => {
-  const { layout, band } = deckScene("reviewing");
-  expect(layout.loops.length).toBe(1);
-  const scene = layoutTaskBands(layout, [band], { zoom: 0.4, mode: "intermediate", viewportWidth: 1440, reader: null });
-  /* The fixed-offset forward/return arcs land nowhere near the band's wrapped,
-     counter-scaled cards; the band emits none, so no squiggle strands in the
-     empty space below its content. */
-  expect(scene.layout.loops).toEqual([]);
+test("the band routes the review connector between the placed implementer and deck, across wrapped rows (#1641)", () => {
+  const wide = deckScene("reviewing");
+  const scene = layoutTaskBands(wide.layout, [wide.band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null });
+  expect(scene.layout.loops.length).toBe(1);
+  const loop = scene.layout.loops[0]!;
+  const impl = scene.layout.byPath.get(wide.nodePath)!;
+  const deck = scene.layout.byPath.get(wide.deckKey)!;
+  /* The connector is drawn between the cards AS PLACED, not at fixed offsets:
+     both endpoints touch the actual implementer and deck rectangles, and it
+     carries a routed path — never a stranded squiggle. */
+  expect(loop.route).toBeTruthy();
+  expect(loop.y1).toBeDefined();
+  const onImpl = loop.x1! >= impl.x - 1 && loop.x1! <= impl.x + impl.w + 1 && loop.y1! >= impl.y - 1 && loop.y1! <= impl.y + impl.h + 1;
+  const onDeck = loop.x2! >= deck.x - 1 && loop.x2! <= deck.x + deck.w + 1 && loop.y2! >= deck.y - 1 && loop.y2! <= deck.y + deck.h + 1;
+  expect(onImpl).toBe(true);
+  expect(onDeck).toBe(true);
+  /* On a narrow board the deck wraps below the implementer; the connector
+     still attaches to both — top/bottom ports instead of side ports. */
+  const narrow = layoutTaskBands(wide.layout, [wide.band], { zoom: 1, mode: "near", viewportWidth: 700, reader: null });
+  const nLoop = narrow.layout.loops[0]!;
+  const nImpl = narrow.layout.byPath.get(wide.nodePath)!;
+  const nDeck = narrow.layout.byPath.get(wide.deckKey)!;
+  expect(Math.round(nImpl.y)).not.toBe(Math.round(nDeck.y));
+  expect(nLoop.route).toBeTruthy();
+  expect(nLoop.y1! >= nImpl.y - 1 && nLoop.y1! <= nImpl.y + nImpl.h + 1).toBe(true);
+  expect(nLoop.y2! >= nDeck.y - 1 && nLoop.y2! <= nDeck.y + nDeck.h + 1).toBe(true);
 });

--- a/src/components/scheme/taskBands.test.ts
+++ b/src/components/scheme/taskBands.test.ts
@@ -537,3 +537,91 @@ test("an empty band ends at its content instead of ruling a line across the canv
     expect(available - widthOf("many")).toBeLessThan(tile + 0.001);
   }
 });
+
+/* -- Board geometry: coherent member scaling, collapsed deck, no stray arcs -- */
+
+function reviewFlow(implementerPath: string, state: "approved" | "reviewing"): import("@/lib/flows/types").Flow {
+  return {
+    id: "flow-geom",
+    template: "implement-review-loop",
+    project: "fixture",
+    cwd: "/repo",
+    implementerPath,
+    roles: { implementer: { engine: "claude", model: "opus", effort: "high" }, reviewer: { engine: "claude", model: "opus", effort: "high" } },
+    baseRef: "0".repeat(40),
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state,
+    stateDetail: null,
+    rounds: [{ n: 1, reviewerPath: "/fixture/reviewer", verdict: state === "approved" ? "APPROVE" : null, findingsCount: state === "approved" ? 2 : null, findingsPath: null, triggeredBy: "marker", readyNote: null, startedAt: "2026-01-01T00:00:00Z", reviewedAt: null, relayedAt: null, error: null } as import("@/lib/flows/types").Round],
+    createdAt: "2026-01-01T00:00:00Z",
+    closedAt: null,
+  } as import("@/lib/flows/types").Flow;
+}
+
+/** A base layout carrying one node and one review deck, plus a hand-built band
+    that holds both as members — the shape `layoutTaskBands` places. */
+function deckScene(flowState: "approved" | "reviewing") {
+  const node = file(0, "busy");
+  const layout = base([node]);
+  const flow = reviewFlow(node.path, flowState);
+  const deckKey = "deck::flow-geom";
+  layout.decks = [{ key: deckKey, flow, rounds: [], x: 700, y: 100, w: 600, h: 810 }] as SchemeLayout["decks"];
+  layout.loops = [{ key: "loop::flow-geom", flow, x1: 600, x2: 700, y: 100 }] as SchemeLayout["loops"];
+  layout.byPath.set(deckKey, layout.decks[0]!);
+  const band: TaskBand = {
+    id: "task:geom", origin: "task", task: task("geom", "2026-01-01T00:00:00Z", [node]), pipeline: null, flow: null,
+    title: "Geometry", status: "assigned", hue: 0,
+    members: [{ key: node.path, kind: "node", file: node }, { key: deckKey, kind: "deck", file: null }],
+    mirrors: [], groups: [], working: 1, unknown: 0, conversations: 1, planned: 0, pinnedTop: false, createdAt: "2026-01-01T00:00:00Z",
+  };
+  return { layout, band, deckKey, nodePath: node.path };
+}
+
+test("a settled review deck reserves its collapsed chip height, not the full expanded box (#1641)", () => {
+  const { layout, band, deckKey } = deckScene("approved");
+  const scene = layoutTaskBands(layout, [band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null });
+  const deck = scene.layout.byPath.get(deckKey)!;
+  /* At 1:1 the world unit is a CSS pixel, so the reserved box is the collapsed
+     chip (BAND.collapsedDeckH), an order of magnitude short of the 810px it
+     would need expanded — the giant empty task frame in the report. */
+  expect(deck.h).toBeLessThanOrEqual(BAND.collapsedDeckH + 1);
+  /* An actionable deck still reserves its working height. */
+  const live = layoutTaskBands(deckScene("reviewing").layout, [deckScene("reviewing").band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null });
+  expect(live.layout.byPath.get(deckKey)!.h).toBeGreaterThan(400);
+});
+
+test("every band surface is screen-constant: a deck scales by the same law as the node tiles beside it (#1641)", () => {
+  const { layout, band, deckKey, nodePath } = deckScene("reviewing");
+  const at = (zoom: number) => {
+    const scene = layoutTaskBands(layout, [band], { zoom, mode: "near", viewportWidth: 1440, reader: null });
+    return { deck: scene.layout.byPath.get(deckKey)!, node: scene.layout.byPath.get(nodePath)! };
+  };
+  const one = at(1);
+  const half = at(0.5);
+  /* World size scales as 1/zoom, so the on-screen size (world × zoom) holds
+     constant. The regression had the deck ride the raw board scale (screen size
+     halving with the camera) while the summary tiles stayed put. */
+  const screen = (rect: { w: number; h: number }, zoom: number) => ({ w: rect.w * zoom, h: rect.h * zoom });
+  const deckScreen1 = screen(one.deck, 1);
+  const deckScreenHalf = screen(half.deck, 0.5);
+  const nodeScreen1 = screen(one.node, 1);
+  const nodeScreenHalf = screen(half.node, 0.5);
+  expect(deckScreenHalf.w).toBeCloseTo(deckScreen1.w, 1);
+  expect(nodeScreenHalf.w).toBeCloseTo(nodeScreen1.w, 1);
+  /* One law, not two: the deck's on-screen width equals what the same shrink
+     applied to the node tile gives (both constant across the zoom change). */
+  expect(deckScreenHalf.w / deckScreen1.w).toBeCloseTo(nodeScreenHalf.w / nodeScreen1.w, 2);
+});
+
+test("the band surface draws no free-board review-cycle arcs (#1641)", () => {
+  const { layout, band } = deckScene("reviewing");
+  expect(layout.loops.length).toBe(1);
+  const scene = layoutTaskBands(layout, [band], { zoom: 0.4, mode: "intermediate", viewportWidth: 1440, reader: null });
+  /* The fixed-offset forward/return arcs land nowhere near the band's wrapped,
+     counter-scaled cards; the band emits none, so no squiggle strands in the
+     empty space below its content. */
+  expect(scene.layout.loops).toEqual([]);
+});

--- a/src/components/scheme/taskBands.test.ts
+++ b/src/components/scheme/taskBands.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
+import { COLLAPSED_DECK_CHIP_H } from "@/components/flows/reviewDeckDisclosure";
 import { projectTaskWorkflows } from "@/components/tasks/taskWorkflowModel";
 
 import type { SchemeLayout, SchemeRect } from "./layout";
@@ -22,6 +23,8 @@ import {
   type BandMode,
   type TaskBand,
 } from "./taskBands";
+import { FLOW_HUB } from "@/components/flows/flowHubGeometry";
+import { sampleRoute } from "./taskGeometry";
 import { anchoredCamera } from "./useSchemeCamera";
 
 type Turn = "busy" | "terminal" | "idle" | "unknown" | null;
@@ -189,7 +192,7 @@ test("bands stack at content width at every mode and width; members, mirrors and
   for (const viewportWidth of [375, 680, 1024, 1280, 1440, 1920]) {
     for (const zoom of [0.07, 0.21, 0.22, 0.4, 0.58, 1]) {
       const mode = bandModeFor(zoom, null);
-      const scene = layoutTaskBands(layout, bands, { zoom, mode, viewportWidth, reader: files[5]!.path });
+      const scene = layoutTaskBands(layout, bands, { mode, viewportWidth, reader: files[5]!.path });
       /* Stable world geometry (#1641): a band member is one rectangle in board
          pixels and the camera's own scale grows or shrinks it, so nothing here
          divides by the zoom. The geometry depends on the zoom only through the
@@ -250,7 +253,7 @@ test("the local +Agent sits right after the last member, or opens the next row w
   const files = Array.from({ length: 12 }, (_, index) => file(index));
   const layout = base(files);
   const one = rankBands(buildTaskBands(layout, sources([task("one", "2026-01-01T00:00:00Z", [files[0]!])], files.slice(0, 1))));
-  const scene1 = layoutTaskBands(layout, one, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const scene1 = layoutTaskBands(layout, one, { mode: "intermediate", viewportWidth: 1440, reader: null });
   const single = scene1.bands[0]!;
   const member = single.members[0]!;
   const memberRect = scene1.layout.byPath.get(member.key)!;
@@ -260,7 +263,7 @@ test("the local +Agent sits right after the last member, or opens the next row w
   /* Four 320px tiles fill a 1440 row (24 gutter + 16 pad each side leaves
      1360; 4 × 320 + 3 × 24 = 1352): the +Agent must start the next row. */
   const four = rankBands(buildTaskBands(layout, sources([task("four", "2026-01-01T00:00:00Z", files.slice(0, 4))], files.slice(0, 4))));
-  const scene = layoutTaskBands(layout, four, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const scene = layoutTaskBands(layout, four, { mode: "intermediate", viewportWidth: 1440, reader: null });
   const band = scene.bands[0]!;
   const last = scene.layout.byPath.get(band.members[3]!.key)!;
   expect(band.geometry.addAgent.y).toBeGreaterThan(last.y + last.h - 0.001);
@@ -273,7 +276,7 @@ test("edges route between same-band members through side ports on a row and top/
   const files = Array.from({ length: 6 }, (_, index) => file(index));
   const layout = base(files, [[0, 1], [0, 5]]);
   const bands = rankBands(buildTaskBands(layout, sources([task("t", "2026-01-01T00:00:00Z", files)], files)));
-  const scene = layoutTaskBands(layout, bands, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const scene = layoutTaskBands(layout, bands, { mode: "intermediate", viewportWidth: 1440, reader: null });
   expect(scene.layout.edges.length).toBe(2);
   const sameRow = scene.layout.edges.find((edge) => edge.to === files[1]!.path)!;
   const from = scene.layout.byPath.get(files[0]!.path)!;
@@ -281,7 +284,7 @@ test("edges route between same-band members through side ports on a row and top/
   const wrapped = scene.layout.edges.find((edge) => edge.to === files[5]!.path)!;
   expect(wrapped.y1).toBeCloseTo(from.y + from.h, 6);
   expect(typeof wrapped.route).toBe("string");
-  const ports = bandEdgePorts({ x: 0, y: 0, w: 10, h: 10 }, { x: 0, y: 40, w: 10, h: 10 }, 1);
+  const ports = bandEdgePorts({ x: 0, y: 0, w: 10, h: 10 }, { x: 0, y: 40, w: 10, h: 10 });
   expect(ports).toEqual({ x1: 5, y1: 10, x2: 5, y2: 40 });
 });
 
@@ -293,7 +296,7 @@ test("350 tasks and 1,000 conversations project to one band per task and place e
   const bands = rankBands(buildTaskBands(layout, sources(tasks, files)));
   expect(bands.length).toBe(350);
   for (const zoom of [0.07, 0.4, 1]) {
-    const scene = layoutTaskBands(layout, bands, { zoom, mode: bandModeFor(zoom, null), viewportWidth: 1440, reader: files[0]!.path });
+    const scene = layoutTaskBands(layout, bands, { mode: bandModeFor(zoom, null), viewportWidth: 1440, reader: files[0]!.path });
     expect(scene.shown.size).toBe(1000);
     expect(scene.bands.length).toBe(350);
     expect(scene.taskRects.size).toBe(350);
@@ -316,7 +319,7 @@ test("a mirror never duplicates a node key, so the layer count equals the node c
   const bands: TaskBand[] = buildTaskBands(base(files), sources(tasks, files));
   expect(bands.flatMap((band) => band.members).length).toBe(2);
   expect(bands.flatMap((band) => band.mirrors).length).toBe(4);
-  const scene = layoutTaskBands(base(files), bands, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const scene = layoutTaskBands(base(files), bands, { mode: "intermediate", viewportWidth: 1440, reader: null });
   expect(scene.layout.nodes.length).toBe(2);
   expect(scene.mirrorRects.size).toBe(4);
 });
@@ -371,7 +374,7 @@ test("opening a shared conversation from its mirror hosts the one surface in tha
   /* Counts are unchanged and the node is still placed exactly once. */
   expect(a.working).toBe(1);
   expect(b.working).toBe(1);
-  const scene = layoutTaskBands(layout, bands, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null, hostOverrides: new Map([[files[0]!.path, "task:b"]]) });
+  const scene = layoutTaskBands(layout, bands, { mode: "intermediate", viewportWidth: 1440, reader: null, hostOverrides: new Map([[files[0]!.path, "task:b"]]) });
   expect(scene.bandOf.get(files[0]!.path)).toBe("task:b");
   expect(scene.layout.nodes.length).toBe(2);
   expect(scene.mirrorRects.size).toBe(1);
@@ -384,7 +387,7 @@ test("a recorded relation across bands becomes a labelled continuation on both e
   const tasks = [task("a", "2026-01-01T00:00:00Z", [files[0]!]), task("b", "2026-01-02T00:00:00Z", [files[1]!, files[0]!])];
   const layout = base(files, [[0, 1], [0, 2]]);
   const bands = rankBands(buildTaskBands(layout, sources(tasks, files)));
-  const scene = layoutTaskBands(layout, bands, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const scene = layoutTaskBands(layout, bands, { mode: "intermediate", viewportWidth: 1440, reader: null });
   /* Node 2 inherits its parent's band a; the edge 0→1 crosses a → b. */
   expect(scene.layout.edges.length).toBe(1);
   const byKey = new Map(scene.continuations.map((entry) => [entry.key, entry]));
@@ -403,7 +406,7 @@ test("a container halo stays inside its own band: a stage worker assigned to ano
   const layout = base(files);
   layout.groups = [{ key: "group::pipeline::p", kind: "pipeline", id: "p", hue: 10, members: files.slice(0, 2).map((entry) => entry.path), label: "Pipeline p", pipeline, x: 0, y: 0, w: 0, h: 0 }];
   const bands = rankBands(buildTaskBands(layout, { tasks, projection: projectTaskWorkflows(tasks, [pipeline], [], files), untitled: "Untitled task" }));
-  const scene = layoutTaskBands(layout, bands, { zoom: 0.5, mode: "intermediate", viewportWidth: 1440, reader: null });
+  const scene = layoutTaskBands(layout, bands, { mode: "intermediate", viewportWidth: 1440, reader: null });
   const halo = scene.layout.groups.find((group) => group.id === "p")!;
   const pipelineBand = scene.bands.find((band) => band.id === "task:t")!;
   const olderBand = scene.bands.find((band) => band.id === "task:older")!;
@@ -527,7 +530,7 @@ test("an empty band ends at its content instead of ruling a line across the canv
     task("many", "2026-01-03T00:00:00Z", files.slice(1)),
   ], files)));
   for (const [viewportWidth, zoom] of [[1440, 1], [1440, 1.6], [1920, 1], [1280, 0.5]] as const) {
-    const scene = layoutTaskBands(layout, bands, { zoom, mode: bandModeFor(zoom, null), viewportWidth, reader: null });
+    const scene = layoutTaskBands(layout, bands, { mode: bandModeFor(zoom, null), viewportWidth, reader: null });
     const widthOf = (id: string) => scene.bands.find((band) => band.task?.id === id)!.geometry.rect.w;
     const available = viewportWidth - BAND.gutter * 2;
     /* The whole complaint: an empty band used to be exactly as wide as a band
@@ -592,43 +595,42 @@ function deckScene(flowState: "approved" | "reviewing") {
 test("a review deck reserves its collapsed chip height by the operator's actual disclosure state (#1641)", () => {
   const { layout, band, deckKey } = deckScene("reviewing");
   const at = (collapsedDecks?: ReadonlySet<string>) =>
-    layoutTaskBands(layout, [band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null, collapsedDecks }).layout.byPath.get(deckKey)!;
+    layoutTaskBands(layout, [band], { mode: "near", viewportWidth: 1440, reader: null, collapsedDecks }).layout.byPath.get(deckKey)!;
   /* Told the deck is collapsed, the band reserves the chip height — an order of
      magnitude short of the 810px it needs expanded, the empty task frame in the
      report. Told it is expanded (a manual expand of a settled deck), it reserves
      the full footprint. The set is authoritative over flow terminality. */
-  expect(at(new Set([deckKey])).h).toBeLessThanOrEqual(BAND.collapsedDeckH + 1);
+  expect(at(new Set([deckKey])).h).toBe(COLLAPSED_DECK_CHIP_H);
   expect(at(new Set()).h).toBeGreaterThan(400);
   /* Without a set, an actionable flow's lifecycle default is expanded. */
   expect(at(undefined).h).toBeGreaterThan(400);
   /* And a settled flow's lifecycle default is collapsed. */
   const settled = deckScene("approved");
-  expect(layoutTaskBands(settled.layout, [settled.band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null }).layout.byPath.get(deckKey)!.h).toBeLessThanOrEqual(BAND.collapsedDeckH + 1);
+  expect(layoutTaskBands(settled.layout, [settled.band], { mode: "near", viewportWidth: 1440, reader: null }).layout.byPath.get(deckKey)!.h).toBe(COLLAPSED_DECK_CHIP_H);
 });
 
-test("a band member physically scales with the camera within one presentation mode (#1641)", () => {
+test("band geometry is board pixels the camera scales as one: the zoom is not a layout input (#1641)", () => {
   const { layout, band, deckKey, nodePath } = deckScene("reviewing");
-  const at = (zoom: number) => {
-    const scene = layoutTaskBands(layout, [band], { zoom, mode: "near", viewportWidth: 1440, reader: null });
-    return { deck: scene.layout.byPath.get(deckKey)!, node: scene.layout.byPath.get(nodePath)! };
+  const at = (mode: "intermediate" | "near") => {
+    const scene = layoutTaskBands(layout, [band], { mode, viewportWidth: 1440, reader: null });
+    return { deck: scene.layout.byPath.get(deckKey)!, node: scene.layout.byPath.get(nodePath)!, header: scene.bands[0]!.geometry.header };
   };
-  /* World geometry is stable, so within one presentation mode two zooms place
-     the SAME rectangle — the camera's own scale, not the layout, changes its
-     on-screen size. This is the operator's actual complaint: a card must get
-     bigger when zooming in and smaller when zooming out. */
-  const one = at(1);
-  const half = at(0.5);
-  expect(half.node.w).toBeCloseTo(one.node.w, 6);
-  expect(half.deck.w).toBeCloseTo(one.deck.w, 6);
-  /* On screen (world × zoom) the card therefore halves from 100% to 50%, and
-     the deck scales by the identical factor — one coherent geometry, not two. */
-  expect((half.node.w * 0.5) / (one.node.w * 1)).toBeCloseTo(0.5, 6);
-  expect((half.deck.w * 0.5) / (one.deck.w * 1)).toBeCloseTo(0.5, 6);
+  /* The two tile-scale modes place identical rectangles: the layout knows no
+     zoom, so the camera's own `scale(zoom)` is the only thing that changes a
+     card's on-screen size — and it changes the deck, the band frame and the
+     connectors by the same factor. (The browser harness measures that factor;
+     what a pure test can pin is that nothing here is counter-scaled.) */
+  const near = at("near");
+  const intermediate = at("intermediate");
+  expect(near.node).toEqual(intermediate.node);
+  expect(near.deck).toEqual(intermediate.deck);
+  expect(near.header.h).toBe(BAND.header);
+  expect(near.node.w).toBe(BAND.summaryW);
 });
 
 test("the band routes the review connector between the placed implementer and deck, across wrapped rows (#1641)", () => {
   const wide = deckScene("reviewing");
-  const scene = layoutTaskBands(wide.layout, [wide.band], { zoom: 1, mode: "near", viewportWidth: 1440, reader: null });
+  const scene = layoutTaskBands(wide.layout, [wide.band], { mode: "near", viewportWidth: 1440, reader: null });
   expect(scene.layout.loops.length).toBe(1);
   const loop = scene.layout.loops[0]!;
   const impl = scene.layout.byPath.get(wide.nodePath)!;
@@ -644,7 +646,7 @@ test("the band routes the review connector between the placed implementer and de
   expect(onDeck).toBe(true);
   /* On a narrow board the deck wraps below the implementer; the connector
      still attaches to both — top/bottom ports instead of side ports. */
-  const narrow = layoutTaskBands(wide.layout, [wide.band], { zoom: 1, mode: "near", viewportWidth: 700, reader: null });
+  const narrow = layoutTaskBands(wide.layout, [wide.band], { mode: "near", viewportWidth: 700, reader: null });
   const nLoop = narrow.layout.loops[0]!;
   const nImpl = narrow.layout.byPath.get(wide.nodePath)!;
   const nDeck = narrow.layout.byPath.get(wide.deckKey)!;
@@ -652,4 +654,50 @@ test("the band routes the review connector between the placed implementer and de
   expect(nLoop.route).toBeTruthy();
   expect(nLoop.y1! >= nImpl.y - 1 && nLoop.y1! <= nImpl.y + nImpl.h + 1).toBe(true);
   expect(nLoop.y2! >= nDeck.y - 1 && nLoop.y2! <= nDeck.y + nDeck.h + 1).toBe(true);
+});
+
+test("the review hub sits on the routed connector, clear of every card but its two endpoints (#1641)", () => {
+  /* Implementer, two helpers and the deck: on a 900px board the third card
+     wraps under the implementer and the deck wraps below that, so the
+     connector must thread past the wrapped helper — and the hub must not land
+     on it, which is where the corridor formula put it (inside the helper). */
+  const files = [file(0, "busy"), file(1), file(2)];
+  const layout = base(files);
+  const flow = reviewFlow(files[0]!.path, "reviewing");
+  const deckKey = "deck::flow-geom";
+  layout.decks = [{ key: deckKey, flow, rounds: [], x: 700, y: 100, w: 600, h: 810 }] as SchemeLayout["decks"];
+  layout.loops = [{ key: "loop::flow-geom", flow, x1: 600, x2: 700, y: 100 }] as SchemeLayout["loops"];
+  layout.byPath.set(deckKey, layout.decks[0]!);
+  const band: TaskBand = {
+    id: "task:geom", origin: "task", task: task("geom", "2026-01-01T00:00:00Z", files), pipeline: null, flow: null,
+    title: "Geometry", status: "assigned", hue: 0,
+    members: [...files.map((entry) => ({ key: entry.path, kind: "node" as const, file: entry })), { key: deckKey, kind: "deck", file: null }],
+    mirrors: [], groups: [], working: 1, unknown: 0, conversations: 3, planned: 0, pinnedTop: false, createdAt: "2026-01-01T00:00:00Z",
+  };
+  for (const viewportWidth of [1440, 900]) {
+    const scene = layoutTaskBands(layout, [band], { mode: "near", viewportWidth, reader: null });
+    const loop = scene.layout.loops[0]!;
+    expect(loop.hub).toBeDefined();
+    const hub = loop.hub!;
+    /* On the path: within a sample step of the drawn connector. */
+    const samples = sampleRoute(loop.route!);
+    const gap = Math.min(...samples.map((point) => Math.hypot(point.x - hub.x, point.y - hub.y)));
+    expect(gap).toBeLessThanOrEqual(1e-6);
+    /* And its box overlaps no card that is not an endpoint of the loop. */
+    for (const helper of files.slice(1)) {
+      const rect = scene.layout.byPath.get(helper.path)!;
+      const overlaps = hub.x + FLOW_HUB.w / 2 > rect.x && hub.x - FLOW_HUB.w / 2 < rect.x + rect.w && hub.y + FLOW_HUB.h / 2 > rect.y && hub.y - FLOW_HUB.h / 2 < rect.y + rect.h;
+      expect(overlaps).toBe(false);
+    }
+    /* The corridor formula the free board uses would have been wrong here:
+       level with the arcs' centre it lands 240px under the implementer's top,
+       inside the wrapped helper on the narrow board. */
+    if (viewportWidth === 900) {
+      const impl = scene.layout.byPath.get(files[0]!.path)!;
+      const wrapped = scene.layout.byPath.get(files[2]!.path)!;
+      const corridorY = impl.y + 240;
+      expect(corridorY > wrapped.y && corridorY < wrapped.y + wrapped.h).toBe(true);
+      expect(hub.y > wrapped.y && hub.y < wrapped.y + wrapped.h && hub.x > wrapped.x && hub.x < wrapped.x + wrapped.w).toBe(false);
+    }
+  }
 });

--- a/src/components/scheme/taskBands.ts
+++ b/src/components/scheme/taskBands.ts
@@ -508,6 +508,12 @@ export interface BandLayoutOptions {
       band shows the reference tile instead. Ignored unless the band holds a
       mirror of the node. */
   hostOverrides?: ReadonlyMap<string, string>;
+  /** Deck keys the operator is seeing collapsed to their verdict chip — the
+      actual disclosure state (localStorage override + lifecycle default). A
+      collapsed deck reserves the chip height so its band hugs; a manually
+      expanded settled deck reserves its full footprint. Absent it, the
+      lifecycle default decides. */
+  collapsedDecks?: ReadonlySet<string>;
 }
 
 /** A recorded relation whose other endpoint lives in another band: shown as a
@@ -574,7 +580,17 @@ export function applyHostOverrides(bands: readonly TaskBand[], overrides: Readon
 export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskBand[], options: BandLayoutOptions): BandScene {
   const { mode, viewportWidth, reader } = options;
   const bands = applyHostOverrides(orderedBands, options.hostOverrides);
-  const s = 1 / Math.max(0.07, options.zoom);
+  /* World geometry is stable: a band member is one rectangle in board pixels,
+     and the camera's own `scale(zoom)` is what makes it grow and shrink on
+     screen — so a card physically scales with the zoom, coherently with the
+     frame that holds it and the connectors between them. (The board once
+     divided every size by the zoom so the camera's later multiply cancelled
+     out and cards stayed screen-constant; that inverse-scale fed a zoom↔layout
+     loop the selection anchor then had to repair, and it is the reason cards
+     did not change size when the operator zoomed. Removed.) Zoom still chooses
+     the presentation — chip, summary, or the native reader — through
+     `bandModeFor`; only the size law is the camera's now. */
+  const s = 1;
   const gutter = (viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter) * s;
   /* The widest a band may become. Content decides the rest. */
   const maxBandW = Math.max(BAND.nativeMinW * s, viewportWidth * s - gutter * 2);
@@ -611,26 +627,16 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     const fit = w > maxInnerW ? maxInnerW / w : 1;
     return { w: w * fit, h: h * fit, fit };
   };
-  /* A deck, slot, draft or stack is authored in board pixels, but a band member
-     is screen-constant like the node tiles beside it: its world box is the base
-     footprint counter-scaled by `s`, and the shell renders its own content back
-     at natural size through that same `fit`. Without this the shell alone rode
-     the raw board scale, so it grew and shrank with the camera while the summary
-     tiles sharing its band held still — two coordinate systems in one row. A box
-     wider than the band shrinks further, contents included. */
-  const fittedShell = (bw: number, bh: number): { w: number; h: number; fit: number } => {
-    const overflow = bw * s > maxInnerW ? maxInnerW / (bw * s) : 1;
-    const fit = s * overflow;
-    return { w: bw * fit, h: bh * fit, fit };
-  };
-  /* A review-round deck whose flow reached its outcome renders as a one-line
-     verdict chip (its lifecycle default, RoundDeck's `deckDisclosureTerminal`).
-     The band must reserve that chip's height, not the full deck box it would
-     need expanded, or a settled review loop leaves a task frame that is almost
-     entirely empty with the cycle arcs stranded in the void below its cards. */
-  const collapsedDeckFlow = new Set(
-    base.decks.filter((deck) => deckDisclosureTerminal(deck.flow)).map((deck) => deck.key),
-  );
+  /* A review-round deck that renders as its one-line verdict chip must reserve
+     the chip's height, not the full deck box it would need expanded, or a
+     collapsed review loop leaves a task frame almost entirely empty. Which decks
+     are collapsed is the operator's actual disclosure state (the localStorage
+     override plus the lifecycle default), passed in by SchemeBoard so a manual
+     expand of a settled deck re-opens its full footprint; absent it (SSR, a
+     pure test) the lifecycle default stands in. */
+  const collapsedDecks = options.collapsedDecks
+    ?? new Set(base.decks.filter((deck) => deckDisclosureTerminal(deck.flow)).map((deck) => deck.key));
+  const deckKeyOfFlow = new Map(base.decks.map((deck) => [deck.flow.id, deck.key] as const));
   let cursorY = gutter;
   for (const band of bands) {
     const items: { key: string; w: number; h: number; fit?: number; kind: "member" | "mirror" | "container" | "add"; node?: SchemeNode }[] = [];
@@ -652,8 +658,8 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       if (mode === "overview" && member.kind !== "draft") continue;
       const rect = baseRect.get(member.key);
       if (!rect) continue;
-      const shellH = member.kind === "deck" && collapsedDeckFlow.has(member.key) ? BAND.collapsedDeckH : rect.h;
-      const natural = fittedShell(rect.w, shellH);
+      const shellH = member.kind === "deck" && collapsedDecks.has(member.key) ? BAND.collapsedDeckH : rect.h;
+      const natural = fitted(rect.w * s, shellH * s);
       items.push({ key: member.key, w: natural.w, h: natural.h, fit: natural.fit, kind: "member" });
     }
     for (const mirror of band.mirrors) {
@@ -796,14 +802,25 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     groups,
     byPath,
     links: base.links.filter((link) => placed.has(link.from) && placed.has(link.to)),
-    /* No free-board review-cycle arcs on the band surface. LoopsLayer draws its
-       forward/return arcs at fixed board-pixel offsets (LOOP_ARC_TOP/BOT,
-       REACH, BULGE) sized for the 780px pair of a spatial board; a band wraps
-       its implementer and reviewer deck into independent screen-constant rows,
-       so those arcs land nowhere near either card and read as a stranded
-       squiggle in the band's empty space. The implement↔review relationship is
-       already legible from both surfaces sharing the one task band. */
-    loops: [],
+    /* The review cycle is drawn between the implementer card and the reviewer
+       deck AS THEY ARE PLACED — same-row side ports, or top/bottom ports when
+       the deck wrapped to a later row — and routed around the other cards in
+       the band, exactly like the lineage edges above. Carrying the routed path
+       and both endpoints lets LoopsLayer draw the connector to the real cards
+       instead of the fixed-offset arcs it used for a 780px side-by-side pair,
+       which on a wrapped band stranded a squiggle in the empty space. */
+    loops: base.loops.flatMap((loop) => {
+      const implKey = loop.flow.implementerPath;
+      const deckKey = deckKeyOfFlow.get(loop.flow.id);
+      const impl = placed.get(implKey);
+      const deckRect = deckKey ? placed.get(deckKey) : undefined;
+      if (!impl || !deckRect || !deckKey) return [];
+      const bandId = bandOf.get(implKey);
+      if (!bandId || bandId !== bandOf.get(deckKey)) return [];
+      const ports = bandEdgePorts(impl, deckRect, s);
+      const route = routeTaskEdge(ports, rectsIn(bandId, [implKey, deckKey]));
+      return [{ ...loop, x1: ports.x1, y1: ports.y1, x2: ports.x2, y2: ports.y2, route: route.d }];
+    }),
     stacks: base.stacks.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     decks: base.decks.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     drafts: base.drafts.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),

--- a/src/components/scheme/taskBands.ts
+++ b/src/components/scheme/taskBands.ts
@@ -2,7 +2,8 @@ import { conversationIdentity } from "@/lib/accounts/identity";
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { taskShowsOnBoard } from "@/lib/tasks/boardVisibility";
-import { deckDisclosureTerminal } from "@/components/flows/reviewDeckDisclosure";
+import { COLLAPSED_DECK_CHIP_H, deckDisclosureTerminal } from "@/components/flows/reviewDeckDisclosure";
+import { FLOW_HUB } from "@/components/flows/flowHubGeometry";
 import type { BoardTask, TaskStatus } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
@@ -12,7 +13,7 @@ import { cleanTitle } from "@/components/utils";
 
 import { hueFromId } from "./agentLinks";
 import type { SchemeEdge, SchemeGroup, SchemeLayout, SchemeNode, SchemeRect } from "./layout";
-import { routeTaskEdge } from "./taskGeometry";
+import { routeTaskEdge, sampleRoute } from "./taskGeometry";
 
 /**
  * Task-centered board (#1586): every admitted conversation belongs to exactly
@@ -431,8 +432,12 @@ export function applyBandOrder(ranked: readonly TaskBand[], frozen: readonly str
 /* Geometry                                                                   */
 /* ------------------------------------------------------------------------- */
 
-/** CSS-pixel constants of the band chrome; the layout divides by zoom so every
-    one of them is constant on screen at any scale. */
+/** Board-pixel constants of the band chrome. World geometry is stable: a band
+    member is one rectangle in board pixels and the camera's own `scale(zoom)`
+    is what grows or shrinks it on screen, so a card, the frame that holds it
+    and the connectors between them scale together (#1641). Zoom still chooses
+    the presentation — chip, summary or the native reader — via `bandModeFor`;
+    nothing here is divided by it. */
 export const BAND = {
   containerW: 280,
   containerH: 44,
@@ -457,10 +462,10 @@ export const BAND = {
   mirrorH: 72,
   mirrorChipW: 220,
   minOverviewH: 72,
-  /* Board height a settled review-round deck occupies as its collapsed verdict
-     chip (RoundDeck's `h-12` plus the shell's own rounding), so a band holding
-     one hugs the chip instead of the full expanded deck box. */
-  collapsedDeckH: 56,
+  /* Board height a review-round deck occupies as its collapsed verdict chip —
+     the height RoundDeck paints the chip at — so a band holding one hugs the
+     chip instead of the full expanded deck box. */
+  collapsedDeckH: COLLAPSED_DECK_CHIP_H,
   /* A band is only as wide as it needs to be (#1590 follow-up). Below this it
      is unreadable — the header alone carries a title, a status pill, counts and
      two controls — and above it nothing is gained by growing further, so a band
@@ -489,8 +494,6 @@ export interface BandScene {
   /** `task::<id>` → header rect, so focus/glide on a task lands on its band. */
   taskRects: Map<string, SchemeRect>;
   mirrorRects: Map<string, SchemeRect>;
-  /** World units per CSS pixel (1 / zoom). */
-  scale: number;
   /** Band id per placed key, for same-band edge filtering and hit tests. */
   bandOf: Map<string, string>;
   /** Cross-band recorded relations, per attached member/mirror. */
@@ -498,7 +501,6 @@ export interface BandScene {
 }
 
 export interface BandLayoutOptions {
-  zoom: number;
   mode: BandMode;
   viewportWidth: number;
   /** Conversation whose reader is native in near mode. */
@@ -534,9 +536,9 @@ function union(rects: readonly SchemeRect[]): SchemeRect {
 /** Directed ports between two placed rects: side ports on the same row, top/
     bottom ports across rows; the port height stays near the header so a tall
     reader's arrow leaves where its title is. */
-export function bandEdgePorts(a: SchemeRect, b: SchemeRect, scale: number): { x1: number; y1: number; x2: number; y2: number } {
+export function bandEdgePorts(a: SchemeRect, b: SchemeRect): { x1: number; y1: number; x2: number; y2: number } {
   const sameRow = a.y < b.y + b.h && b.y < a.y + a.h;
-  const portY = (rect: SchemeRect) => rect.y + Math.min(rect.h / 2, 40 * scale);
+  const portY = (rect: SchemeRect) => rect.y + Math.min(rect.h / 2, 40);
   if (sameRow) {
     return a.x + a.w <= b.x
       ? { x1: a.x + a.w, y1: portY(a), x2: b.x, y2: portY(b) }
@@ -547,13 +549,6 @@ export function bandEdgePorts(a: SchemeRect, b: SchemeRect, scale: number): { x1
     : { x1: a.x + a.w / 2, y1: a.y, x2: b.x + b.w / 2, y2: b.y + b.h };
 }
 
-/**
- * Stack the ordered bands top to bottom at full available width and wrap their
- * members into rows. Node footprints are screen-constant per mode (chip /
- * summary / native reader); slots, decks, drafts and stacks keep their base
- * footprint. The returned layout carries every placed surface at its final
- * rectangle, so cards, halos, hit targets and edge endpoints agree.
- */
 /** Swap a conversation's surface into the band the operator opened it in: the
     override band's mirror becomes the member and the canonical band keeps a
     mirror, so the reader owner is one and the counts do not change. */
@@ -577,32 +572,52 @@ export function applyHostOverrides(bands: readonly TaskBand[], overrides: Readon
   return next;
 }
 
+/** Where the ⟳ hub of a review loop sits: ON the routed connector, as close
+    to its middle as a hub-sized box can be without covering a card that is
+    not one of the loop's two endpoints. The connector already threads between
+    the band's other cards; the hub is wider than a stroke, so it walks along
+    the path from the middle outward until its box is clear. */
+export function hubOnRoute(route: string, others: readonly SchemeRect[]): { x: number; y: number } {
+  const points = sampleRoute(route);
+  const mid = Math.floor(points.length / 2);
+  const clear = (point: { x: number; y: number }) => !others.some((rect) =>
+    point.x + FLOW_HUB.w / 2 > rect.x && point.x - FLOW_HUB.w / 2 < rect.x + rect.w
+    && point.y + FLOW_HUB.h / 2 > rect.y && point.y - FLOW_HUB.h / 2 < rect.y + rect.h);
+  for (let step = 0; step < points.length; step += 1) {
+    for (const index of [mid + step, mid - step]) {
+      const point = points[index];
+      if (point && clear(point)) return point;
+    }
+  }
+  return points[mid] ?? { x: 0, y: 0 };
+}
+
+/**
+ * Stack the ordered bands top to bottom and wrap their members into rows, in
+ * board pixels the camera scales as one. Node footprints follow the mode
+ * (chip / summary / native reader); slots, decks, drafts and stacks keep their
+ * base footprint, a collapsed deck its chip. The returned layout carries every
+ * placed surface at its final rectangle, so cards, halos, hit targets, edge
+ * endpoints and the review hub agree. The zoom is deliberately not an input:
+ * the board once divided every size by it so the camera's multiply cancelled
+ * out and cards stayed screen-constant, which is why cards did not change size
+ * when the operator zoomed and why every zoom frame forced a relayout (#1641).
+ */
 export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskBand[], options: BandLayoutOptions): BandScene {
   const { mode, viewportWidth, reader } = options;
   const bands = applyHostOverrides(orderedBands, options.hostOverrides);
-  /* World geometry is stable: a band member is one rectangle in board pixels,
-     and the camera's own `scale(zoom)` is what makes it grow and shrink on
-     screen — so a card physically scales with the zoom, coherently with the
-     frame that holds it and the connectors between them. (The board once
-     divided every size by the zoom so the camera's later multiply cancelled
-     out and cards stayed screen-constant; that inverse-scale fed a zoom↔layout
-     loop the selection anchor then had to repair, and it is the reason cards
-     did not change size when the operator zoomed. Removed.) Zoom still chooses
-     the presentation — chip, summary, or the native reader — through
-     `bandModeFor`; only the size law is the camera's now. */
-  const s = 1;
-  const gutter = (viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter) * s;
+  const gutter = viewportWidth < 1024 ? BAND.gutterNarrow : BAND.gutter;
   /* The widest a band may become. Content decides the rest. */
-  const maxBandW = Math.max(BAND.nativeMinW * s, viewportWidth * s - gutter * 2);
-  const pad = BAND.pad * s;
-  const itemGap = (mode === "overview" ? BAND.chipGap : BAND.tileGap) * s;
-  const rowGap = (mode === "overview" ? BAND.chipGap : BAND.rowGap) * s;
-  const headerH = BAND.header * s;
+  const maxBandW = Math.max(BAND.nativeMinW, viewportWidth - gutter * 2);
+  const pad = BAND.pad;
+  const itemGap = mode === "overview" ? BAND.chipGap : BAND.tileGap;
+  const rowGap = mode === "overview" ? BAND.chipGap : BAND.rowGap;
+  const headerH = BAND.header;
   /* Members are measured against the widest a band could be, then the band is
      narrowed to the row they actually occupied — measuring against a width that
      the band has not been given yet would wrap a row that fits. */
   const maxInnerW = maxBandW - pad * 2;
-  const minBandW = Math.min(maxBandW, BAND.minBandW * s);
+  const minBandW = Math.min(maxBandW, BAND.minBandW);
   const innerX0 = gutter + pad;
   const innerRight = gutter + maxBandW - pad;
 
@@ -647,10 +662,10 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
            up: clicking a tile opens it in place, siblings stay tiles. */
         const presentation = mode === "overview" ? "chip" : member.key === reader ? "native" : "summary";
         const natural = fitted(
-          (presentation === "chip" ? BAND.chipW : presentation === "native" ? Math.max(BAND.nativeMinW, Math.min(BAND.nativeW, maxInnerW / s)) : BAND.summaryW) * s,
-          (presentation === "chip" ? BAND.chipH : presentation === "native" ? BAND.nativeH : BAND.summaryH) * s,
+          presentation === "chip" ? BAND.chipW : presentation === "native" ? Math.max(BAND.nativeMinW, Math.min(BAND.nativeW, maxInnerW)) : BAND.summaryW,
+          presentation === "chip" ? BAND.chipH : presentation === "native" ? BAND.nativeH : BAND.summaryH,
         );
-        items.push({ key: member.key, w: natural.w, h: natural.h, kind: "member", node: { ...node, presentation, readerScale: s * natural.fit, w: natural.w, h: natural.h } });
+        items.push({ key: member.key, w: natural.w, h: natural.h, kind: "member", node: { ...node, presentation, readerScale: natural.fit, w: natural.w, h: natural.h } });
         continue;
       }
       /* Decks, stacks and planned slots are thumbnails at overview scale:
@@ -659,11 +674,11 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       const rect = baseRect.get(member.key);
       if (!rect) continue;
       const shellH = member.kind === "deck" && collapsedDecks.has(member.key) ? BAND.collapsedDeckH : rect.h;
-      const natural = fitted(rect.w * s, shellH * s);
+      const natural = fitted(rect.w, shellH);
       items.push({ key: member.key, w: natural.w, h: natural.h, fit: natural.fit, kind: "member" });
     }
     for (const mirror of band.mirrors) {
-      const natural = fitted((mode === "overview" ? BAND.mirrorChipW : BAND.mirrorW) * s, (mode === "overview" ? BAND.chipH : BAND.mirrorH) * s);
+      const natural = fitted(mode === "overview" ? BAND.mirrorChipW : BAND.mirrorW, mode === "overview" ? BAND.chipH : BAND.mirrorH);
       items.push({ key: mirror.key, w: natural.w, h: natural.h, kind: "mirror" });
     }
     /* A hosted pipeline/flow with none of its surfaces placed in this mode
@@ -673,9 +688,9 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     for (const groupKey of band.groups) {
       const group = base.groups.find((entry) => entry.key === groupKey);
       if (!group || group.members.some((key) => placedKeys.has(key) || mirrored.has(key))) continue;
-      items.push({ key: groupKey, w: (mode === "overview" ? BAND.chipW : BAND.containerW) * s, h: (mode === "overview" ? BAND.chipH : BAND.containerH) * s, kind: "container" });
+      items.push({ key: groupKey, w: mode === "overview" ? BAND.chipW : BAND.containerW, h: mode === "overview" ? BAND.chipH : BAND.containerH, kind: "container" });
     }
-    items.push({ key: `add::${band.id}`, w: BAND.addW * s, h: (mode === "overview" ? BAND.chipH : BAND.addH) * s, kind: "add" });
+    items.push({ key: `add::${band.id}`, w: BAND.addW, h: mode === "overview" ? BAND.chipH : BAND.addH, kind: "add" });
 
     let x = innerX0;
     let y = cursorY + headerH + pad;
@@ -684,7 +699,7 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     /* Rightmost inked edge across every row, so the band can be trimmed to the
        content it actually holds instead of to the width it was measured in. */
     let contentRight = innerX0;
-    let addAgent: SchemeRect = { x, y, w: BAND.addW * s, h: BAND.addH * s };
+    let addAgent: SchemeRect = { x, y, w: BAND.addW, h: BAND.addH };
     for (const item of items) {
       if (x + item.w > innerRight + 0.001 && x > innerX0) {
         x = innerX0;
@@ -709,7 +724,7 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       rowH = Math.max(rowH, item.h);
     }
     let bandH = headerH + pad + (y - (cursorY + headerH + pad)) + rowH + pad;
-    if (mode === "overview") bandH = Math.max(bandH, BAND.minOverviewH * s);
+    if (mode === "overview") bandH = Math.max(bandH, BAND.minOverviewH);
     /* The band ends where its content ends. The floor keeps the header
        readable — title, status, counts, Details and «+ Agent» all live on one
        screen-constant row — and the ceiling is the width it was measured in, so
@@ -719,7 +734,7 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     const header = { x: gutter, y: cursorY, w: bandW, h: headerH };
     if (band.task) taskRects.set(`task::${band.task.id}`, header);
     placedBands.push({ ...band, geometry: { rect, header, addAgent, rows } });
-    cursorY += bandH + BAND.gap * s;
+    cursorY += bandH + BAND.gap;
   }
 
   const byPath = new Map<string, SchemeRect>(placed);
@@ -760,7 +775,7 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       for (const rep of representations.get(edge.to) ?? []) continue_(rep, { key: edge.from, bandId: bandOf.get(edge.from)!, direction: "from" });
       return [];
     }
-    const ports = bandEdgePorts(from, to, s);
+    const ports = bandEdgePorts(from, to);
     const route = routeTaskEdge(ports, rectsIn(bandOf.get(edge.from)!, [edge.from, edge.to]));
     return [{ ...edge, ...ports, route: route.d, routeCrosses: route.crosses }];
   });
@@ -791,8 +806,8 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       return slot ? [{ ...group, members: [], ...slot }] : [];
     }
     const envelope = union(local.map((key) => placed.get(key)!));
-    const padX = 12 * s;
-    const heading = 30 * s;
+    const padX = 12;
+    const heading = 30;
     return [{ ...group, members: local, x: envelope.x - padX, y: envelope.y - heading, w: envelope.w + padX * 2, h: envelope.h + heading + padX }];
   });
   const layout: SchemeLayout = {
@@ -817,17 +832,18 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       if (!impl || !deckRect || !deckKey) return [];
       const bandId = bandOf.get(implKey);
       if (!bandId || bandId !== bandOf.get(deckKey)) return [];
-      const ports = bandEdgePorts(impl, deckRect, s);
-      const route = routeTaskEdge(ports, rectsIn(bandId, [implKey, deckKey]));
-      return [{ ...loop, x1: ports.x1, y1: ports.y1, x2: ports.x2, y2: ports.y2, route: route.d }];
+      const ports = bandEdgePorts(impl, deckRect);
+      const others = rectsIn(bandId, [implKey, deckKey]);
+      const route = routeTaskEdge(ports, others);
+      return [{ ...loop, x1: ports.x1, y1: ports.y1, x2: ports.x2, y2: ports.y2, route: route.d, hub: hubOnRoute(route.d, others) }];
     }),
     stacks: base.stacks.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     decks: base.decks.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     drafts: base.drafts.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     slots: base.slots.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     regionTasks: [],
-    width: viewportWidth * s,
+    width: viewportWidth,
     height: cursorY + gutter,
   };
-  return { layout, bands: placedBands, shown, mode, taskRects, mirrorRects, scale: s, bandOf, continuations: [...continuationByKey.values()] };
+  return { layout, bands: placedBands, shown, mode, taskRects, mirrorRects, bandOf, continuations: [...continuationByKey.values()] };
 }

--- a/src/components/scheme/taskBands.ts
+++ b/src/components/scheme/taskBands.ts
@@ -2,6 +2,7 @@ import { conversationIdentity } from "@/lib/accounts/identity";
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { taskShowsOnBoard } from "@/lib/tasks/boardVisibility";
+import { deckDisclosureTerminal } from "@/components/flows/reviewDeckDisclosure";
 import type { BoardTask, TaskStatus } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
@@ -456,6 +457,10 @@ export const BAND = {
   mirrorH: 72,
   mirrorChipW: 220,
   minOverviewH: 72,
+  /* Board height a settled review-round deck occupies as its collapsed verdict
+     chip (RoundDeck's `h-12` plus the shell's own rounding), so a band holding
+     one hugs the chip instead of the full expanded deck box. */
+  collapsedDeckH: 56,
   /* A band is only as wide as it needs to be (#1590 follow-up). Below this it
      is unreadable — the header alone carries a title, a status pill, counts and
      two controls — and above it nothing is gained by growing further, so a band
@@ -606,6 +611,26 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     const fit = w > maxInnerW ? maxInnerW / w : 1;
     return { w: w * fit, h: h * fit, fit };
   };
+  /* A deck, slot, draft or stack is authored in board pixels, but a band member
+     is screen-constant like the node tiles beside it: its world box is the base
+     footprint counter-scaled by `s`, and the shell renders its own content back
+     at natural size through that same `fit`. Without this the shell alone rode
+     the raw board scale, so it grew and shrank with the camera while the summary
+     tiles sharing its band held still — two coordinate systems in one row. A box
+     wider than the band shrinks further, contents included. */
+  const fittedShell = (bw: number, bh: number): { w: number; h: number; fit: number } => {
+    const overflow = bw * s > maxInnerW ? maxInnerW / (bw * s) : 1;
+    const fit = s * overflow;
+    return { w: bw * fit, h: bh * fit, fit };
+  };
+  /* A review-round deck whose flow reached its outcome renders as a one-line
+     verdict chip (its lifecycle default, RoundDeck's `deckDisclosureTerminal`).
+     The band must reserve that chip's height, not the full deck box it would
+     need expanded, or a settled review loop leaves a task frame that is almost
+     entirely empty with the cycle arcs stranded in the void below its cards. */
+  const collapsedDeckFlow = new Set(
+    base.decks.filter((deck) => deckDisclosureTerminal(deck.flow)).map((deck) => deck.key),
+  );
   let cursorY = gutter;
   for (const band of bands) {
     const items: { key: string; w: number; h: number; fit?: number; kind: "member" | "mirror" | "container" | "add"; node?: SchemeNode }[] = [];
@@ -627,7 +652,8 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       if (mode === "overview" && member.kind !== "draft") continue;
       const rect = baseRect.get(member.key);
       if (!rect) continue;
-      const natural = fitted(rect.w, rect.h);
+      const shellH = member.kind === "deck" && collapsedDeckFlow.has(member.key) ? BAND.collapsedDeckH : rect.h;
+      const natural = fittedShell(rect.w, shellH);
       items.push({ key: member.key, w: natural.w, h: natural.h, fit: natural.fit, kind: "member" });
     }
     for (const mirror of band.mirrors) {
@@ -770,12 +796,14 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     groups,
     byPath,
     links: base.links.filter((link) => placed.has(link.from) && placed.has(link.to)),
-    loops: base.loops.flatMap((loop) => {
-      const impl = placed.get(loop.flow.implementerPath);
-      const deck = base.decks.find((entry) => entry.flow.id === loop.flow.id);
-      const target = deck ? placed.get(deck.key) : undefined;
-      return impl && target ? [{ ...loop, x1: impl.x + impl.w, x2: target.x, y: impl.y }] : [];
-    }),
+    /* No free-board review-cycle arcs on the band surface. LoopsLayer draws its
+       forward/return arcs at fixed board-pixel offsets (LOOP_ARC_TOP/BOT,
+       REACH, BULGE) sized for the 780px pair of a spatial board; a band wraps
+       its implementer and reviewer deck into independent screen-constant rows,
+       so those arcs land nowhere near either card and read as a stranded
+       squiggle in the band's empty space. The implement↔review relationship is
+       already legible from both surfaces sharing the one task band. */
+    loops: [],
     stacks: base.stacks.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     decks: base.decks.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),
     drafts: base.drafts.flatMap((rect) => (placed.has(rect.key) ? [{ ...rect, ...placed.get(rect.key)! }] : [])),

--- a/src/components/scheme/taskGeometry.test.ts
+++ b/src/components/scheme/taskGeometry.test.ts
@@ -13,6 +13,7 @@ import {
   routePathsBounds,
   routeTaskEdge,
   routeTaskEdges,
+  sampleRoute,
   TASK_ACTION_ROW_H,
   TASK_DISCLOSURE_H,
   TASK_PREVIEW_CLAMP,
@@ -1232,4 +1233,21 @@ describe("taskEdgesSignature — poll-stable route cache key (Finding 2)", () =>
     expect(taskEdgesSignature(edges, [{ id: "a", x: 80, y: 10, w: 260, h: 100 }], [])).not.toBe(base);
     expect(taskEdgesSignature(edges, cards, [{ x: 0, y: 0, w: 10, h: 10 }])).not.toBe(base);
   });
+});
+
+test("sampleRoute walks the M/L/C commands the routers emit, endpoints included (#1641)", () => {
+  const cubic = sampleRoute("M 0 0 C 50 0, 50 100, 100 100", 4);
+  expect(cubic[0]).toEqual({ x: 0, y: 0 });
+  expect(cubic[cubic.length - 1]).toEqual({ x: 100, y: 100 });
+  expect(cubic.length).toBe(5);
+  /* t = 0.5 of that S-curve is its midpoint. */
+  expect(cubic[2]!.x).toBeCloseTo(50, 6);
+  expect(cubic[2]!.y).toBeCloseTo(50, 6);
+  const detour = sampleRoute("M 0 0 L 0 40 L 80 40 L 80 0", 2);
+  expect(detour.map((point) => `${point.x},${point.y}`)).toEqual(["0,0", "0,20", "0,40", "40,40", "80,40", "80,20", "80,0"]);
+  /* A routed edge's midpoint sample coincides with its reported mid. */
+  const route = routeTaskEdge({ x1: 0, y1: 0, x2: 200, y2: 60 }, []);
+  const samples = sampleRoute(route.d, 2);
+  expect(samples[1]!.x).toBeCloseTo(route.mid.x, 6);
+  expect(samples[1]!.y).toBeCloseTo(route.mid.y, 6);
 });

--- a/src/components/scheme/taskGeometry.ts
+++ b/src/components/scheme/taskGeometry.ts
@@ -642,6 +642,37 @@ function detourRoute(
  * Pure and deterministic — depends only on the endpoints, the lane, and the
  * obstacle rects.
  */
+/**
+ * Points along a routed path, in path order — the polyline a `routeTaskEdge`
+ * / detour `d` string draws, sampled densely enough to place something ON the
+ * connector (the review hub) without the DOM. Reads the three commands those
+ * routers emit (`M`, `L`, `C`); anything else ends the walk.
+ */
+export function sampleRoute(d: string, perSegment = 16): { x: number; y: number }[] {
+  const points: { x: number; y: number }[] = [];
+  const tokens = d.match(/[MLCZ]|-?\d*\.?\d+(?:e[-+]?\d+)?/gi) ?? [];
+  let index = 0;
+  let cursor = { x: 0, y: 0 };
+  const num = () => Number(tokens[index++]);
+  while (index < tokens.length) {
+    const command = tokens[index++];
+    if (command === "M" || command === "L") {
+      const next = { x: num(), y: num() };
+      if (command === "M") points.push(next);
+      else for (let i = 1; i <= perSegment; i += 1) points.push({ x: cursor.x + (next.x - cursor.x) * (i / perSegment), y: cursor.y + (next.y - cursor.y) * (i / perSegment) });
+      cursor = next;
+    } else if (command === "C") {
+      const c1x = num(), c1y = num(), c2x = num(), c2y = num(), x = num(), y = num();
+      for (let i = 1; i <= perSegment; i += 1) {
+        const t = i / perSegment;
+        points.push({ x: cubicAt(t, cursor.x, c1x, c2x, x), y: cubicAt(t, cursor.y, c1y, c2y, y) });
+      }
+      cursor = { x, y };
+    } else break;
+  }
+  return points;
+}
+
 export function routeTaskEdge(
   edge: { x1: number; y1: number; x2: number; y2: number },
   obstacles: readonly SchemeRect[],

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -81,6 +81,10 @@ interface CameraOptions {
       centred zoom would only open a gap beside the band). The selection anchor
       still corrects both axes; horizontal panning stays available to come back. */
   lockX?: boolean;
+  /** Zoom an opened conversation is framed at (#1641). On the physical-scaling
+      band board a reader's size follows the camera, so an open reaches for a
+      fuller zoom than the bare readable floor; defaults to `READABLE_Z`. */
+  focusZoom?: number;
 }
 
 export interface SchemeAnchor {
@@ -272,6 +276,7 @@ export function useSchemeCamera({
   onFit,
   anchor = null,
   lockX = false,
+  focusZoom = READABLE_Z,
 }: CameraOptions): SchemeCamera {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const tapRef = useRef<{ x: number; y: number } | null>(null);
@@ -746,16 +751,22 @@ export function useSchemeCamera({
     if (aim.at && sameRect(aim.at, node) && aim.cam && cameraMatchesFraming(cam, aim.cam)) return;
     const rect = viewportRef.current?.getBoundingClientRect();
     if (!rect || !(rect.width > 1) || !(rect.height > 1)) return;
-    const z = Math.min(MAX_Z, Math.max(cam.z, READABLE_Z));
+    /* The zoom an open reaches for. On the physical-scaling band board a card's
+       size follows the camera, so opening a conversation at the bare readable
+       floor would leave its reader shrunk; the band asks for a fuller zoom so
+       the opened conversation reads prominently. Never below the readable floor,
+       and never past the current zoom downward. */
+    const openZoom = Math.max(focusZoom, READABLE_Z);
+    const z = Math.min(MAX_Z, Math.max(cam.z, openZoom));
     aim.at = { x: node.x, y: node.y, w: node.w, h: node.h };
     aim.cam = alignX(centredCamera(node, z, { w: rect.width, h: rect.height }));
     aiming.current = true;
     try {
-      centerOn(node, READABLE_Z);
+      centerOn(node, openZoom);
     } finally {
       aiming.current = false;
     }
-  }, [focus, project, layout, taskRects, cam, vp, centerOn, alignX]);
+  }, [focus, project, layout, taskRects, cam, vp, centerOn, alignX, focusZoom]);
 
   /* Wheel: plain — pan (shift turns it horizontal); ctrl/cmd (and trackpad
      pinch) — zoom at the cursor. The only surface that keeps the wheel for

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -758,8 +758,13 @@ export function useSchemeCamera({
   }, [focus, project, layout, taskRects, cam, vp, centerOn, alignX]);
 
   /* Wheel: plain — pan (shift turns it horizontal); ctrl/cmd (and trackpad
-     pinch) — zoom at the cursor. In select mode a wheel over a scrollable
-     feed keeps native scrolling. */
+     pinch) — zoom at the cursor. The only surface that keeps the wheel for
+     itself is a scroll container under the pointer with content to scroll —
+     the open conversation reader's feed, or a scrollable panel floating over
+     the board. Everything else pans, so a wheel over the task background, a
+     band's header controls, «+ Agent», a mirror tile or a collapsed agent card
+     moves the board instead of being swallowed by a control that cannot use it
+     (#1641). */
   useEffect(() => {
     const el = viewportRef.current;
     if (!el) return;
@@ -769,8 +774,20 @@ export function useSchemeCamera({
       if (wheelSettle.current) window.clearTimeout(wheelSettle.current);
       wheelSettle.current = window.setTimeout(() => setManualNonce((n) => n + 1), 250);
     };
+    /* The nearest ancestor between the target and the viewport that can consume
+       vertical wheel: overflowing content in an auto/scroll box. Interactive
+       chrome that does not scroll (a button, a status pill, a card that is not
+       an open reader) returns nothing, so the board pans over it. */
+    const scrollableAncestor = (target: HTMLElement | null): HTMLElement | null => {
+      for (let node = target; node && node !== el; node = node.parentElement) {
+        if (node.scrollHeight > node.clientHeight + 1) {
+          const overflowY = getComputedStyle(node).overflowY;
+          if (overflowY === "auto" || overflowY === "scroll") return node;
+        }
+      }
+      return null;
+    };
     const onWheel = (event: WheelEvent) => {
-      if ((event.target as HTMLElement).closest("[data-scheme-ui]")) return;
       const rect = el.getBoundingClientRect();
       if (event.ctrlKey || event.metaKey) {
         event.preventDefault();
@@ -778,14 +795,8 @@ export function useSchemeCamera({
         armSettle();
         return;
       }
-      if (modeRef.current === "select" && !spaceRef.current) {
-        for (let node = event.target as HTMLElement | null; node && node !== el; node = node.parentElement) {
-          if (node.scrollHeight > node.clientHeight + 1) {
-            const overflowY = getComputedStyle(node).overflowY;
-            if (overflowY === "auto" || overflowY === "scroll") return;
-          }
-        }
-      }
+      /* A held Space is an explicit hand-pan and overrides even a feed. */
+      if (!spaceRef.current && scrollableAncestor(event.target as HTMLElement | null)) return;
       event.preventDefault();
       const dx = event.shiftKey && !event.deltaX ? event.deltaY : event.deltaX;
       const dy = event.shiftKey && !event.deltaX ? 0 : event.deltaY;

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -14,9 +14,10 @@ const EDGE_KEEP = 120;
 const OFF_WORLD_SETTLE_MS = 300;
 
 const MODE_KEY = "llvSchemeMode";
-/* Band board framings (#1586): content is screen-constant, so "fit" cannot
-   shrink it into the viewport. Fit All frames the task overview from the top at
-   chip scale; Fit Current frames the top (working) bands at tile scale. */
+/* Band board framings (#1586): the band stack is a document taller than any
+   viewport, so "fit" frames it from the top at a chosen scale rather than
+   shrinking it in. Fit All frames the task overview at chip scale; Fit Current
+   frames the top (working) bands at tile scale. */
 export const BAND_FIT_ALL_Z = 0.2;
 export const BAND_FIT_CURRENT_Z = 0.58;
 
@@ -76,10 +77,13 @@ interface CameraOptions {
       through zoom and relayout (#1586): key identifies the projection, rect is
       its current world box. Null when nothing is selected. */
   anchor?: SchemeAnchor | null;
-  /** Full-width band layouts: gesture and button zoom keep the world's left
-      edge where it is (the world is exactly one viewport wide, so a pointer-
-      centred zoom would only open a gap beside the band). The selection anchor
-      still corrects both axes; horizontal panning stays available to come back. */
+  /** Band layouts read as a document (#1641): the band stack is exactly one
+      viewport wide in world pixels, so whenever it fits the viewport (zoom at
+      or below 1) the camera keeps its left edge on the viewport's — no dead
+      canvas beside the bands, from any zoom, framing, anchor hold, resize or
+      pan; when the stack is wider than the viewport the camera may show any
+      part of it but never past its edges. Every camera the hook settles on the
+      band board goes through this rule, the selection anchor included. */
   lockX?: boolean;
   /** Zoom an opened conversation is framed at (#1641). On the physical-scaling
       band board a reader's size follows the camera, so an open reaches for a
@@ -376,11 +380,18 @@ export function useSchemeCamera({
     },
     [world, vp],
   );
-  /* Horizontal zoom origin: the pointer on the free map, the world's left edge
-     on the band board (see `lockX`). Explicit framings on the band board align
-     that edge with the viewport's; only the selection anchor may offset it. */
-  const zoomOriginX = useCallback((cx: number, c: Camera) => (lockX ? c.x - world.x * c.z : cx), [lockX, world.x]);
-  const alignX = useCallback((c: Camera): Camera => (lockX ? { ...c, x: -world.x * c.z } : c), [lockX, world.x]);
+  /* The document rule of the band board (see `lockX`): a world that fits the
+     viewport horizontally sits on its left edge; a wider one is clamped so
+     neither of its edges leaves a gap. Identity on the free map. */
+  const alignX = useCallback((c: Camera): Camera => {
+    if (!lockX) return c;
+    const left = -world.x * c.z;
+    if (world.w * c.z <= vp.w) return c.x === left ? c : { ...c, x: left };
+    const x = Math.min(left, Math.max(vp.w - (world.x + world.w) * c.z, c.x));
+    return x === c.x ? c : { ...c, x };
+  }, [lockX, world.x, world.w, vp.w]);
+  /* Every gesture and framing settles through both rules. */
+  const settle = useCallback((c: Camera): Camera => alignX(clampCam(c)), [alignX, clampCam]);
 
   /* Selection anchor (#1586). Every commit records where the selected
      projection's top-left sits on screen. When the next commit finds the same
@@ -409,7 +420,11 @@ export function useSchemeCamera({
     const sx = cam.x + rect.x * cam.z;
     const sy = cam.y + rect.y * cam.z;
     if (prev && prev.key === anchor.key && !explicit && (prev.z !== cam.z || prev.wx !== rect.x || prev.wy !== rect.y)) {
-      const next = anchoredCamera(prev, rect, cam.z);
+      /* The hold is exact on the free map. On the band board the document
+         rule outranks it horizontally (#1641): a reader that wrapped to
+         another row keeps its vertical screen position, and the band stack
+         stays on the viewport's left edge instead of following the tile. */
+      const next = alignX(anchoredCamera(prev, rect, cam.z));
       if (Math.abs(next.x - cam.x) > 0.01 || Math.abs(next.y - cam.y) > 0.01) {
         anchorRef.current = { key: anchor.key, sx: next.x + rect.x * cam.z, sy: next.y + rect.y * cam.z, wx: rect.x, wy: rect.y, z: cam.z };
         latestCam.current = next;
@@ -418,7 +433,7 @@ export function useSchemeCamera({
       }
     }
     anchorRef.current = { key: anchor.key, sx, sy, wx: rect.x, wy: rect.y, z: cam.z };
-  }, [anchor, cam]);
+  }, [anchor, cam, alignX]);
 
   /* High-rate gestures (wheel, pointermove, pinch) coalesce into one camera
      update per frame: updater functions queue up and compose inside a single
@@ -451,11 +466,10 @@ export function useSchemeCamera({
         const z = Math.min(MAX_Z, Math.max(MIN_Z, c.z * factor));
         if (z === c.z) return c;
         const k = z / c.z;
-        const ox = zoomOriginX(cx, c);
-        return clampCam({ z, x: ox - (ox - c.x) * k, y: cy - (cy - c.y) * k });
+        return settle({ z, x: cx - (cx - c.x) * k, y: cy - (cy - c.y) * k });
       });
     },
-    [clampCam, queueCam, zoomOriginX],
+    [settle, queueCam],
   );
 
   const zoomCenter = useCallback(
@@ -475,12 +489,12 @@ export function useSchemeCamera({
         const z = Math.min(MAX_Z, Math.max(MIN_Z, targetZ));
         if (z === c.z) return c;
         const k = z / c.z;
-        const cx = zoomOriginX(rect.width / 2, c);
+        const cx = rect.width / 2;
         const cy = rect.height / 2;
-        return clampCam({ z, x: cx - (cx - c.x) * k, y: cy - (cy - c.y) * k });
+        return settle({ z, x: cx - (cx - c.x) * k, y: cy - (cy - c.y) * k });
       });
     },
-    [clampCam, zoomOriginX],
+    [settle],
   );
 
   const fitCam = useCallback((): Camera | null => {
@@ -516,10 +530,10 @@ export function useSchemeCamera({
   const fit = useCallback(() => {
     const c = fitCam();
     if (c) {
-      glideTo(clampCam(c));
+      glideTo(settle(c));
       onFit?.("all");
     }
-  }, [fitCam, glideTo, clampCam, onFit]);
+  }, [fitCam, glideTo, settle, onFit]);
 
   const currentFitCam = useCallback((): Camera | null => {
     const rect = viewportRef.current?.getBoundingClientRect();
@@ -531,14 +545,14 @@ export function useSchemeCamera({
   const fitCurrent = useCallback(() => {
     const c = currentFitCam();
     if (!c) return;
-    glideTo(clampCam(c));
+    glideTo(settle(c));
     onFit?.(currentWork ? "current" : "all");
-  }, [currentFitCam, glideTo, clampCam, onFit, currentWork]);
+  }, [currentFitCam, glideTo, settle, onFit, currentWork]);
 
   const fitCurrentOrAll = useCallback(() => {
     const current = currentFitCam();
     if (!current) return;
-    const target = clampCam(current);
+    const target = settle(current);
     if (currentWork && cameraMatchesFraming(latestCam.current, target)) {
       fit();
       return;
@@ -546,15 +560,15 @@ export function useSchemeCamera({
     latestCam.current = target;
     glideTo(target);
     onFit?.(currentWork ? "current" : "all");
-  }, [currentFitCam, currentWork, clampCam, fit, glideTo, onFit]);
+  }, [currentFitCam, currentWork, settle, fit, glideTo, onFit]);
 
   const fitRect = useCallback(
     (r: SchemeRect) => {
       const rect = viewportRef.current?.getBoundingClientRect();
       if (!rect || r.w <= 0 || r.h <= 0) return;
-      glideTo(clampCam(alignX(fitCameraToRect(r, { w: rect.width, h: rect.height }))));
+      glideTo(settle(fitCameraToRect(r, { w: rect.width, h: rect.height })));
     },
-    [glideTo, clampCam, alignX],
+    [glideTo, settle],
   );
 
   /* Glide a node into view: centered horizontally, its head near the top so
@@ -572,9 +586,9 @@ export function useSchemeCamera({
      translate the camera the opposite way (× z) so it holds its screen spot. */
   const glideBy = useCallback(
     (wdx: number, wdy: number) => {
-      glideTo((c) => clampCam({ ...c, x: c.x - wdx * c.z, y: c.y - wdy * c.z }));
+      glideTo((c) => settle({ ...c, x: c.x - wdx * c.z, y: c.y - wdy * c.z }));
     },
-    [glideTo, clampCam],
+    [glideTo, settle],
   );
 
   /* Restore an exact camera — #688's return point, which puts back a framing
@@ -582,9 +596,9 @@ export function useSchemeCamera({
      position verbatim (still clamped, since the world may have shrunk). */
   const glideToCamera = useCallback(
     (next: { x: number; y: number; zoom: number }) => {
-      glideTo(clampCam({ x: next.x, y: next.y, z: next.zoom }));
+      glideTo(settle({ x: next.x, y: next.y, z: next.zoom }));
     },
-    [glideTo, clampCam],
+    [glideTo, settle],
   );
 
   /* The keyboard zoom ladder: same centered/head-near-top placement as
@@ -595,14 +609,14 @@ export function useSchemeCamera({
       if (!rect) return;
       const zz = Math.min(MAX_Z, Math.max(MIN_Z, z));
       glideTo(
-        clampCam(alignX({
+        settle({
           z: zz,
           x: rect.width / 2 - (node.x + node.w / 2) * zz,
           y: Math.min(rect.height / 2 - node.y * zz, rect.height * 0.08 - (node.y - 40) * zz),
-        })),
+        }),
       );
     },
-    [glideTo, clampCam, alignX],
+    [glideTo, settle],
   );
 
   /* First layout of a project: restore the saved camera or fit everything.
@@ -740,15 +754,26 @@ export function useSchemeCamera({
        that conversation, not merely for its rectangle to be somewhere in the
        viewport, so returning to one from the overview scale still zooms in to
        it — the guarantee `centerOn(node, 0.55)` has always carried. Only once
-       an aim has been taken does "already shown" complete the request. */
-    if (aim.at && nodeIsFramed(node, cam, vp)) {
-      focusAim.current = null;
-      return;
+       an aim has been taken AGAINST THE RECTANGLE THE NODE STILL HAS does
+       "already shown" complete the request: the aim promised the framing
+       `centredCamera` computes for that rectangle, and a rectangle that moved
+       since (the tile it was taken against became the reader and wrapped to
+       the next row, the bands re-measured for a mode change) has not been
+       given that framing — its head may be on screen, its composer below the
+       fold, with the space it was promised sitting empty above it (#1641).
+       Such a node is aimed at again; a node whose rectangle is stable and
+       framed discharges the request, and a stable one that the aim could not
+       frame is left alone rather than fought over. */
+    if (aim.at && sameRect(aim.at, node)) {
+      if (nodeIsFramed(node, cam, vp)) {
+        focusAim.current = null;
+        return;
+      }
+      /* Our own aim is already standing and the node is still not framed:
+         there is nothing further this rule can do, and repeating the move
+         would only fight whatever is holding the camera. */
+      if (aim.cam && cameraMatchesFraming(cam, aim.cam)) return;
     }
-    /* Our own aim is already standing and the node is still not framed: there
-       is nothing further this rule can do, and repeating the move would only
-       fight whatever is holding the camera. */
-    if (aim.at && sameRect(aim.at, node) && aim.cam && cameraMatchesFraming(cam, aim.cam)) return;
     const rect = viewportRef.current?.getBoundingClientRect();
     if (!rect || !(rect.width > 1) || !(rect.height > 1)) return;
     /* The zoom an open reaches for. On the physical-scaling band board a card's
@@ -811,7 +836,7 @@ export function useSchemeCamera({
       event.preventDefault();
       const dx = event.shiftKey && !event.deltaX ? event.deltaY : event.deltaX;
       const dy = event.shiftKey && !event.deltaX ? 0 : event.deltaY;
-      queueCam((c) => clampCam({ ...c, x: c.x - dx, y: c.y - dy }));
+      queueCam((c) => settle({ ...c, x: c.x - dx, y: c.y - dy }));
       armSettle();
     };
     el.addEventListener("wheel", onWheel, { passive: false });
@@ -819,7 +844,7 @@ export function useSchemeCamera({
       el.removeEventListener("wheel", onWheel);
       if (wheelSettle.current) window.clearTimeout(wheelSettle.current);
     };
-  }, [applyZoom, clampCam, queueCam]);
+  }, [applyZoom, settle, queueCam]);
 
   /* Keyboard: H/V tools, Space-hold temporary hand, +/−/1 zoom, 0 fit,
      arrows pan, Esc drops the selection. */
@@ -975,8 +1000,7 @@ export function useSchemeCamera({
         queueCam((c) => {
           const z = Math.min(MAX_Z, Math.max(MIN_Z, c.z * factor));
           const k = z / c.z;
-          const ox = zoomOriginX(pinch.cx, c);
-          return clampCam({ z, x: lockX ? ox - (ox - c.x) * k : cx - (pinch.cx - c.x) * k, y: cy - (pinch.cy - c.y) * k });
+          return settle({ z, x: cx - (pinch.cx - c.x) * k, y: cy - (pinch.cy - c.y) * k });
         });
         pinchRef.current = { d, cx, cy };
         return;
@@ -989,7 +1013,7 @@ export function useSchemeCamera({
     /* Past the 9px tap threshold this is a real drag, not a click — mark it so
        its end re-baselines nav. */
     if (Math.hypot(dx, dy) > 9) panMovedRef.current = true;
-    queueCam((c) => clampCam({ ...c, x: pan.cx + dx, y: pan.cy + dy }));
+    queueCam((c) => settle({ ...c, x: pan.cx + dx, y: pan.cy + dy }));
   };
 
   /* Gestures end on window-level listeners: a pointerup outside the viewport
@@ -1083,9 +1107,9 @@ export function useSchemeCamera({
   const jump = useCallback(
     (wx: number, wy: number) => {
       framingRef.current = true;
-      setCam((c) => clampCam(alignX({ ...c, x: vp.w / 2 - wx * c.z, y: vp.h / 2 - wy * c.z })));
+      setCam((c) => settle({ ...c, x: vp.w / 2 - wx * c.z, y: vp.h / 2 - wy * c.z }));
     },
-    [vp, clampCam, alignX],
+    [vp, settle],
   );
 
   return {


### PR DESCRIPTION
Closes #1639. Repairs the task-centered board geometry the operator reported: cards that do not change size when zooming, a huge empty task/review-loop frame, disconnected squiggle arrows, a conversation click that flies elsewhere, and a wheel that dies over band controls and collapsed cards.

## What changed

The board once divided every card size by the zoom so the camera's later multiply cancelled out and cards stayed screen-constant. That inverse-scale fed a zoom↔layout feedback loop the selection anchor kept repairing, and it is why cards did not change size when the operator zoomed. This gives the board **stable world geometry** (root's top architecture recommendation): a band member is one rectangle in board pixels, and the camera's own `scale(zoom)` grows and shrinks it — so a card, its band frame and the connectors between them scale together as one coherent geometry.

- **Physical card scaling.** `layoutTaskBands` no longer counter-scales by `1/zoom`; the semantic thresholds still choose the presentation (chip / summary / native reader), only the size law is the camera's now.
- **Review connector routed to the real endpoints.** The implement↔review cycle is drawn between the implementer card and the reviewer deck AS PLACED — side ports on one row, top/bottom ports when the deck wrapped to a later row — routed around the other cards, with an arrowhead at each end. The relationship is a drawn connector, not co-location, and no longer a stranded fixed-offset squiggle.
- **Compact frame by actual disclosure.** A deck reserves its collapsed chip height by the operator's real disclosure state (the localStorage override plus the lifecycle default), threaded in from `SchemeBoard` and re-read when `RoundDeck` toggles it, so a manually expanded settled deck reserves its full footprint.
- **Opened readers stay prominent.** Under physical scaling a conversation is framed at a fuller zoom (`focusZoom`) so its reader reads large instead of shrinking to the readable floor.
- **Wheel routing.** The board pans over the task background, band header controls, «+ Agent», mirror tiles and collapsed cards; only a scroll container under the pointer — an open reader's feed or a scrollable panel — keeps the wheel. A held Space still forces a hand-pan.

## Source pin

Branched from `main` at `22ca4557`.

## Causal browser checks

`scripts/capture-board-geometry.ts` serves the production build under a synthetic home and drives real pointer + wheel input at a wide (1400×900) and a narrow (830×600) viewport across overview / intermediate / near zoom. It asserts:

- a summary tile **halves on screen from 80% to 40% zoom** while its deck and band frame scale by the identical factor (physical, coherent);
- the review connector's endpoints touch the implementer card and the reviewer deck, including when the deck wrapped to a later row;
- a settled review band hugs its content, no connector dangling below it;
- clicking a conversation frames **that exact conversation** as its reader from every zoom entry (overview / intermediate / near) and on a repeat open, camera settling once;
- the wheel pans over band background / Details / «+ Agent» / a collapsed card, and the open reader's feed keeps its own scroll.

Every assertion is a negative control (round 1, against `22ca4557`): against the base module it reads **red** (a tile scaling 1.00× between 80% and 40% — cards do not follow the camera; a 778px empty frame; no connector between implementer and deck plus a dangling squiggle; an 810px deck reserving a 48px chip; a click landing nowhere; a wheel over controls moving 0px). Against this commit it is **green** at both viewports across all three zoom levels. Unit checks in `taskBands.test.ts` pin the physical scaling, the disclosure-driven collapse and the routed wrapped-row connector, and are themselves red on the base module.

## Checks

- `tsc --noEmit --incremental false`: clean.
- `bun test` on the touched suites (`taskBands.test.ts`, `SchemeBoard.bands.dom.test.tsx`, `SchemeBoard.camera.dom.test.tsx`, `useSchemeCamera.test.ts`, `useSchemeCamera.focus.dom.test.tsx`, `layout.test.ts`): green. (Board DOM suites are red on `main` already — issue #1624. Measured **per file** under an isolated state directory, `src/components/scheme/` and `src/components/flows/` total 23 failures at the merge base and 23 at this head, the same set of files; the aggregate `bun test` sweep over both directories reports 24 on both trees through cross-file `mock.module` leakage and cannot show a one-file delta, so it is not the gate.)
- Privacy publication gate: PASS.

No merge, no deploy. The native Codex queue / Voice work (PR #1636) stays separate; this touches only the outer board geometry, layout, navigation and wheel routing, and the wheel policy passes a scroll container (the native bounded queue scroller) through unchanged.

## Round 2 — the six review findings

Reviewed SHA `d50a670a` drew REQUEST_CHANGES with six findings; every one is fixed here, each with a check that is red on `d50a670a` and green on this commit.

- **The ⟳ hub sits on the routed connector.** The band layout samples the routed review connector (`sampleRoute`, M/L/C only — the three commands the routers emit) and places the hub on it, walking from the middle outward until a hub-sized box (`FLOW_HUB`, the size FlowHub renders) clears every card that is not one of the two endpoints; `AgentLinksLayer` reads that point off `FlowLoop.hub` and keeps the corridor formula only for the free board. Unit test: on a 900px board the corridor formula lands inside the wrapped helper, the routed hub does not. Browser: hub centre within a few px of the drawn path, covering no unrelated card, wide and narrow, near zoom.
- **An open frames what it promised, from any zoom.** The focus obligation discharged the moment the node's head was visible, even when the aim had been taken against the summary tile that then became the reader and wrapped 192 world px lower in the same commit as the aimed camera (so the anchor re-baselined instead of holding). Now a node whose rectangle moved since the aim is aimed at again; only a stable, framed rectangle discharges. Browser: the reader's top lands within 4px of the `centredCamera` target at every entry zoom and on repeat opens, its bottom on screen whenever it fits — before: 275px down from 50%, 287px from 95%.
- **The band board is a document (the `lockX` rule, held everywhere).** `alignX` now pins the stack's left edge whenever it fits the viewport and clamps to its edges when it is wider; every camera the hook settles on the band board — gestures, framings, the selection anchor's hold, jump, restore — goes through it (`settle = alignX ∘ clampCam`). `zoomOriginX` is gone: the pointer is the zoom origin everywhere, and the rule decides the rest. The anchor keeps a selected reader's vertical screen position through zoom and reflow; horizontally the stack stays put and the tile moves within it. Two DOM tests that encoded the old two-axis hold (and a horizontal-only drag) now assert the document rule. Browser: `|cam.x| ≤ 1` after a resize with a reader open, after every framing, after reload — before: x = 334 after resize, 410 after an overview-entry open.
- **The harness crosses the operator's criteria.** Real `Control`+wheel for the pinch path, real mouse clicks on the toolbar, real keys for 100% / fit current / fit all / ±, a real resize, a real reload for restore, Arrow navigation, deck expand→collapse on the settled deck asserting the reserved frame and no overlap, and a selector-free nested scroll box injected into a card that keeps the wheel (the PR #1636 queue shape). Click framing asserts the exact promised top, the bottom when it fits, the horizontal span and the document rule — no more "first 140px" / ">18%".
- **The inverse-scale machinery is deleted.** `BandLayoutOptions.zoom`, the `s = 1` multiplier and its sites, `BandScene.scale`, the counter-scale transforms in `TaskBandsLayer`, `SchemeBoard`'s `layoutZoom` state and the relayout on every zoom frame; the two docstrings that still asserted the 1/zoom law are rewritten.
- **One chip height.** `COLLAPSED_DECK_CHIP_H` is read by RoundDeck's chip (inline height) and by the band layout, and the RoundDeck DOM test asserts the chip is painted at it.

Negative control: the same harness file served the `d50a670a` build — 22 failures, including the hub 191–727px off the connector, 56px reserved for a 48px chip, a reader top at 275px (promised 102) with its bottom 60–106px below the fold, dead canvas x=410 after an overview-entry open and x=7 after a resize — and this build: 0 failures. Round-2 evidence lives beside the round-1 evidence in the private artifact directory (measurements + frames for both builds, and the round-2 before/after report).

## Round 3 — the coordinate-space test guard

Review of `9050672f` confirmed every product behaviour above independently and found one thing: `SchemeBoard.catalogFocus.dom.test.tsx` was green by path at the merge base and red at that head. Its behavioural assertions (band count, readable, native presentation — the #1625 promise) still held; what failed was the fixture-depth guard, a bare `> 2500` written in the counter-scaled unit this PR deletes. The card sits at the same physical depth, now 2072 board pixels, and the earlier claim that this branch added no failure was wrong for that file.

- **The guard is restated in the unit the world uses now, against the viewport.** The requested conversation's depth must exceed `VIEWPORT.height`: at the zooms the board frames a reader, a head more than a whole viewport down the stack cannot share a screen with its top, so the open has to move the camera. The behavioural assertions above it are untouched.
- **Negative control:** with the fixture's target moved into the first band the guard reads 280 and the test fails; at this head it is 4 pass / 0 fail.
- **Per-file totals are back at the merge base's:** 23 across the two directories on both trees, the same files red on both; only pass counts rose (the new `taskBands` and `taskGeometry` unit checks).
- No product source changed in this round, so the round-2 browser approval of `9050672f` stands for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

