### PR TITLE
Stop board crashes caused by subagent anchor updates

### DIFF
--- a/src/components/scheme/SubagentBadges.dom.test.tsx
+++ b/src/components/scheme/SubagentBadges.dom.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import { Window } from "happy-dom";
+import { Component, useMemo, useState, type ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
@@ -242,6 +243,52 @@ test("visible circles register their fixed world-space centers for structural ar
   await Bun.sleep(0);
 
   expect(registry.anchorFor("parent", "child")).toEqual({ x: 721, y: 255 });
+});
+
+test("anchor publication settles with fresh parent props and retains a remaining duplicate", async () => {
+  let notifications = 0;
+  let failure: Error | null = null;
+  let registry = createSubagentBadgeAnchorRegistry();
+  class Boundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+    state = { failed: false };
+    static getDerivedStateFromError() { return { failed: true }; }
+    componentDidCatch(error: Error) { failure = error; }
+    render() { return this.state.failed ? null : this.props.children; }
+  }
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const child = entry({ path: "/child", conversationId: "child", parent: parent.path });
+  function Board({ duplicate, offset = 0 }: { duplicate: boolean; offset?: number }) {
+    const [, setRevision] = useState(0);
+    registry = useMemo(() => createSubagentBadgeAnchorRegistry(() => {
+      notifications++;
+      if (notifications === 13) throw new Error("anchor publication did not settle");
+      setRevision(value => value + 1);
+    }), []);
+    return <>{[100 + offset, ...(duplicate ? [400] : [])].map((x, index) => (
+      <SubagentBadges key={index} conversationId="parent" entries={[{ ...parent }, { ...child }]}
+        cardRect={{ x, y: 200, w: 600, h: 70 }} anchorRegistry={registry}
+        onNavigate={() => undefined} now={1_800_000_000} />
+    ))}</>;
+  }
+  const element = dom.document.createElement("div");
+  dom.document.body.append(element);
+  const root = createRoot(element as unknown as HTMLElement);
+  roots.add(root);
+  flushSync(() => root.render(<Boundary><Board duplicate /></Boundary>));
+  await Bun.sleep(30);
+  expect(failure).toBeNull();
+  expect(notifications).toBeLessThanOrEqual(2);
+  expect(registry.anchorFor("parent", "child")).toEqual({ x: 1021, y: 255 });
+
+  flushSync(() => root.render(<Boundary><Board duplicate={false} /></Boundary>));
+  await Bun.sleep(0);
+  expect(failure).toBeNull();
+  expect(registry.anchorFor("parent", "child")).toEqual({ x: 721, y: 255 });
+  flushSync(() => root.render(<Boundary><Board duplicate={false} offset={30} /></Boundary>));
+  await Bun.sleep(0);
+  expect(failure).toBeNull();
+  expect(registry.anchorFor("parent", "child")).toEqual({ x: 751, y: 255 });
+  expect(notifications).toBeLessThan(8);
 });
 
 test("removing the expanded child releases the parent card foreground layer", async () => {

--- a/src/components/scheme/SubagentBadges.tsx
+++ b/src/components/scheme/SubagentBadges.tsx
@@ -52,6 +52,11 @@ export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, 
   const at = now ?? clock;
   const children = useMemo(() => subagentsOf(conversationId, entries, exclude, at), [conversationId, entries, exclude, at]);
   const positions = useMemo(() => layoutBadges(children, cardRect), [children, cardRect]);
+  // Parent renders can recreate entries and rectangles without moving a badge.
+  // Publish by geometry so the registry's notification does not re-arm this effect.
+  const anchorGeometry = JSON.stringify(positions.flatMap(position => position.kind === "badge"
+    ? [[position.child.id, position.x + position.size / 2, position.y + position.size / 2]]
+    : []));
   const hasExpandedChild = expandedId !== null && children.some((child) => child.id === expandedId);
 
   useEffect(() => {
@@ -59,14 +64,11 @@ export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, 
   }, [hasExpandedChild, onExpandedChange]);
   useEffect(() => {
     if (!anchorRegistry) return;
-    const anchors = new Map(
-      positions.flatMap((position) => position.kind === "badge"
-        ? [[position.child.id, { x: position.x + position.size / 2, y: position.y + position.size / 2 }] as const]
-        : []),
-    );
+    const points = JSON.parse(anchorGeometry) as Array<[string, number, number]>;
+    const anchors = new Map(points.map(([id, x, y]) => [id, { x, y }]));
     if (!anchors.size) return;
     return anchorRegistry.replace(conversationId, anchors);
-  }, [anchorRegistry, conversationId, positions]);
+  }, [anchorRegistry, conversationId, anchorGeometry]);
   if (!positions.length) return null;
 
   return (

--- a/src/components/scheme/subagentBadgeAnchors.ts
+++ b/src/components/scheme/subagentBadgeAnchors.ts
@@ -10,31 +10,45 @@ export interface SubagentBadgeAnchorRegistry {
 
 function sameAnchors(
   left: ReadonlyMap<string, SubagentBadgeAnchor> | undefined,
-  right: ReadonlyMap<string, SubagentBadgeAnchor>,
+  right: ReadonlyMap<string, SubagentBadgeAnchor> | undefined,
 ): boolean {
-  if (!left || left.size !== right.size) return false;
+  if ((left?.size ?? 0) !== (right?.size ?? 0)) return false;
+  if (!right) return true;
   for (const [id, anchor] of right) {
-    const current = left.get(id);
+    const current = left?.get(id);
     if (!current || current.x !== anchor.x || current.y !== anchor.y) return false;
   }
   return true;
 }
 
 export function createSubagentBadgeAnchorRegistry(onChange: () => void = () => undefined): SubagentBadgeAnchorRegistry {
-  const byParent = new Map<string, ReadonlyMap<string, SubagentBadgeAnchor>>();
+  type Anchors = ReadonlyMap<string, SubagentBadgeAnchor>;
+  type Owners = Map<symbol, Anchors>;
+  const byParent = new Map<string, Owners>();
+  const current = (owners: Owners | undefined): Anchors | undefined => {
+    let anchors: Anchors | undefined;
+    for (const candidate of owners?.values() ?? []) anchors = candidate;
+    return anchors;
+  };
   return {
     anchorFor(parentConversationId, childConversationId) {
-      return byParent.get(parentConversationId)?.get(childConversationId) ?? null;
+      return current(byParent.get(parentConversationId))?.get(childConversationId) ?? null;
     },
     replace(parentConversationId, anchors) {
+      // One conversation can appear in several task bands. Each mounted copy
+      // owns its registration; removing the latest copy restores the remaining one.
+      const owners = byParent.get(parentConversationId) ?? new Map<symbol, Anchors>();
+      const owner = Symbol();
       const owned = new Map(anchors);
-      const changed = !sameAnchors(byParent.get(parentConversationId), owned);
-      byParent.set(parentConversationId, owned);
+      const changed = !sameAnchors(current(owners), owned);
+      owners.set(owner, owned);
+      byParent.set(parentConversationId, owners);
       if (changed) onChange();
       return () => {
-        if (byParent.get(parentConversationId) !== owned) return;
-        byParent.delete(parentConversationId);
-        onChange();
+        const previous = current(owners);
+        if (!owners.delete(owner)) return;
+        if (!owners.size) byParent.delete(parentConversationId);
+        if (!sameAnchors(previous, current(owners))) onChange();
       };
     },
   };


### PR DESCRIPTION
Opening a conversation with subagent badges could crash the board with React’s maximum-update-depth error. Publishing badge anchors caused a parent render; fresh position objects then tore down and republished those same anchors indefinitely.

Key publication by actual geometry and retain a registration per mounted copy. Unmounting a duplicate conversation now restores the remaining copy’s anchors. Scaling, navigation and edge geometry are preserved.

Validation: the new parent-rerender regression fails on the base and passes after the fix; 18 focused tests and TypeScript pass. An equivalent page-only patch against production data removes the reproduced crash and remains stable at 90%, 100% and 160% with 11 badges mounted. That browser experiment is separate from the source tests and the forthcoming built-release verification.

Closes #1649
