### PR TITLE
fix(spawn): a reviewer refused for missing reviews leaves recoverable evidence (#1641)

### DIFF
--- a/docs/design/spawn-admission-fence.md
+++ b/docs/design/spawn-admission-fence.md
@@ -1,0 +1,70 @@
+# The spawn admission fence, and what recovery may conclude from it
+
+A launch dispatched through the MCP `spawn_agent` tool carries a downstream key
+derived from the caller's `clientRequestId`. When the dispatch is interrupted —
+the host dies, the connection resets, the answer is unreadable — the caller
+recovers that exact key rather than launching again. Recovery may report only
+what durable state can prove:
+
+| what durable state holds | recovery reports |
+| --- | --- |
+| a launch receipt for the key | `accepted` / `in-flight` / `settled` |
+| an admission fence whose digest is the bound request | `not-executed` |
+| neither | `unknown` — execution remains possible |
+
+`unknown` is the safe answer and it never decays into `failed`. A bare HTTP 400,
+or the current absence of a conversation, proves nothing about what the server
+did before it answered: only the fence does.
+
+## Every pre-reservation refusal writes the fence
+
+`POST /api/spawn` refuses a number of requests before it reserves anything.
+Recovery cannot distinguish "refused before reservation" from "reserved and then
+lost" unless each of those refusals leaves a request-bound compare-and-set fence
+behind. Issue #1641 was one refusal that did not: a reviewer launch naming no
+`reviews` answered 400 and wrote nothing, so its owner's key stayed `unknown`
+indefinitely and the reviewer could be neither recovered nor safely relaunched.
+
+Two branches reach that same refusal, and both fence:
+
+- **Role resolution, then the mandatory reviewer contract.** Viewer control
+  calls (the MCP dispatch and its recovery probe alike) present a same-origin
+  marker, so this is the branch a tool-dispatched launch takes.
+- **The agent lineage refusal**, for a request that arrives without that marker
+  — an agent calling the endpoint directly with its own spawn capability. It
+  fires earlier, on the same missing field.
+
+`mandatoryReviewsError` in `src/app/api/spawn/admission.ts` is the single
+predicate behind both, and `/api/spawn/validate` — the endpoint recovery probes
+— applies it too. A validator that calls a launch admissible while the route
+refuses it is the drift that made this unrecoverable; sharing the predicate is
+what prevents it returning.
+
+## The caller is authenticated before any fence is written
+
+A fence is terminal for its key. An unauthenticated caller must never be able to
+burn a key that belongs to someone else, so both paths establish the caller
+before the first refusal that fences. `/api/spawn` still defers its 403 until
+after validation, so a stranger learns the ordinary refusal and nothing more —
+it simply writes no fence while doing so. `/api/spawn/validate` answers the
+stranger 403 outright.
+
+Precedence is unchanged, and the compare-and-set enforces it under the account
+lock:
+
+- A launch receipt that already owns the key wins: no fence is written, and the
+  refusal reports `fenced: false`, which keeps recovery at `unknown`.
+- A fence already held for the key with a **different** request digest is a
+  conflict: the refusal reports `fenced: false`, and a later reservation on that
+  key answers 409. A corrected launch uses a new key.
+
+## Recovering a stranded launch
+
+1. The owning caller replays its recovery with the **unchanged** original
+   arguments and the original `clientRequestId`. Any changed field produces a
+   different digest, which the fence contradicts, and the answer stays
+   `unknown`.
+2. A `not-executed` outcome with evidence `spawn-admission-fence` is
+   authoritative: nothing was launched, and the reason names the refusal.
+3. Only then may a corrected launch go out, under a **new** key, with the field
+   the refusal named.

--- a/src/app/api/spawn/admission.ts
+++ b/src/app/api/spawn/admission.ts
@@ -46,6 +46,28 @@ export function isAgentInitiatedSpawn(req: Pick<NextRequest, "headers">): boolea
   }
 }
 
+export const REVIEWER_REQUIRES_REVIEWS_ERROR = "reviewer requires reviews";
+export const REVIEWS_REQUIRE_REVIEWER_ERROR = "reviews requires role: reviewer";
+
+/**
+ * The mandatory reviewer contract, as ONE predicate (#1641).
+ *
+ * `/api/spawn` and `/api/spawn/validate` both call this, so the validator
+ * cannot report a launch admissible that the route then refuses. That drift is
+ * what left a reviewer spawn rejected for a missing `reviews` permanently
+ * unknown: the route answered a bare 400 without a request-bound fence, and
+ * recovery — which trusts only the fence — had nothing terminal to read.
+ *
+ * `role` is the RESOLVED role id (or null when the request names none), so a
+ * role alias or override cannot smuggle a reviewer past the check.
+ */
+export function mandatoryReviewsError(role: string | null, body: { reviews?: unknown }): string | null {
+  if (role === "reviewer") {
+    return typeof body.reviews === "string" && body.reviews.trim() ? null : REVIEWER_REQUIRES_REVIEWS_ERROR;
+  }
+  return body.reviews === undefined ? null : REVIEWS_REQUIRE_REVIEWER_ERROR;
+}
+
 /** Lineage no longer gates admission on `src` (#341): the durable parent is
     inferred from the authenticated caller conversation, so agent-initiated
     requests only need their admission identity (`role`, plus `reviews` for
@@ -57,9 +79,7 @@ export function agentSpawnLineageError(
   if (!isAgentInitiatedSpawn(req)) return null;
   if (body.src !== undefined && (typeof body.src !== "string" || !body.src.trim())) return AGENT_SPAWN_LINEAGE_ERROR;
   if (typeof body.role !== "string" || !body.role.trim()) return AGENT_SPAWN_LINEAGE_ERROR;
-  if (body.role.trim() === "reviewer" && (typeof body.reviews !== "string" || !body.reviews.trim())) {
-    return AGENT_SPAWN_LINEAGE_ERROR;
-  }
+  if (body.role.trim() === "reviewer" && mandatoryReviewsError("reviewer", body)) return AGENT_SPAWN_LINEAGE_ERROR;
   return null;
 }
 

--- a/src/app/api/spawn/validate/route.test.ts
+++ b/src/app/api/spawn/validate/route.test.ts
@@ -5,8 +5,11 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 
+import { AGENT_SPAWN_LINEAGE_ERROR } from "@/app/api/spawn/admission";
 import { AgentRegistry } from "@/lib/agent/registry";
+import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { readSpawnAdmissionFence } from "@/lib/agent/spawnAdmission";
+import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import type { RuntimeHostClient } from "@/lib/runtime/client";
 
 import { POST as spawnPost } from "../route";
@@ -261,4 +264,295 @@ test("an existing downstream launch wins over a validation refusal", async () =>
   expect(await response.json()).toMatchObject({ admissible: false, fenced: false, status: 400 });
   expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
   expect(store.spawnReceiptForClientAttempt(clientAttemptId)?.launchId).toBe(begun.receipt.launchId);
+});
+
+/* #1641 — the mandatory reviewer contract. A reviewer spawn refused for a
+   missing `reviews` used to answer a bare 400 on both paths, so the caller's
+   downstream key carried no terminal evidence and recovery stayed unknown
+   forever. The request reaches that refusal through two different branches
+   depending on the request's origin, and both must fence. */
+
+const REVIEWER_MISSING_REVIEWS = "reviewer requires reviews";
+
+function reviewerBody(cwd: string, clientAttemptId: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: "Independent runtime packet review",
+    role: "reviewer",
+    roleParams: { diffSource: "origin/main...HEAD" },
+    engine: "codex",
+    cwd,
+    ["prompt"]: "review the runtime packet and return a verdict",
+    clientAttemptId,
+    ...extra,
+  };
+}
+
+/** Headers of a launch dispatched by an agent through the MCP control path:
+    no same-origin marker, and the operator spawn capability the Viewer's own
+    control calls carry. */
+function agentOriginHeaders(capability: string): Record<string, string> {
+  return { "sec-fetch-site": "none", [VIEWER_SPAWN_CAPABILITY_HEADER]: capability };
+}
+
+test("a same-origin reviewer without reviews is fenced by the route and reported by the validator", async () => {
+  const cwd = path.join(sandbox, "reviewer-same-origin-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const body = reviewerBody(cwd, "spawn_reviewer_same_origin_1");
+
+  /* The route itself now records the request-bound fence on this branch. */
+  const route = await spawnPost.withDependencies(spawnRequest(body), spawnDependencies(store, cwd));
+  expect({ status: route.status, body: await route.json() }).toEqual({
+    status: 400,
+    body: { error: REVIEWER_MISSING_REVIEWS },
+  });
+  expect(readSpawnAdmissionFence(String(body.clientAttemptId))).toMatchObject({
+    clientAttemptId: body.clientAttemptId,
+    status: 400,
+    error: REVIEWER_MISSING_REVIEWS,
+  });
+  expect(store.spawnReceiptForClientAttempt(String(body.clientAttemptId))).toBeNull();
+
+  /* The validator reports the same refusal, in the admissibility shape the
+     recovery probe reads, instead of calling the launch admissible. */
+  const validation = await POST.withDependencies(request(body), { registry: () => store });
+  expect(validation.status).toBe(200);
+  expect(await validation.json()).toEqual({
+    admissible: false,
+    fenced: true,
+    reason: REVIEWER_MISSING_REVIEWS,
+    status: 400,
+  });
+
+  /* A changed payload cannot claim this refusal: the compare-and-set answers
+     a conflict and reports fenced:false, so recovery of a request that is not
+     the fenced one keeps its outcome unknown. */
+  const changedPayload = await POST.withDependencies(
+    request(reviewerBody(cwd, String(body.clientAttemptId), { ["prompt"]: "review something else entirely" })),
+    { registry: () => store },
+  );
+  expect(await changedPayload.json()).toEqual({
+    admissible: false,
+    fenced: false,
+    reason: REVIEWER_MISSING_REVIEWS,
+    status: 400,
+  });
+  expect(readSpawnAdmissionFence(String(body.clientAttemptId))).toMatchObject({
+    error: REVIEWER_MISSING_REVIEWS,
+  });
+
+  /* The burnt key cannot carry a different launch either: the reservation
+     refuses it under the same lock, before any receipt or worker exists. */
+  const reused = await spawnPost.withDependencies(
+    spawnRequest({
+      title: "A different launch on a burnt key",
+      role: "verifier",
+      roleParams: { claims: "the fenced key is terminal" },
+      engine: "codex",
+      cwd,
+      ["prompt"]: "verify the supplied claim",
+      clientAttemptId: body.clientAttemptId,
+    }),
+    spawnDependencies(store, cwd),
+  );
+  expect({ status: reused.status, body: await reused.json() }).toEqual({
+    status: 409,
+    body: { error: "spawn attempt conflicts with its original request" },
+  });
+  expect(store.spawnReceiptForClientAttempt(String(body.clientAttemptId))).toBeNull();
+  expect(Object.keys(store.readOnlySnapshot().receipts)).toEqual([]);
+});
+
+test("an authenticated agent-origin reviewer without reviews is fenced at the lineage refusal", async () => {
+  const cwd = path.join(sandbox, "reviewer-agent-origin-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const capability = ensureOperatorSpawnCapability();
+  const routeKey = "spawn_reviewer_agent_route_1";
+  const validateKey = "spawn_reviewer_agent_validate_1";
+
+  /* An agent-origin request never reaches the role check: the lineage refusal
+     fires first for the same missing field, and it fences too. */
+  const route = await spawnPost.withDependencies(
+    spawnRequest(reviewerBody(cwd, routeKey), agentOriginHeaders(capability)),
+    spawnDependencies(store, cwd),
+  );
+  expect({ status: route.status, body: await route.json() }).toEqual({
+    status: 400,
+    body: { error: AGENT_SPAWN_LINEAGE_ERROR },
+  });
+  expect(readSpawnAdmissionFence(routeKey)).toMatchObject({ status: 400, error: AGENT_SPAWN_LINEAGE_ERROR });
+  expect(store.spawnReceiptForClientAttempt(routeKey)).toBeNull();
+
+  const validation = await POST.withDependencies(
+    request(reviewerBody(cwd, validateKey), agentOriginHeaders(capability)),
+    { registry: () => store },
+  );
+  expect(validation.status).toBe(200);
+  expect(await validation.json()).toEqual({
+    admissible: false,
+    fenced: true,
+    reason: AGENT_SPAWN_LINEAGE_ERROR,
+    status: 400,
+  });
+  expect(readSpawnAdmissionFence(validateKey)).toMatchObject({ status: 400 });
+  expect(Object.keys(store.readOnlySnapshot().receipts)).toEqual([]);
+});
+
+test("a reviewer naming its reviews target stays admissible and unfenced on both origins", async () => {
+  const cwd = path.join(sandbox, "reviewer-admissible-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const capability = ensureOperatorSpawnCapability();
+  const reviews = path.join(cwd, "implementer.jsonl");
+
+  const sameOrigin = await POST.withDependencies(
+    request(reviewerBody(cwd, "spawn_reviewer_named_same_1", { reviews })),
+    { registry: () => store },
+  );
+  expect(await sameOrigin.json()).toEqual({ admissible: true, fenced: false });
+  expect(readSpawnAdmissionFence("spawn_reviewer_named_same_1")).toBeNull();
+
+  const agentOrigin = await POST.withDependencies(
+    request(reviewerBody(cwd, "spawn_reviewer_named_agent_1", { reviews }), agentOriginHeaders(capability)),
+    { registry: () => store },
+  );
+  expect(await agentOrigin.json()).toEqual({ admissible: true, fenced: false });
+  expect(readSpawnAdmissionFence("spawn_reviewer_named_agent_1")).toBeNull();
+});
+
+test("reviews without the reviewer role is refused and fenced like any other admission error", async () => {
+  const cwd = path.join(sandbox, "reviews-without-reviewer-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_reviews_without_reviewer_1";
+  const body = {
+    title: "Builder carrying a review target",
+    role: "builder",
+    cwd,
+    ["prompt"]: "implement the scoped directive",
+    reviews: path.join(cwd, "implementer.jsonl"),
+    clientAttemptId,
+  };
+
+  const validation = await POST.withDependencies(request(body), { registry: () => store });
+  expect(await validation.json()).toEqual({
+    admissible: false,
+    fenced: true,
+    reason: "reviews requires role: reviewer",
+    status: 400,
+  });
+  const route = await spawnPost.withDependencies(spawnRequest(body), spawnDependencies(store, cwd));
+  expect({ status: route.status, body: await route.json() }).toEqual({
+    status: 400,
+    body: { error: "reviews requires role: reviewer" },
+  });
+  expect(Object.keys(store.readOnlySnapshot().receipts)).toEqual([]);
+});
+
+test("an unknown role keeps its baseline fenced refusal", async () => {
+  const cwd = path.join(sandbox, "unknown-role-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_unknown_role_1";
+
+  const validation = await POST.withDependencies(request({
+    title: "Unknown role",
+    role: "inspector",
+    cwd,
+    ["prompt"]: "run an inspection",
+    clientAttemptId,
+  }), { registry: () => store });
+  const payload = await validation.json() as Record<string, unknown>;
+  expect(payload).toMatchObject({ admissible: false, fenced: true, status: 400 });
+  expect(String(payload.reason)).toStartWith("unknown role: inspector");
+  expect(readSpawnAdmissionFence(clientAttemptId)).toMatchObject({ status: 400 });
+});
+
+test("an unauthenticated agent-origin reviewer cannot burn the owner's key", async () => {
+  const cwd = path.join(sandbox, "reviewer-unauthenticated-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_reviewer_unauth_1";
+  const body = reviewerBody(cwd, clientAttemptId);
+
+  const validation = await POST.withDependencies(request(body, { "sec-fetch-site": "none" }), { registry: () => store });
+  expect(validation.status).toBe(403);
+  expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
+
+  const route = await spawnPost.withDependencies(
+    spawnRequest(body, { "sec-fetch-site": "none" }),
+    spawnDependencies(store, cwd),
+  );
+  expect({ status: route.status, body: await route.json() }).toEqual({
+    status: 400,
+    body: { error: AGENT_SPAWN_LINEAGE_ERROR },
+  });
+  expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
+  expect(Object.keys(store.readOnlySnapshot().receipts)).toEqual([]);
+});
+
+test("a launch receipt that already owns the key wins over a reviewer refusal", async () => {
+  const cwd = path.join(sandbox, "reviewer-existing-launch-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const clientAttemptId = "spawn_reviewer_existing_1";
+  const begun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    clientAttemptId,
+    requestDigest: "d".repeat(64),
+    launchProfile: { title: "Reviewer already launched" },
+    origin: { kind: "operator" },
+  });
+  if (begun.kind !== "created") throw new Error("expected an existing-launch fixture");
+
+  const validation = await POST.withDependencies(
+    request(reviewerBody(cwd, clientAttemptId)),
+    { registry: () => store },
+  );
+  expect(await validation.json()).toEqual({
+    admissible: false,
+    fenced: false,
+    reason: REVIEWER_MISSING_REVIEWS,
+    status: 400,
+  });
+  expect(readSpawnAdmissionFence(clientAttemptId)).toBeNull();
+  expect(store.spawnReceiptForClientAttempt(clientAttemptId)?.launchId).toBe(begun.receipt.launchId);
+});
+
+test("a malformed validation request is refused before anything is fenced", async () => {
+  const store = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const malformed = new NextRequest("http://127.0.0.1:8898/api/spawn/validate", {
+    method: "POST",
+    headers: {
+      origin: "http://127.0.0.1:8898",
+      host: "127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: "not json",
+  });
+  const response = await POST.withDependencies(malformed, { registry: () => store });
+  expect({ status: response.status, body: await response.json() }).toEqual({
+    status: 400,
+    body: { error: "invalid JSON" },
+  });
+
+  const array = await POST.withDependencies(
+    new NextRequest("http://127.0.0.1:8898/api/spawn/validate", {
+      method: "POST",
+      headers: {
+        origin: "http://127.0.0.1:8898",
+        host: "127.0.0.1:8898",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify([{ role: "reviewer", clientAttemptId: "spawn_malformed_array_1" }]),
+    }),
+    { registry: () => store },
+  );
+  expect(array.status).toBe(400);
+  expect(readSpawnAdmissionFence("spawn_malformed_array_1")).toBeNull();
+  expect(Object.keys(store.readOnlySnapshot().receipts)).toEqual([]);
 });

--- a/src/lib/agent/spawnAdmissionValidation.ts
+++ b/src/lib/agent/spawnAdmissionValidation.ts
@@ -4,6 +4,7 @@ import {
   agentSpawnLineageError,
   authenticatedAgentSpawnCaller,
   isAgentInitiatedSpawn,
+  mandatoryReviewsError,
 } from "@/app/api/spawn/admission";
 import {
   fenceSpawnAdmissionRejection,
@@ -19,6 +20,25 @@ function recordBody(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+/** One refusal shape for every branch `/api/spawn` refuses before it reserves
+    anything. `fenced` reports what the shared compare-and-set actually did:
+    false when a launch receipt already owns the key, or the key cannot carry a
+    fence, so recovery keeps the original outcome unknown rather than reading a
+    refusal that nothing durable backs. */
+function refusal(
+  body: Record<string, unknown>,
+  reason: string,
+  dependencies: SpawnValidationDependencies,
+): NextResponse {
+  const fence = fenceSpawnAdmissionRejection(body, 400, reason, dependencies);
+  return NextResponse.json({
+    admissible: false,
+    fenced: fence?.kind === "fenced",
+    reason,
+    status: 400,
+  });
 }
 
 /** Validate the role admission that can strand an MCP spawn claim. A refusal
@@ -39,12 +59,10 @@ export async function executeSpawnAdmissionValidation(
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
 
-  const lineageError = agentSpawnLineageError(req, body);
-  if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
-
   /* Establish the same caller identity as `/api/spawn` before this endpoint is
      allowed to write a fence. A stranger may learn only the ordinary refusal,
-     never burn another caller's downstream key. */
+     never burn another caller's downstream key. This precedes the lineage
+     refusal below, which now fences (#1641). */
   if (isAgentInitiatedSpawn(req)) {
     let caller: ReturnType<typeof authenticatedAgentSpawnCaller>;
     try {
@@ -55,16 +73,21 @@ export async function executeSpawnAdmissionValidation(
     if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
   }
 
+  /* An agent-origin request that names no role, or a reviewer that names no
+     `reviews`, is refused here exactly as `/api/spawn` refuses it — and the
+     refusal is reported in the admissibility shape, so a recovery probe reads
+     the fence instead of an unreadable transport error (#1641). */
+  const lineageError = agentSpawnLineageError(req, body);
+  if (lineageError) return refusal(body, lineageError, dependencies);
+
   const role = resolveSpawnRole(body);
-  if (!role.ok) {
-    const fence = fenceSpawnAdmissionRejection(body, 400, role.error, dependencies);
-    return NextResponse.json({
-      admissible: false,
-      fenced: fence?.kind === "fenced",
-      reason: role.error,
-      status: 400,
-    });
-  }
+  if (!role.ok) return refusal(body, role.error, dependencies);
+
+  /* The same mandatory reviewer predicate the route applies. A same-origin
+     reviewer request without `reviews` reaches this branch instead of the
+     lineage one, and both must answer with the same durable fence. */
+  const reviewsError = mandatoryReviewsError(role.value?.role ?? null, body);
+  if (reviewsError) return refusal(body, reviewsError, dependencies);
 
   return NextResponse.json({ admissible: true, fenced: false });
 }

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -58,7 +58,7 @@ import type { ApiError } from "@/lib/types";
 import { recordDirectOperatorWakatimeActivity } from "@/lib/wakatime/operatorActivity";
 
 import { sourceCwdStatus } from "@/app/api/spawn/sourceCwd";
-import { AGENT_SPAWN_LINEAGE_ERROR, agentSpawnLineageError, authenticatedAgentSpawnCaller, isAgentInitiatedSpawn, spawnLineageSelectorForCaller, type AuthenticatedSpawnCaller } from "@/app/api/spawn/admission";
+import { AGENT_SPAWN_LINEAGE_ERROR, agentSpawnLineageError, authenticatedAgentSpawnCaller, isAgentInitiatedSpawn, mandatoryReviewsError, spawnLineageSelectorForCaller, type AuthenticatedSpawnCaller } from "@/app/api/spawn/admission";
 import { spawnAccountErrorResponse } from "@/app/api/spawn/accountError";
 import { attributeNamedAccountChoice } from "@/lib/accounts/accountOverrides";
 
@@ -240,8 +240,10 @@ export async function executeSpawnRequest(
   const requestedPlugins = normalizeSpawnPlugins(body.plugins);
   if (!requestedPlugins.ok) return NextResponse.json({ error: requestedPlugins.error }, { status: 400 });
 
-  const lineageError = agentSpawnLineageError(req, body);
-  if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
+  /* The caller is established BEFORE the first refusal that writes a fence
+     (#1641). The 403 itself still waits until after validation, so a stranger
+     learns the ordinary refusal and no more — but an unauthenticated one can
+     never burn another caller's downstream key. */
   const agentInitiated = isAgentInitiatedSpawn(req);
   let registryForCaller: ReturnType<SpawnCommandDependencies["registry"]> | null = null;
   let authenticatedCaller: AuthenticatedSpawnCaller | null = null;
@@ -259,22 +261,24 @@ export async function executeSpawnRequest(
       };
     }
   }
+  /* Every pre-reservation refusal below records the request-bound fence, so a
+     caller whose dispatch was interrupted can recover this exact key to a
+     terminal NOT_EXECUTED instead of an indefinite unknown (#1641). */
+  const refuse = (error: string): NextResponse<ApiError> => {
+    if (!authenticatedCallerError) {
+      fenceSpawnAdmissionRejection(body as Record<string, unknown>, 400, error, dependencies);
+    }
+    return NextResponse.json({ error }, { status: 400 });
+  };
+  const lineageError = agentSpawnLineageError(req, body);
+  if (lineageError) return refuse(lineageError);
   if (body.allowSubagents !== undefined && typeof body.allowSubagents !== "boolean") {
     return NextResponse.json({ error: "allowSubagents must be a boolean" }, { status: 400 });
   }
   const role = resolveSpawnRole(body);
-  if (!role.ok) {
-    if (!authenticatedCallerError) {
-      fenceSpawnAdmissionRejection(body as Record<string, unknown>, 400, role.error, dependencies);
-    }
-    return NextResponse.json({ error: role.error }, { status: 400 });
-  }
-  if (role.value?.role === "reviewer" && (typeof body.reviews !== "string" || !body.reviews.trim())) {
-    return NextResponse.json({ error: "reviewer requires reviews" }, { status: 400 });
-  }
-  if (role.value?.role !== "reviewer" && body.reviews !== undefined) {
-    return NextResponse.json({ error: "reviews requires role: reviewer" }, { status: 400 });
-  }
+  if (!role.ok) return refuse(role.error);
+  const reviewsError = mandatoryReviewsError(role.value?.role ?? null, body);
+  if (reviewsError) return refuse(reviewsError);
   /* Reviewer isolation (#393): reviewer/verifier launch profiles always carry
      allowSubagents:false, so every engine denies native multi-agent tools on
      fresh launch, resume, and restart adoption. Even the operator lane cannot

--- a/src/lib/agent/spawnParent.ts
+++ b/src/lib/agent/spawnParent.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { agentRegistry, type AgentRegistry } from "./registry";
 import { sessionKeyFromTranscript } from "./sessionKey";
 import { claudeProjectRootFor, codexSessionRootFor } from "@/lib/scanner/roots";
+import { REVIEWER_REQUIRES_REVIEWS_ERROR, REVIEWS_REQUIRE_REVIEWER_ERROR } from "@/app/api/spawn/admission";
 
 export interface ResolvedSpawnParent {
   conversationId: `conversation_${string}`;
@@ -83,12 +84,14 @@ export function resolveSpawnLineage(
   registry = agentRegistry(),
 ): ResolvedSpawnLineage {
   const reviewer = body.role === "reviewer";
+  /* The same two messages admission refuses with (#1641), so a fence written
+     at admission and this deeper refusal never disagree about the reason. */
   if (!reviewer) {
-    if (body.reviews !== undefined) throw new SpawnParentError("reviews requires role: reviewer", 400);
+    if (body.reviews !== undefined) throw new SpawnParentError(REVIEWS_REQUIRE_REVIEWER_ERROR, 400);
     return { parent: resolveSpawnParent(body, registry), reviewed: null };
   }
   if (typeof body.reviews !== "string" || !body.reviews.trim()) {
-    throw new SpawnParentError("reviewer requires reviews", 400);
+    throw new SpawnParentError(REVIEWER_REQUIRES_REVIEWS_ERROR, 400);
   }
   const reviewRef = body.reviews.trim();
   const reviewed = reviewRef.startsWith("conversation_")

--- a/src/lib/mcp/spawnRecovery.integration.test.ts
+++ b/src/lib/mcp/spawnRecovery.integration.test.ts
@@ -297,3 +297,93 @@ test("production recovery probes the exported validate route over HTTP with the 
     else process.env.LLV_VIEWER_CONTROL_URL = previousControlUrl;
   }
 });
+
+/** The exact shape the original stranded claim carried (#1641): a reviewer
+    launch that names no `reviews`. Its arguments are otherwise complete, so
+    every refusal it meets belongs to the mandatory reviewer contract alone. */
+function reviewerArgsWithoutReviews(clientRequestId: string, cwd: string): Record<string, unknown> {
+  return {
+    clientRequestId,
+    role: "reviewer",
+    roleParams: { diffSource: "origin/main...HEAD" },
+    engine: "codex",
+    cwd,
+    ["prompt"]: "independent read-only review of the runtime packet",
+    title: "Independent runtime packet review",
+  };
+}
+
+test("a reviewer stranded for missing reviews recovers to NOT_EXECUTED on its exact original key", async () => {
+  const cwd = path.join(sandbox, "reviewer-http-probe-dir");
+  fs.mkdirSync(cwd, { recursive: true });
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const requests: { pathname: string; capability: string | null; secFetchSite: string | null }[] = [];
+  const viewer = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      requests.push({
+        pathname: new URL(request.url).pathname,
+        capability: request.headers.get(VIEWER_SPAWN_CAPABILITY_HEADER),
+        secFetchSite: request.headers.get("sec-fetch-site"),
+      });
+      return spawnAdmissionPost.withDependencies(
+        new NextRequest(request),
+        { registry: () => registry },
+      );
+    },
+  });
+  const previousControlUrl = process.env.LLV_VIEWER_CONTROL_URL;
+  process.env.LLV_VIEWER_CONTROL_URL = viewer.url.origin;
+  try {
+    const args = reviewerArgsWithoutReviews("spawn_reviewer_stranded_http_1", cwd);
+    const tools = viewerMcpRecoverableTools({
+      ...productionDomainDependencies,
+      registrySnapshot: () => registry.readOnlySnapshot(),
+      attentionAuthority: () => ({ kind: "root", conversationId: null, role: null }),
+      recoveryPredecessors: () => [],
+    });
+    const bindingInput = await tools.spawn_agent!.bind(args);
+    const binding: McpRequestBinding = {
+      ...bindingInput,
+      version: 1,
+      toolName: "spawn_agent",
+      clientRequestId: String(args.clientRequestId),
+      owner: { pid: process.pid, startIdentity: null },
+      claimedAt: new Date().toISOString(),
+    };
+
+    /* Viewer control calls carry the same-origin marker, so this probe lands
+       on the validator's role-resolution branch — the same branch the original
+       dispatch reached through `/api/spawn`. That branch used to answer
+       admissible:true, which is why the caller's key could only stay unknown. */
+    const recovered = await tools.spawn_agent!.recover(binding, { legacy: false, args });
+    expect(recovered).toMatchObject({
+      outcome: "not-executed",
+      evidence: "spawn-admission-fence",
+      reason: "reviewer requires reviews",
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      pathname: "/api/spawn/validate",
+      capability: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+      secFetchSite: "same-origin",
+    });
+    expect(readSpawnAdmissionFence(binding.downstreamKey)).toMatchObject({ status: 400 });
+    /* Nothing was launched for the recovered key. */
+    expect(registry.readOnlySnapshot().receipts).toEqual({});
+
+    /* A recovery bound to different arguments under the same key reads the
+       fence as contradicting its request and must stay unknown. */
+    const contradicted = await tools.spawn_agent!.recover(binding, {
+      legacy: false,
+      args: { ...args, ["prompt"]: "review a different packet" },
+    });
+    expect(contradicted).toMatchObject({ outcome: "unknown" });
+    expect(requests).toHaveLength(1);
+  } finally {
+    viewer.stop(true);
+    if (previousControlUrl === undefined) delete process.env.LLV_VIEWER_CONTROL_URL;
+    else process.env.LLV_VIEWER_CONTROL_URL = previousControlUrl;
+  }
+});


### PR DESCRIPTION
Closes #1641.

A reviewer launch without `reviews` previously returned 400 while original-key recovery stayed `unknown`. The covered role and reviewer-target presence checks now share validation and record an exact-request rejection fence when caller checks and the existing compare-and-set guard permit it. Recovery can then report `NOT_EXECUTED`; accepted or concurrent launches still take precedence, and incomplete evidence remains `unknown`.

Agent-origin requests authenticate before recording a fence. Same-origin requests retain the existing loopback/CSRF trust model. This change does not cover every other pre-reservation refusal: an unresolved reviewer target and other validation branches can still require separate recovery work. A corrected launch must name an existing, resolvable implementer.

Independent review approved `fa1d820ddda2f524760de895f5d9cb5d28658586`. Isolated HTTP and MCP regressions passed, including causal failures on the base, changed payloads, foreign callers and concurrent launch receipts. TypeScript, privacy and exact-head CI passed. One admission-suite failure was reproduced unchanged on the base.

No production claim was reset. After deployment, the original caller must recover the unchanged rejected request and verify authoritative terminal evidence before a corrected launch. The separate source-reviewer request has its own disposition and is not implicitly settled by this fix.
