### PR TITLE
Fix truncated attachment sends through the Next proxy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,12 @@ const nextConfig: NextConfig = {
   // Dev-only: hosts allowed to reach dev resources cross-origin (Tailscale/LAN preview).
   allowedDevOrigins: process.env.LLV_DEV_ORIGINS ? process.env.LLV_DEV_ORIGINS.split(",") : undefined,
   images: { unoptimized: true },
+  experimental: {
+    // A send can carry 24 MiB of encoded images plus 40 MiB of files
+    // (about 54 MiB after base64). Keep room for its JSON envelope so the
+    // proxy forwards complete bodies to the existing attachment validators.
+    proxyClientMaxBodySize: 80 * 1024 * 1024,
+  },
   outputFileTracingExcludes: {
     "*": ["node_modules/@img/**", "node_modules/sharp/**"],
   },

--- a/src/lib/proxyBodySize.test.ts
+++ b/src/lib/proxyBodySize.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+import { getCloneableBody } from "next/dist/server/body-streams";
+
+import nextConfig from "../../next.config";
+import { MAX_INBOX_FILES_TOTAL_BYTES } from "./filePolicy";
+import { admitRuntimeImagePayload } from "./runtime/runtimeImageAdmission";
+import { MAX_STRUCTURED_IMAGE_TOTAL_BYTES } from "./runtime/runtimeImageStore";
+
+function png(bytes: number) {
+  const data = Buffer.alloc(bytes);
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(data);
+  data.write("IHDR", 12, "ascii");
+  return { mime: "image/png", base64: data.toString("base64") };
+}
+
+async function throughProxy(value: unknown, limit = nextConfig.experimental?.proxyClientMaxBodySize) {
+  if (limit !== undefined && typeof limit !== "number") throw new Error("Expected a byte limit");
+  const wire = Buffer.from(JSON.stringify(value));
+  const incoming = new Readable({ read() {} });
+  const body = getCloneableBody(incoming as unknown as IncomingMessage, limit);
+  const clone = body.cloneBodyStream();
+  const proxyRead = (async () => {
+    for await (const _chunk of clone) { /* Consume the proxy's copy. */ }
+  })();
+  for (let offset = 0; offset < wire.length; offset += 64 * 1024) {
+    incoming.push(wire.subarray(offset, offset + 64 * 1024));
+  }
+  incoming.push(null);
+  await proxyRead;
+  await body.finalize();
+  const chunks: Buffer[] = [];
+  for await (const chunk of incoming) chunks.push(Buffer.from(chunk));
+  return JSON.parse(Buffer.concat(chunks).toString());
+}
+
+test("four admitted images survive the installed Next proxy clone", async () => {
+  const images = Array.from({ length: 4 }, () => png(3 * 1024 * 1024));
+  expect(admitRuntimeImagePayload({ images }).error).toBeNull();
+  const received = await throughProxy({ text: "Inspect these images", images });
+  expect(received.images).toEqual(images);
+  expect(received.text).toBe("Inspect these images");
+});
+
+test("the combined supported image and file payload reaches the route intact", async () => {
+  const images = Array.from({ length: 4 }, () => png(MAX_STRUCTURED_IMAGE_TOTAL_BYTES / 4));
+  const files = Array.from({ length: 2 }, (_, i) => ({
+    name: `attachment-${i}.bin`, mime: "application/octet-stream",
+    base64: Buffer.alloc(MAX_INBOX_FILES_TOTAL_BYTES / 2).toString("base64"),
+  }));
+  const received = await throughProxy({ text: "Inspect attachments", images, files });
+  expect(received.images.map((image: { base64: string }) => image.base64.length))
+    .toEqual(images.map(image => image.base64.length));
+  expect(received.files.map((file: { base64: string }) => file.base64.length))
+    .toEqual(files.map(file => file.base64.length));
+});
+
+test("transport capacity preserves the runtime image admission limit", async () => {
+  const images = Array.from({ length: 4 }, () => png(5 * 1024 * 1024));
+  const received = await throughProxy({ images });
+  expect(admitRuntimeImagePayload(received).error?.status).toBe(413);
+});
+
+test("the old 10 MiB boundary reproduces the invalid JSON incident", async () => {
+  const images = Array.from({ length: 4 }, () => png(3 * 1024 * 1024));
+  await expect(throughProxy({ images }, 10 * 1024 * 1024)).rejects.toBeInstanceOf(SyntaxError);
+});


### PR DESCRIPTION
Valid messages with multiple images exceeded the Next proxy’s default 10 MiB buffer. It forwarded a truncated JSON body, so the send endpoint returned `invalid JSON` before runtime admission.

Set the proxy buffer to 80 MiB, enough for the existing combined attachment allowance: 24 MiB of encoded images plus 40 MiB of raw files (about 54 MiB encoded) and the JSON envelope. Existing image/file admission limits remain enforced.

Validation: 19 focused tests pass, including the installed Next clone/finalize path with four images and the maximum combined payload. The original 10 MiB limit reproduces the parse failure; an oversized image batch still reaches admission and returns 413. TypeScript and privacy checks pass. Production logs confirmed the same truncation warning; no user message was replayed during diagnosis.

Closes #1644
