### PR TITLE
Restore first Codex delivery with native canonical history

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -133,6 +133,8 @@ class FakeAppServer extends EventEmitter {
   persistUserMessages = false;
   readTurns: unknown[] | null = null;
   readError: string | null = null;
+  turnsError: string | null = null;
+  userAgent = "codex_desktop_app/0.144.1 (Linux)";
   /* Rejects only hydrated reads (includeTurns), the way codex 0.151+ paginated
      threads do; metadata-only reads and thread/turns/list keep answering. */
   hydratedReadError: string | null = null;
@@ -215,7 +217,8 @@ class FakeAppServer extends EventEmitter {
     if (typeof message.id !== "number") return;
     const method = message.method;
     if (typeof method === "string" && this.ignoredMethods.includes(method)) return;
-    if (method === "initialize") return this.respond(message.id, { userAgent: "codex_desktop_app/0.144.1 (Linux)" });
+    if (method === "initialize") return this.respond(message.id, { userAgent: this.userAgent });
+    if (method === "thread/queue/list") return this.respondError(message.id, "method not found");
     if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
     if (method === "model/list") {
       if (this.modelListFailuresRemaining > 0) {
@@ -263,6 +266,7 @@ class FakeAppServer extends EventEmitter {
       });
     }
     if (method === "thread/turns/list") {
+      if (this.turnsError) return this.respondError(message.id, this.turnsError);
       if (this.readError) return this.respondError(message.id, this.readError);
       const turns = [...(this.readTurns ?? this.turns)];
       if ((message.params as { sortDirection?: string } | undefined)?.sortDirection === "desc") turns.reverse();
@@ -2221,9 +2225,14 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
-  test("starts the first delivery when Codex reports an unmaterialized thread", async () => {
+  test.each(["0.144.1", "0.154.0"])("starts the first delivery when Codex %s reports an unmaterialized thread", async (version) => {
     const server = new FakeAppServer("fresh-delivery-thread");
+    server.userAgent = `codex_desktop_app/${version} (Linux)`;
     server.readError = "thread fresh-delivery-thread is not materialized yet; includeTurns is unavailable before first user message";
+    if (version === "0.154.0") {
+      server.turnsError = server.readError.replace("includeTurns", "thread/turns/list");
+      server.readError = null;
+    }
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       eventStore: new MemoryEventStore(),
@@ -2235,6 +2244,20 @@ describe("CodexAppServerHost", () => {
       turnId: "turn-1",
     });
     await host.release();
+  });
+
+  test("native-history transport refusals never authorize a first delivery", async () => {
+    const server = new FakeAppServer("refused-first-thread");
+    server.userAgent = "codex_desktop_app/0.154.0 (Linux)";
+    server.readError = "permission denied";
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server),
+    });
+    try {
+      await expect(host.send({ id: "refused-first", text: "hello" }))
+        .rejects.toThrow("Codex canonical history is unavailable: transport");
+      expect(server.requests.some(request => request.method === "turn/start" || request.method === "turn/steer")).toBeFalse();
+    } finally { await host.release(); }
   });
 
   test("a successful hydrated read with no turns defers to the rollout on disk (#1332)", async () => {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1651,7 +1651,12 @@ export class CodexAppServerHost implements EngineHost {
         { deadlineAt: Date.now() + (timeoutMs ?? this.requestTimeoutMs), sortDirection: window === "first" ? "asc" : "desc" });
       if (history.state === "complete") return { thread: { id: history.identity.threadId, path: history.identity.path,
         turns: window === "latest" ? [...history.turns].reverse() : history.turns } };
-      if (history.state === "unknown") throw new Error(`Codex canonical history is unavailable: ${history.reason}`);
+      if (history.state === "unknown") {
+        if (history.reason === "not-materialized") {
+          throw new Error("Codex thread is not materialized yet before first user message");
+        }
+        throw new Error(`Codex canonical history is unavailable: ${history.reason}`);
+      }
     }
     try {
       return await this.rpc("thread/read", {

--- a/src/lib/runtime/codexHistoryReader.test.ts
+++ b/src/lib/runtime/codexHistoryReader.test.ts
@@ -186,7 +186,7 @@ describe("bounded canonical history", () => {
     for (const error of [Object.assign(new Error("Method not found"), { code: -32601 }), new Error("Codex app-server request failed: list_turns is not supported yet")]) {
       expect((await lookup([metadata, error])).history).toEqual({ state: "legacy-fallback", reason: "unsupported" });
     }
-    for (const error of [new Error("transport not supported"), new Error("Codex app-server request failed: permission denied"), new Error("Codex app-server request failed: thread not materialized yet before first user message"), new Error("thread/read timed out")]) {
+    for (const error of [new Error("transport not supported"), new Error("Codex app-server request failed: permission denied"), new Error("thread/read timed out")]) {
       expect((await lookup([error])).history).toEqual({ state: "unknown", reason: "transport" });
     }
   });
@@ -208,6 +208,23 @@ describe("bounded canonical history", () => {
     expect(result.delivery.state).toBe("found");
     if (result.history.state === "complete") expect(result.history.bytes).toBe(exact);
     expect((await lookup(responses, target, { maxBytes: exact - 1 })).history.state).toBe("unknown");
+  });
+
+  test("preserves only the initial native unmaterialized-history diagnostic", async () => {
+    const error = new Error("Codex app-server request failed: thread fixture is not materialized yet; includeTurns is unavailable before first user message");
+    const initial = await readCodexHistory(async () => { throw error; }, identity, options());
+    expect(initial).toEqual({ state: "unknown", reason: "not-materialized" });
+    expect(findCodexHistoryDelivery(initial, target).state).toBe("unknown");
+    expect(await readCodexHistory(async (method) => {
+      if (method === "thread/read") return metadata;
+      throw error;
+    }, identity, options())).toEqual({ state: "unknown", reason: "not-materialized" });
+    let calls = 0;
+    expect(await readCodexHistory(async () => {
+      if (++calls === 1) return metadata;
+      if (calls === 2) return page([turn()], "next");
+      throw error;
+    }, identity, options())).toEqual({ state: "unknown", reason: "transport" });
   });
 
   test("bounds pages, enforces one deadline even if RPC never settles, ignores late results", async () => {
@@ -312,6 +329,10 @@ plugins = false
     let client = startClient(); await init(client);
     const started = await client.rpc("thread/start", { cwd, model: "fixture-model", modelProvider: "fixture", approvalPolicy: "never", sandbox: "read-only", historyMode: "paginated" }, 5000) as { thread: { id: string; path: string } };
     const nativeIdentity = { threadId: started.thread.id, path: started.thread.path };
+    // Before the first native turn, preserve the precise unavailable-history
+    // classification that the host's first-delivery preflight consumes.
+    expect(await readCodexHistory(client.rpc, nativeIdentity, options({ deadlineAt: Date.now() + 8000 })))
+      .toEqual({ state: "unknown", reason: "not-materialized" });
     const targets: CodexHistoryDeliveryTarget[] = [];
     for (let i = 0; i < 3; i++) {
       const input = [{ type: "text", text: `Canonical fixture ${i} 🌍`, text_elements: [

--- a/src/lib/runtime/codexHistoryReader.ts
+++ b/src/lib/runtime/codexHistoryReader.ts
@@ -31,7 +31,7 @@ export interface CodexHistoryPage {
   nextCursor: string | null;
   backwardsCursor?: string | null;
 }
-type UnknownReason = "identity" | "malformed" | "cursor" | "bytes" | "pages" | "deadline" | "transport" | "not-observed" | "conflicting-record";
+type UnknownReason = "identity" | "malformed" | "cursor" | "bytes" | "pages" | "deadline" | "transport" | "not-materialized" | "not-observed" | "conflicting-record";
 export type CodexHistoryResult =
   | { state: "complete"; identity: CodexHistoryIdentity; turns: CodexHistoryTurn[]; pages: CodexHistoryPage[]; bytes: number }
   | { state: "unknown"; reason: UnknownReason }
@@ -53,6 +53,12 @@ function unsupported(error: unknown): boolean {
   if (object(error)?.code === -32601) return true;
   const message = error instanceof Error ? error.message : object(error)?.message;
   return typeof message === "string" && /^Codex app-server request failed: (?:method not found|unknown method [`'"]?thread\/(?:turns|items)\/list[`'"]?|(?:list_turns|list_items) is not supported yet)[.!]?$/i.test(message);
+}
+
+function notMaterialized(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : object(error)?.message;
+  return typeof message === "string" && /\bnot materialized yet\b/i.test(message)
+    && /\bbefore (?:the )?first user message\b/i.test(message);
 }
 
 /** Counts JSON wire bytes before retaining a response. Large strings fail before encoding. */
@@ -163,6 +169,14 @@ export async function readCodexHistory(
         ]);
       } catch (error) {
         if (error instanceof ReadFailure) throw error;
+        // This is still unavailable history. Preserve the native first-turn
+        // diagnostic so the host can distinguish initial delivery from a
+        // transport failure; a later pagination failure grants no such fact.
+        if (((method === "thread/read" && requests === 1)
+          || (method === "thread/turns/list" && requests === 2 && params.cursor === null))
+          && notMaterialized(error)) {
+          throw new ReadFailure("not-materialized");
+        }
         throw new ReadFailure(unsupported(error) ? "unsupported" : "transport");
       } finally { clearTimeout(timer); }
       requireValue(Date.now() < deadlineAt, "deadline");


### PR DESCRIPTION
New Codex conversations could not receive their first message because the canonical history reader hid Codex’s expected pre-first-message diagnostic inside a generic transport error.

Preserve `not-materialized` as an unknown-history reason only at the initial metadata or first turns-page read. The host can then use its existing first-delivery handling. Generic transport failures and later-page contradictions remain refused; unavailable history is never reported as complete or empty.

Validation: causal old/current host tests, an actual Codex 0.154 pre-first-turn probe with a credential-free local Responses fixture, existing pagination/restart/shared-history checks, and refusal/dedup regressions. All 28 targeted tests pass. Local typecheck and privacy passed; exact-head CI and independent review follow. No real-provider Voice success is claimed yet.

Fixes #1656.
