### PR TITLE
Fix Codex send failures at transcript tail boundaries

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -2112,6 +2112,66 @@ describe("CodexAppServerHost", () => {
     }
   });
 
+  test.each([false, true])("a bounded tail starting inside a marker-bearing record preserves send dedup (already delivered: %s)", async (alreadyDelivered) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-tail-boundary-"));
+    const transcriptPath = path.join(directory, "delivery-thread.jsonl");
+    const operationId = "operation-tail-boundary";
+    const text = "retain exact recipient ownership";
+    const delivered = JSON.stringify({ type: "event_msg", payload: {
+      type: "user_message",
+      message: encodeCodexStructuredUserText(text, undefined, null, null, deliveryDedup(operationId)),
+    } });
+    // The 16 MiB tail starts inside this complete, valid tool record. Its
+    // quoted marker is ordinary tool output, not a corrupt recipient message.
+    const tool = JSON.stringify({ type: "response_item", payload: {
+      type: "function_call_output", output: "x".repeat(2 * 1024 * 1024) + " llv:structured-user quoted source",
+    } });
+    const filler = JSON.stringify({ type: "event_msg", payload: {
+      type: "agent_message", message: "x".repeat(15 * 1024 * 1024),
+    } });
+    fs.writeFileSync(transcriptPath, `${alreadyDelivered ? delivered + "\n" : ""}${tool}\n${filler}\n`);
+    const server = new FakeAppServer("delivery-thread", "delivery-thread");
+    server.threadPath = transcriptPath;
+    server.hydratedReadError = "list_turns is not supported yet";
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server),
+    });
+    try {
+      expect(await host.send({ id: operationId, text })).toEqual({
+        outcome: "turn-started", turnId: alreadyDelivered ? operationId : "turn-1",
+      });
+      expect(server.requests.filter((request) => request.method === "turn/start" || request.method === "turn/steer"))
+        .toHaveLength(alreadyDelivered ? 0 : 1);
+    } finally {
+      await host.release();
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("a malformed marker-bearing record crossing the tail boundary still refuses delivery", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-tail-corrupt-"));
+    const transcriptPath = path.join(directory, "delivery-thread.jsonl");
+    const corrupt = "x".repeat(2 * 1024 * 1024) + " llv:structured-user malformed record";
+    const filler = JSON.stringify({ type: "event_msg", payload: {
+      type: "agent_message", message: "x".repeat(15 * 1024 * 1024),
+    } });
+    fs.writeFileSync(transcriptPath, `${corrupt}\n${filler}\n`);
+    const server = new FakeAppServer("delivery-thread", "delivery-thread");
+    server.threadPath = transcriptPath;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server),
+    });
+    try {
+      await expect(host.send({ id: "operation-corrupt-tail", text: "deliver once" }))
+        .rejects.toThrow("recipient transcript is unavailable for delivery deduplication");
+      expect(server.requests.some((request) => request.method === "turn/start" || request.method === "turn/steer"))
+        .toBeFalse();
+    } finally {
+      await host.release();
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("keeps a send pending until the matching user item is persisted", async () => {
     const server = new FakeAppServer("confirm-after-rpc");
     server.autoCompleteUserMessage = false;

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -738,9 +738,13 @@ function rolloutCacheEntryFromDisk(pathname: string | null | undefined): Rollout
     if (stat.size > ROLLOUT_FALLBACK_READ_BYTES) {
       const descriptor = fs.openSync(pathname, "r");
       try {
-        const buffer = Buffer.alloc(ROLLOUT_FALLBACK_READ_BYTES);
+        // Include the preceding byte to distinguish a complete first record
+        // from a fragment created by our bounded read. The full delivery index
+        // still scans that record before absence can authorize a new send.
+        const buffer = Buffer.alloc(ROLLOUT_FALLBACK_READ_BYTES + 1);
         const read = fs.readSync(descriptor, buffer, 0, buffer.length, stat.size - buffer.length);
-        raw = buffer.subarray(0, read).toString("utf8");
+        const start = buffer[0] === 0x0a ? 1 : buffer.indexOf(0x0a, 1) + 1;
+        raw = start > 0 ? buffer.subarray(start, read).toString("utf8") : "";
       } finally {
         fs.closeSync(descriptor);
       }


### PR DESCRIPTION
Long Codex histories could make every send remain uncertain: the bounded transcript reader began inside a JSONL record and interpreted a quoted delivery marker in that fragment as corrupt recipient evidence.

Read the preceding byte and skip only an artificial leading fragment. Full-history deduplication still checks the skipped record before a new send; genuinely malformed marker records remain refused. This allows fresh sends while retaining original-operation duplicate protection.

Validation: causal baseline fails both new-send and already-delivered scenarios; seven focused tests pass after the fix, including corrupt boundary records, unreadable transcripts, lost confirmation, and history-prefix deduplication. Privacy checks pass. The full typecheck passed after host memory pressure cleared. A read-only source comparison on the affected history recovered 156 turns where the old reader returned none. CI and independent review remain required.

Fixes #1653 (backend reading defect). Duplicate generic composer notices remain tracked in the attachment/recovery UI integration.
