### PR TITLE
fix: render each native Voice utterance once across mirrored transcript streams (#1658)

### DIFF
--- a/src/lib/realtime/codexRealtimeClient.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.test.ts
@@ -13,6 +13,19 @@ test("parses Frameless Bidi transcript, handoff, usage and error events", () => 
     type: "turn.done",
     turn: { role: "assistant", transcript: "done" },
   })).toEqual({ kind: "transcript", role: "assistant", text: "done", final: true });
+  /* Native's streamed fragments carry their own id, and a done with no words
+     still ends the turn of the speaker it names (#1658). */
+  expect(parseCodexRealtimeEvent({
+    type: "output_transcript.added",
+    item: { id: "chunk-1", type: "output_transcript", text: " word" },
+    start_ms: 800,
+    end_ms: 1000,
+  })).toEqual({ kind: "transcript", role: "assistant", text: " word", final: false, chunkId: "chunk-1" });
+  expect(parseCodexRealtimeEvent({
+    type: "turn.done",
+    turn: { id: "turn-1", role: "user", transcript: "" },
+  })).toEqual({ kind: "transcript", role: "user", text: "", final: true });
+  expect(parseCodexRealtimeEvent({ type: "turn.done", turn: { transcript: "" } })).toEqual({ kind: "ignored" });
   /* The identities the native controller reads off this event, and the join
      between an utterance and the work it became (#1629). */
   expect(parseCodexRealtimeEvent({

--- a/src/lib/realtime/codexRealtimeClient.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.test.ts
@@ -13,8 +13,9 @@ test("parses Frameless Bidi transcript, handoff, usage and error events", () => 
     type: "turn.done",
     turn: { role: "assistant", transcript: "done" },
   })).toEqual({ kind: "transcript", role: "assistant", text: "done", final: true });
-  /* Native's streamed fragments carry their own id, and a done with no words
-     still ends the turn of the speaker it names (#1658). */
+  /* Native's streamed fragments carry their own id, a done carries its turn's,
+     and a done with no words still ends the turn of the speaker it names
+     (#1658). */
   expect(parseCodexRealtimeEvent({
     type: "output_transcript.added",
     item: { id: "chunk-1", type: "output_transcript", text: " word" },
@@ -24,7 +25,7 @@ test("parses Frameless Bidi transcript, handoff, usage and error events", () => 
   expect(parseCodexRealtimeEvent({
     type: "turn.done",
     turn: { id: "turn-1", role: "user", transcript: "" },
-  })).toEqual({ kind: "transcript", role: "user", text: "", final: true });
+  })).toEqual({ kind: "transcript", role: "user", text: "", final: true, turnId: "turn-1" });
   expect(parseCodexRealtimeEvent({ type: "turn.done", turn: { transcript: "" } })).toEqual({ kind: "ignored" });
   /* The identities the native controller reads off this event, and the join
      between an utterance and the work it became (#1629). */

--- a/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
@@ -136,12 +136,17 @@ test("barge-in mid-answer interleaves transcripts, keeps the mic live, and never
     // The agent is mid-answer when server VAD detects operator speech: the
     // truncated agent line stays visible, the operator turn opens a new line,
     // and the post-interruption answer never glues onto the abandoned one.
+    // The abandoned answer ends at its own turn.done, which is where native
+    // closes the agent's segment too. The operator speaking leaves it open,
+    // because in a duplex call the two overlap word by word within one turn
+    // (#1658).
     peer.channel.onmessage?.({ data: JSON.stringify({ type: "output_transcript.added", item: { text: "The build is" } }) });
     peer.channel.onmessage?.({ data: JSON.stringify({ type: "input_transcript.added", item: { text: "Stop — check the tests instead" } }) });
+    peer.channel.onmessage?.({ data: JSON.stringify({ type: "turn.done", turn: { role: "assistant", transcript: "The build is" } }) });
     peer.channel.onmessage?.({ data: JSON.stringify({ type: "output_transcript.added", item: { text: "Checking the tests" } }) });
     peer.channel.onmessage?.({ data: JSON.stringify({ type: "turn.done", turn: { role: "assistant", transcript: "Checking the tests now" } }) });
     expect(client.getSnapshot().lines.map((line) => [line.role, line.text, line.final])).toEqual([
-      ["assistant", "The build is", false],
+      ["assistant", "The build is", true],
       ["user", "Stop — check the tests instead", false],
       ["assistant", "Checking the tests now", true],
     ]);

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -62,10 +62,11 @@ export interface CodexRealtimeSnapshot {
 }
 
 export type ParsedRealtimeEvent =
-  /** `chunkId` is the provider's id for one streamed fragment; a `turn.done`
-      has none. An empty `text` occurs only on a `turn.done` that names its
-      speaker: it ends that speaker's turn with the words already streamed. */
-  | { kind: "transcript"; role: "user" | "assistant"; text: string; final: boolean; chunkId?: string }
+  /** `chunkId` is the provider's id for one streamed fragment, and `turnId` the
+      id a `turn.done` names its turn by. An empty `text` occurs only on a
+      `turn.done` that names its speaker: it ends that speaker's turn with the
+      words already streamed. */
+  | { kind: "transcript"; role: "user" | "assistant"; text: string; final: boolean; chunkId?: string; turnId?: string }
   /** The handoff that turns the utterance just finished into work on the thread.
       Its identities are the canonical join between what was said and what the
       backing model was asked to do (#1629). */
@@ -78,39 +79,57 @@ const MAX_LINE_CHARS = 12_000;
 const MAX_LINES = 80;
 /** Canonical segment ids one call remembers. Above the runtime store's own
     tail of 80, so every segment the store can still redeliver is recognised as
-    already placed and keeps the one place it has in the turn order. */
+    already placed and updates the line it has. */
 const MAX_CANONICAL_SEGMENTS = 160;
-/** Utterances one source may be ahead of the other, per speaker. The canonical
-    stream lags the data channel by a few turns at most. */
-const MAX_UNPAIRED_UTTERANCES = 32;
-/** Fragment ids one streaming turn remembers for replay detection. */
-const MAX_TURN_CHUNKS = 512;
+/** Turns per speaker and source still open to alignment. The canonical stream
+    lags the data channel by a few turns at most; an older turn keeps the line
+    it has. */
+const MAX_OPEN_TURNS = 32;
+/** Fragment ids one call remembers, so a fragment delivered again is known
+    however long ago its turn ended. */
+const MAX_SEEN_FRAGMENTS = 2_048;
 /** Earlier calls whose late canonical segments must stay out of the current one. */
 const MAX_RETIRED_SESSIONS = 8;
 
-/**
- * One spoken turn, and the panel line it owns (#1658).
- *
- * Two sources describe it: the data channel's caption, immediate and streamed
- * fragment by fragment, and the app-server's canonical segment, committed and a
- * little behind. They share no identifier. What they share is the turn
- * structure: native opens a speaker's segment on that speaker's first fragment
- * and closes it on that speaker's `turn.done` — the same provider events the data
- * channel delivers — so within one call the k-th turn a speaker takes is the
- * k-th on both sources. Each half is attached here when its source reaches that
- * turn, in whichever order the two arrive.
- */
-interface Utterance {
-  lineId: string;
+/** One speaker's turn as the data channel captioned it (#1658). */
+interface CaptionTurn {
   role: TranscriptSpeaker;
-  caption: { text: string; final: boolean } | null;
-  canonical: { text: string; final: boolean } | null;
-  /** The line has been drawn once. Missing after that means it scrolled out of
-      the bounded list, and it is not brought back. */
-  drawn: boolean;
+  /** The streamed fragments, joined. */
+  streamed: string;
+  /** The first fragment with words: the provider fragment native opens its
+      segment for this turn with. */
+  opening: string;
+  /** The words of the `turn.done` that closed the turn: the provider's final
+      transcript. Null while the turn is open, and when that done had none. */
+  finalText: string | null;
+  /** The turn id that done carried, to know the same done delivered again. */
+  closedBy: string | null;
+  closed: boolean;
+  /** The panel line it is on, once drawn. */
+  line: string | null;
 }
 
-/** One call's transcript: which utterance each source is filling, per speaker. */
+/** One speaker's turn as native committed it: one canonical segment. */
+interface CanonicalTurn {
+  role: TranscriptSpeaker;
+  /** The whole segment so far, as the store carries it. */
+  text: string;
+  final: boolean;
+  line: string | null;
+  /** The caption turn it was last aligned with. */
+  caption: CaptionTurn | null;
+}
+
+/** One panel line: a turn from either source, or from both. */
+interface TurnView {
+  role: TranscriptSpeaker;
+  caption: CaptionTurn | null;
+  canonical: CanonicalTurn | null;
+  /** How strongly the two were shown to be one turn; 0 for a single source. */
+  agreement: number;
+}
+
+/** One call's transcript. */
 interface TranscriptLedger {
   /** The realtime session whose canonical segments belong on these lines. */
   sessionId: string | null;
@@ -118,28 +137,39 @@ interface TranscriptLedger {
       one overall: in a duplex call both speak at once, and closing one
       speaker's line whenever the other spoke split every overlapping sentence
       into fragments. */
-  streaming: Map<TranscriptSpeaker, { utterance: Utterance; chunkIds: Set<string> }>;
-  /** Captioned turns the canonical stream has not reached yet, oldest first. */
-  awaitingCanonical: Record<TranscriptSpeaker, Utterance[]>;
-  /** Canonical turns the data channel has not reached yet, oldest first. */
-  awaitingCaption: Record<TranscriptSpeaker, Utterance[]>;
-  /** The utterance each canonical segment id was placed on. */
-  segments: Map<string, Utterance>;
+  streaming: Map<TranscriptSpeaker, CaptionTurn>;
+  /** Each speaker's latest caption turn, open or closed. */
+  lastCaption: Map<TranscriptSpeaker, CaptionTurn>;
+  /** Each speaker's turns still open to alignment, per source, in the order
+      that source took them. Everything older has settled on its line. */
+  open: Record<TranscriptSpeaker, { captions: CaptionTurn[]; canonicals: CanonicalTurn[] }>;
+  /** Every canonical segment placed, by id, so a redelivery updates its own turn. */
+  segments: Map<string, CanonicalTurn>;
+  /** Fragment ids already applied. */
+  fragments: Set<string>;
 }
 
 function newTranscriptLedger(sessionId: string | null = null): TranscriptLedger {
   return {
     sessionId,
     streaming: new Map(),
-    awaitingCanonical: { user: [], assistant: [] },
-    awaitingCaption: { user: [], assistant: [] },
+    lastCaption: new Map(),
+    open: { user: { captions: [], canonicals: [] }, assistant: { captions: [], canonicals: [] } },
     segments: new Map(),
+    fragments: new Set(),
   };
 }
 
 function boundedPush<T>(queue: T[], value: T, limit: number): void {
   queue.push(value);
   if (queue.length > limit) queue.splice(0, queue.length - limit);
+}
+
+/** Drop the oldest entry of an insertion-ordered collection once it is past `limit`. */
+function forgetOldest<T>(entries: Set<T> | Map<T, unknown>, limit: number): void {
+  if (entries.size <= limit) return;
+  const oldest = entries.keys().next();
+  if (!oldest.done) entries.delete(oldest.value);
 }
 
 function comparable(text: string): string {
@@ -151,23 +181,113 @@ function continues(longer: string, shorter: string): boolean {
   return comparable(longer).startsWith(comparable(shorter));
 }
 
+/* How strongly a caption turn and a canonical segment are shown to be one turn. */
+const DIFFERENT_TURNS = 0;
+/** Only their first words agree. That is all a final segment whose text its
+    repair rewrote shares with a caption that has no final text of its own. */
+const SAME_OPENING = 1;
+/** Their words agree past the opening. */
+const SAME_WORDS = 2;
+
 /**
- * The words one utterance shows.
+ * Whether a caption turn and a canonical segment are the same spoken turn.
  *
- * The committed text wins once it is final, and the caption leads while both
- * stream, because the caption is the low-latency one. When both have finished
- * and disagree, the caption's `turn.done` is the provider's own final text: a
- * canonical completion can reach the panel before native's mirrored `done`
- * repairs it, and a stale completion must not overwrite a correct line.
+ * They share no identifier, but they carry the same provider evidence: native
+ * builds its segment from the same fragments the data channel delivers, in the
+ * same order, and its mirrored `transcript/done` carries the same final text as
+ * the channel's `turn.done`. So a segment still streaming must be the same
+ * fragments as the caption, one a little ahead of the other; a final one is what
+ * those fragments accumulated or, once repaired, the provider's final text. A
+ * pair that fits none of that is two turns, whatever order they arrived in.
  */
-function utteranceText(utterance: Utterance): string {
-  const { caption, canonical } = utterance;
-  if (!canonical?.text) return caption?.text ?? "";
-  if (!caption?.text) return canonical.text;
-  if (canonical.final && caption.final) return continues(canonical.text, caption.text) ? canonical.text : caption.text;
-  if (canonical.final) return canonical.text;
-  if (caption.final) return caption.text;
-  return continues(canonical.text, caption.text) ? canonical.text : caption.text;
+function sameTurn(caption: CaptionTurn, canonical: CanonicalTurn): number {
+  const committed = comparable(canonical.text);
+  const opening = comparable(caption.opening);
+  const finalText = caption.finalText === null ? null : comparable(caption.finalText);
+  /* A turn that streamed nothing is only its final text. */
+  const streamed = comparable(caption.streamed) || finalText || "";
+  if (!committed) return DIFFERENT_TURNS;
+  if (!committed.startsWith(opening) && !opening.startsWith(committed)) {
+    /* A different start. The provider's final text can still show one turn,
+       because a repair may rewrite how the turn began. */
+    return canonical.final && finalText === committed ? SAME_WORDS : DIFFERENT_TURNS;
+  }
+  if (!canonical.final) {
+    /* A closed caption already holds every fragment the segment can reach. */
+    return streamed.startsWith(committed) || (!caption.closed && committed.startsWith(streamed))
+      ? SAME_WORDS
+      : DIFFERENT_TURNS;
+  }
+  if (committed === streamed || committed === finalText || (!caption.closed && committed.startsWith(streamed))) {
+    return SAME_WORDS;
+  }
+  /* A caption with a final text of its own that still disagrees is another
+     turn; one without it can be checked no further than its opening. */
+  return finalText === null ? SAME_OPENING : DIFFERENT_TURNS;
+}
+
+/**
+ * Pair one speaker's caption turns with native's segments (#1658).
+ *
+ * Both sources take a speaker's turns in the same order, since native opens a
+ * segment on the speaker's first fragment and closes it on that speaker's
+ * `turn.done`, the same provider events the data channel carries. Either can
+ * miss a turn, though: a data channel that opened late, a segment with no
+ * words, a host that restarted. Pairing the k-th with the k-th then shifts every
+ * later turn onto its neighbour's line. So this is the in-order alignment of
+ * the two sequences with the most agreement by `sameTurn`: a turn one source
+ * missed is left on a line of its own, the turns around it still pair, and the
+ * same words said twice stay two turns because each turn pairs once. On a tie
+ * the earlier pairing wins.
+ */
+function align(role: TranscriptSpeaker, captions: readonly CaptionTurn[], canonicals: readonly CanonicalTurn[]): TurnView[] {
+  const agreement = captions.map((caption) => canonicals.map((canonical) => sameTurn(caption, canonical)));
+  /* best[i][j]: the most agreement captions from i and segments from j can reach. */
+  const best = Array.from({ length: captions.length + 1 }, () => new Array<number>(canonicals.length + 1).fill(0));
+  for (let i = captions.length - 1; i >= 0; i -= 1) {
+    for (let j = canonicals.length - 1; j >= 0; j -= 1) {
+      const paired = agreement[i]![j]! ? agreement[i]![j]! + best[i + 1]![j + 1]! : 0;
+      best[i]![j] = Math.max(paired, best[i + 1]![j]!, best[i]![j + 1]!);
+    }
+  }
+  const views: TurnView[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < captions.length || j < canonicals.length) {
+    const here = i < captions.length && j < canonicals.length ? agreement[i]![j]! : 0;
+    if (here && here + best[i + 1]![j + 1]! === best[i]![j]) {
+      views.push({ role, caption: captions[i++]!, canonical: canonicals[j++]!, agreement: here });
+    } else if (j < canonicals.length && (i === captions.length || best[i]![j + 1] === best[i]![j])) {
+      views.push({ role, caption: null, canonical: canonicals[j++]!, agreement: 0 });
+    } else {
+      views.push({ role, caption: captions[i++]!, canonical: null, agreement: 0 });
+    }
+  }
+  return views;
+}
+
+/**
+ * The words one line shows.
+ *
+ * The caption leads while both stream, because it is the low-latency one, and
+ * the caption's final text leads a segment still streaming. A final segment
+ * wins: it is committed, and its mirrored `done` has repaired any fragment the
+ * provider never streamed. The one exception is the moment between native's
+ * completion and that repair, recognisable because the segment still says
+ * exactly what the fragments said; the caption's final text is already right,
+ * and the line does not flicker back.
+ */
+function viewText({ caption, canonical }: TurnView): string {
+  const captioned = caption ? caption.finalText ?? caption.streamed : "";
+  if (!canonical) return captioned;
+  if (!caption || !captioned) return canonical.text;
+  if (canonical.final) {
+    return caption.finalText !== null && comparable(canonical.text) === comparable(caption.streamed)
+      ? caption.finalText
+      : canonical.text;
+  }
+  if (caption.finalText !== null) return caption.finalText;
+  return continues(canonical.text, captioned) ? canonical.text : captioned;
 }
 
 function newOperatorActivityId(): string {
@@ -256,8 +376,10 @@ export function parseCodexRealtimeEvent(value: unknown): ParsedRealtimeEvent {
        speaker's canonical segment on it (#1658), and a caption left open would
        swallow the next turn into this one. Without words it is only a boundary
        when it says whose. */
-    if (!text) return role ? { kind: "transcript", role, text: "", final: true } : { kind: "ignored" };
-    return { kind: "transcript", role: role ?? "assistant", text, final: true };
+    if (!text && !role) return { kind: "ignored" };
+    const parsed: ParsedRealtimeEvent = { kind: "transcript", role: role ?? "assistant", text, final: true };
+    const turnId = stringAt(event.turn, "id");
+    return turnId ? { ...parsed, turnId } : parsed;
   }
   if (type === "delegation.created" || type === "conversation.handoff.requested") {
     /* Both events name the same handoff; `delegation.created` nests the
@@ -848,7 +970,7 @@ class CodexRealtimeClient {
     }
     const event = parseCodexRealtimeEvent(value);
     if (event.kind === "transcript") {
-      this.writeCaption(event.role, event.text, event.final, event.chunkId);
+      this.writeCaption(event.role, event.text, event.final, event.chunkId, event.turnId);
       /* THE UTTERANCE BOUNDARY (#844 §2). The operator's speech never passes
          through our server — it rides the WebRTC leg straight to the model — so
          this is the one moment in the whole system where a spoken turn can be
@@ -883,43 +1005,50 @@ class CodexRealtimeClient {
    * showed nothing of what the backend had actually recorded. Both now reach
    * here, and the whole job is not showing the operator every sentence twice.
    *
-   * A canonical segment carries its WHOLE text each time, and is placed ONCE
+   * A canonical segment carries its WHOLE text each time, and is one turn
    * (#1658):
    *
-   * - a segment already placed updates its own utterance, in place. That is what
+   * - a segment already placed updates its own turn, in place. That is what
    *   makes a redelivered frame, a `done` completing its own deltas, and the
    *   store handing over its whole tail again converge on one line.
    * - a segment seen for the first time is the speaker's next turn on the
-   *   canonical stream, so it joins that speaker's oldest captioned turn still
-   *   waiting for one — the same turn, by the turn order both sources share.
-   *   Nothing is matched by words, so the same sentence said twice stays two
-   *   lines.
-   * - a segment the caption has not reached is a line of its own, and the
-   *   caption joins it when it gets there. That is the case a dropped data
-   *   channel produces, and it is the reason for all of this.
+   *   canonical stream, and `align` pairs it with the caption turn it is, in
+   *   whichever order the two arrived.
+   * - a segment no caption turn is has a line of its own. That is the case a
+   *   dropped data channel produces, and it is the reason for all of this.
    *
    * A segment with no words yet takes no line and no place in the order: native
    * opens every segment empty, and an empty one used to claim a line before the
    * caption with its words could be joined.
    */
   reconcileCanonicalTranscript(segments: readonly RuntimeVoiceTranscriptSegment[] | null | undefined): void {
-    const changed = new Set<Utterance>();
+    const ledger = this.transcript;
+    const realign = new Set<TranscriptSpeaker>();
+    /* Turns already settled on their lines, whose segment changed again. */
+    const resettled: TurnView[] = [];
     for (const segment of segments ?? []) {
       if (!segment?.segmentId || typeof segment.text !== "string") continue;
       if (segment.role !== "user" && segment.role !== "assistant") continue;
-      let utterance = this.transcript.segments.get(segment.segmentId);
-      if (!utterance) {
-        if (!segment.text || !this.belongsToThisCall(segment.realtimeSessionId)) continue;
-        utterance = this.transcript.awaitingCanonical[segment.role].shift()
-          ?? this.newUtterance(segment.role, this.transcript.awaitingCaption[segment.role]);
-        this.placeSegment(segment.segmentId, utterance);
+      const text = segment.text.slice(0, MAX_LINE_CHARS);
+      const placed = ledger.segments.get(segment.segmentId);
+      if (!placed) {
+        if (!comparable(text) || !this.belongsToThisCall(segment.realtimeSessionId)) continue;
+        const turn: CanonicalTurn = { role: segment.role, text, final: segment.final, line: null, caption: null };
+        ledger.segments.set(segment.segmentId, turn);
+        forgetOldest(ledger.segments, MAX_CANONICAL_SEGMENTS);
+        ledger.open[segment.role].canonicals.push(turn);
+        realign.add(segment.role);
+        continue;
       }
       /* A settled segment is not reopened by a late non-final frame of it. */
-      if (utterance.canonical?.final && !segment.final) continue;
-      utterance.canonical = { text: segment.text.slice(0, MAX_LINE_CHARS), final: segment.final };
-      changed.add(utterance);
+      if (!comparable(text) || (placed.final && !segment.final)) continue;
+      if (placed.text === text && placed.final === segment.final) continue;
+      placed.text = text;
+      placed.final = segment.final;
+      if (ledger.open[placed.role].canonicals.includes(placed)) realign.add(placed.role);
+      else resettled.push({ role: placed.role, caption: placed.caption, canonical: placed, agreement: 0 });
     }
-    this.draw(changed);
+    this.draw([...resettled, ...[...realign].flatMap((role) => this.realign(role))]);
   }
 
   /**
@@ -938,24 +1067,6 @@ class CodexRealtimeClient {
     return true;
   }
 
-  private placeSegment(segmentId: string, utterance: Utterance): void {
-    const placed = this.transcript.segments;
-    placed.set(segmentId, utterance);
-    if (placed.size > MAX_CANONICAL_SEGMENTS) {
-      const oldest = placed.keys().next().value as string | undefined;
-      if (oldest !== undefined) placed.delete(oldest);
-    }
-  }
-
-  /** A turn only one source has reached so far, queued for the other. */
-  private newUtterance(role: TranscriptSpeaker, waitingFor: Utterance[]): Utterance {
-    const utterance: Utterance = {
-      lineId: `${role}:${++this.lineSequence}`, role, caption: null, canonical: null, drawn: false,
-    };
-    boundedPush(waitingFor, utterance, MAX_UNPAIRED_UTTERANCES);
-    return utterance;
-  }
-
   /**
    * Route a caption fragment to the turn its speaker is taking.
    *
@@ -966,55 +1077,124 @@ class CodexRealtimeClient {
    * with the whole of it repeated underneath. Worker progress lands between
    * them too, so position says nothing about ownership.
    */
-  private writeCaption(role: TranscriptSpeaker, text: string, final: boolean, chunkId?: string): void {
+  private writeCaption(role: TranscriptSpeaker, text: string, final: boolean, chunkId?: string, turnId?: string): void {
     const ledger = this.transcript;
-    let streaming = ledger.streaming.get(role);
-    /* The same fragment delivered twice is one fragment. */
-    if (chunkId && streaming?.chunkIds.has(chunkId)) return;
-    if (!streaming) {
+    /* The same fragment delivered twice is one fragment, however long ago its
+       turn ended. */
+    if (chunkId) {
+      if (ledger.fragments.has(chunkId)) return;
+      ledger.fragments.add(chunkId);
+      forgetOldest(ledger.fragments, MAX_SEEN_FRAGMENTS);
+    }
+    let turn = ledger.streaming.get(role);
+    if (!turn) {
       /* A done with no words and nothing streamed before it is no turn. */
       if (!text) return;
-      const utterance = ledger.awaitingCaption[role].shift() ?? this.newUtterance(role, ledger.awaitingCanonical[role]);
-      streaming = { utterance, chunkIds: new Set() };
-      if (!final) ledger.streaming.set(role, streaming);
+      /* Nor is the done that closed the last turn, delivered again, known by
+         the turn id it carries. */
+      const last = ledger.lastCaption.get(role);
+      if (final && turnId && last?.closedBy === turnId && last.finalText !== null
+        && comparable(last.finalText) === comparable(text)) return;
+      turn = { role, streamed: "", opening: text, finalText: null, closedBy: null, closed: false, line: null };
+      ledger.open[role].captions.push(turn);
+      ledger.lastCaption.set(role, turn);
+      if (!final) ledger.streaming.set(role, turn);
     }
-    if (chunkId) {
-      if (streaming.chunkIds.size >= MAX_TURN_CHUNKS) streaming.chunkIds.clear();
-      streaming.chunkIds.add(chunkId);
+    if (final) {
+      /* A done carries the complete turn; an empty one keeps what streamed. */
+      turn.finalText = text ? text.slice(0, MAX_LINE_CHARS) : null;
+      turn.closedBy = turnId ?? null;
+      turn.closed = true;
+      ledger.streaming.delete(role);
+    } else {
+      /* A fragment carries only the new words, except on backends that resend
+         the whole text, which the prefix check absorbs. */
+      turn.streamed = (text.startsWith(turn.streamed) ? text : `${turn.streamed}${text}`).slice(-MAX_LINE_CHARS);
+      if (!comparable(turn.opening)) turn.opening = text;
     }
-    const { utterance } = streaming;
-    const previous = utterance.caption?.text ?? "";
-    /* A final event carries the complete turn — an empty one keeps what was
-       streamed — and a streamed one only the new fragment, except on backends
-       that resend the whole text, which the prefix check absorbs. */
-    const combined = final
-      ? text || previous
-      : text.startsWith(previous) ? text : `${previous}${text}`;
-    utterance.caption = { text: combined.slice(-MAX_LINE_CHARS), final };
-    if (final) ledger.streaming.delete(role);
-    this.draw([utterance]);
+    this.draw(this.realign(role));
   }
 
-  /** Put these utterances on the panel, in one update. */
-  private draw(utterances: Iterable<Utterance>): void {
-    let lines: CodexRealtimeLine[] | null = null;
-    for (const utterance of utterances) {
-      const text = utteranceText(utterance);
-      if (!text) continue;
-      const final = utterance.caption?.final === true || utterance.canonical?.final === true;
-      const current = lines ?? this.snapshot.lines;
-      const index = current.findIndex((line) => line.id === utterance.lineId);
-      if (index < 0 && utterance.drawn) continue;
-      if (index >= 0 && current[index]!.text === text && current[index]!.final === final) continue;
-      lines ??= [...this.snapshot.lines];
-      if (index < 0) {
-        lines.push({ id: utterance.lineId, role: utterance.role, text, final });
-        utterance.drawn = true;
-      } else {
-        lines[index] = { ...lines[index]!, text, final };
-      }
+  /**
+   * Align a speaker's open turns again, and settle the ones that are done.
+   *
+   * A pair whose words agree and whose two halves have both finished can no
+   * longer change partner, so it and everything before it leave the open lists
+   * and keep the lines they have. That keeps the alignment to the few turns
+   * the two sources are apart, and the lists bounded however long the call.
+   */
+  private realign(role: TranscriptSpeaker): TurnView[] {
+    const open = this.transcript.open[role];
+    const views = align(role, open.captions, open.canonicals);
+    let settled = 0;
+    views.forEach((view, index) => {
+      if (view.agreement === SAME_WORDS && view.caption!.closed && view.canonical!.final) settled = index + 1;
+    });
+    let captions = views.slice(settled).filter((view) => view.caption).length;
+    let canonicals = views.slice(settled).filter((view) => view.canonical).length;
+    while (captions > MAX_OPEN_TURNS || canonicals > MAX_OPEN_TURNS) {
+      const oldest = views[settled++]!;
+      if (oldest.caption) captions -= 1;
+      if (oldest.canonical) canonicals -= 1;
     }
-    if (lines) this.update({ lines: lines.slice(-MAX_LINES) });
+    for (const view of views) if (view.canonical) view.canonical.caption = view.caption;
+    open.captions = views.slice(settled).flatMap((view) => view.caption ? [view.caption] : []);
+    open.canonicals = views.slice(settled).flatMap((view) => view.canonical ? [view.canonical] : []);
+    return views;
+  }
+
+  /**
+   * Put these turns on the panel, in one update.
+   *
+   * A turn keeps the line it was first drawn on. When alignment joins two
+   * turns that were each drawn alone, the earlier line takes both and the
+   * other goes; when it separates two, the one drawn first keeps the line and
+   * the other gets a new one. A new line goes just before the next turn of the
+   * same speaker that has one, so a turn one source missed and the other
+   * supplied late still reads in its place.
+   */
+  private draw(views: readonly TurnView[]): void {
+    let lines: readonly CodexRealtimeLine[] = this.snapshot.lines;
+    let copied: CodexRealtimeLine[] | null = null;
+    const editable = (): CodexRealtimeLine[] => {
+      copied ??= [...lines];
+      lines = copied;
+      return copied;
+    };
+    const indexOf = (id: string | null) => id === null ? -1 : lines.findIndex((line) => line.id === id);
+    /* Lines a turn earlier in this pass has taken, or folded into another. */
+    const taken = new Set<string>();
+    views.forEach((view, position) => {
+      const turns: (CaptionTurn | CanonicalTurn)[] = [];
+      if (view.caption) turns.push(view.caption);
+      if (view.canonical) turns.push(view.canonical);
+      const held = [...new Set(turns.map((turn) => turn.line))]
+        .filter((id): id is string => id !== null && !taken.has(id) && indexOf(id) >= 0)
+        .sort((a, b) => indexOf(a) - indexOf(b));
+      const text = viewText(view);
+      const final = view.caption?.closed === true || view.canonical?.final === true;
+      let lineId = held[0] ?? null;
+      if (lineId === null) {
+        /* A line that scrolled out of the bounded list is not brought back. */
+        if (!text || turns.some((turn) => turn.line !== null && !taken.has(turn.line))) return;
+        lineId = `${view.role}:${++this.lineSequence}`;
+        const next = views.slice(position + 1)
+          .filter((later) => later.role === view.role)
+          .flatMap((later) => [indexOf(later.caption?.line ?? null), indexOf(later.canonical?.line ?? null)])
+          .find((index) => index >= 0);
+        editable().splice(next ?? lines.length, 0, { id: lineId, role: view.role, text, final });
+      }
+      for (const folded of held.slice(1)) {
+        editable().splice(indexOf(folded), 1);
+        taken.add(folded);
+      }
+      for (const turn of turns) turn.line = lineId;
+      taken.add(lineId);
+      const index = indexOf(lineId);
+      const line = lines[index]!;
+      if (text && (line.text !== text || line.final !== final)) editable()[index] = { ...line, text, final };
+    });
+    if (copied) this.update({ lines: lines.slice(-MAX_LINES) });
   }
 
   private writeLine(key: string, role: CodexRealtimeRole, text: string, final: boolean): void {

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -62,7 +62,10 @@ export interface CodexRealtimeSnapshot {
 }
 
 export type ParsedRealtimeEvent =
-  | { kind: "transcript"; role: "user" | "assistant"; text: string; final: boolean }
+  /** `chunkId` is the provider's id for one streamed fragment; a `turn.done`
+      has none. An empty `text` occurs only on a `turn.done` that names its
+      speaker: it ends that speaker's turn with the words already streamed. */
+  | { kind: "transcript"; role: "user" | "assistant"; text: string; final: boolean; chunkId?: string }
   /** The handoff that turns the utterance just finished into work on the thread.
       Its identities are the canonical join between what was said and what the
       backing model was asked to do (#1629). */
@@ -73,6 +76,99 @@ export type ParsedRealtimeEvent =
 
 const MAX_LINE_CHARS = 12_000;
 const MAX_LINES = 80;
+/** Canonical segment ids one call remembers. Above the runtime store's own
+    tail of 80, so every segment the store can still redeliver is recognised as
+    already placed and keeps the one place it has in the turn order. */
+const MAX_CANONICAL_SEGMENTS = 160;
+/** Utterances one source may be ahead of the other, per speaker. The canonical
+    stream lags the data channel by a few turns at most. */
+const MAX_UNPAIRED_UTTERANCES = 32;
+/** Fragment ids one streaming turn remembers for replay detection. */
+const MAX_TURN_CHUNKS = 512;
+/** Earlier calls whose late canonical segments must stay out of the current one. */
+const MAX_RETIRED_SESSIONS = 8;
+
+/**
+ * One spoken turn, and the panel line it owns (#1658).
+ *
+ * Two sources describe it: the data channel's caption, immediate and streamed
+ * fragment by fragment, and the app-server's canonical segment, committed and a
+ * little behind. They share no identifier. What they share is the turn
+ * structure: native opens a speaker's segment on that speaker's first fragment
+ * and closes it on that speaker's `turn.done` — the same provider events the data
+ * channel delivers — so within one call the k-th turn a speaker takes is the
+ * k-th on both sources. Each half is attached here when its source reaches that
+ * turn, in whichever order the two arrive.
+ */
+interface Utterance {
+  lineId: string;
+  role: TranscriptSpeaker;
+  caption: { text: string; final: boolean } | null;
+  canonical: { text: string; final: boolean } | null;
+  /** The line has been drawn once. Missing after that means it scrolled out of
+      the bounded list, and it is not brought back. */
+  drawn: boolean;
+}
+
+/** One call's transcript: which utterance each source is filling, per speaker. */
+interface TranscriptLedger {
+  /** The realtime session whose canonical segments belong on these lines. */
+  sessionId: string | null;
+  /** The turn each speaker's caption is streaming into. One per speaker, not
+      one overall: in a duplex call both speak at once, and closing one
+      speaker's line whenever the other spoke split every overlapping sentence
+      into fragments. */
+  streaming: Map<TranscriptSpeaker, { utterance: Utterance; chunkIds: Set<string> }>;
+  /** Captioned turns the canonical stream has not reached yet, oldest first. */
+  awaitingCanonical: Record<TranscriptSpeaker, Utterance[]>;
+  /** Canonical turns the data channel has not reached yet, oldest first. */
+  awaitingCaption: Record<TranscriptSpeaker, Utterance[]>;
+  /** The utterance each canonical segment id was placed on. */
+  segments: Map<string, Utterance>;
+}
+
+function newTranscriptLedger(sessionId: string | null = null): TranscriptLedger {
+  return {
+    sessionId,
+    streaming: new Map(),
+    awaitingCanonical: { user: [], assistant: [] },
+    awaitingCaption: { user: [], assistant: [] },
+    segments: new Map(),
+  };
+}
+
+function boundedPush<T>(queue: T[], value: T, limit: number): void {
+  queue.push(value);
+  if (queue.length > limit) queue.splice(0, queue.length - limit);
+}
+
+function comparable(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** `longer` says everything `shorter` does and possibly more. */
+function continues(longer: string, shorter: string): boolean {
+  return comparable(longer).startsWith(comparable(shorter));
+}
+
+/**
+ * The words one utterance shows.
+ *
+ * The committed text wins once it is final, and the caption leads while both
+ * stream, because the caption is the low-latency one. When both have finished
+ * and disagree, the caption's `turn.done` is the provider's own final text: a
+ * canonical completion can reach the panel before native's mirrored `done`
+ * repairs it, and a stale completion must not overwrite a correct line.
+ */
+function utteranceText(utterance: Utterance): string {
+  const { caption, canonical } = utterance;
+  if (!canonical?.text) return caption?.text ?? "";
+  if (!caption?.text) return canonical.text;
+  if (canonical.final && caption.final) return continues(canonical.text, caption.text) ? canonical.text : caption.text;
+  if (canonical.final) return canonical.text;
+  if (caption.final) return caption.text;
+  return continues(canonical.text, caption.text) ? canonical.text : caption.text;
+}
 
 function newOperatorActivityId(): string {
   return randomHex(32);
@@ -129,30 +225,39 @@ function eventText(event: Record<string, unknown>): string {
   ).slice(0, MAX_LINE_CHARS);
 }
 
-function eventRole(event: Record<string, unknown>, fallback: "user" | "assistant"): "user" | "assistant" {
+function namedRole(event: Record<string, unknown>): "user" | "assistant" | null {
   const role = stringAt(event, "role")
     ?? stringAt(event.turn, "role")
     ?? stringAt(event.item, "role");
-  return role === "user" || role === "input" ? "user" : role === "assistant" || role === "output" ? "assistant" : fallback;
+  return role === "user" || role === "input" ? "user" : role === "assistant" || role === "output" ? "assistant" : null;
+}
+
+function transcriptChunk(event: Record<string, unknown>, role: "user" | "assistant"): ParsedRealtimeEvent {
+  const text = eventText(event);
+  if (!text) return { kind: "ignored" };
+  /* Native's streamed fragments each carry their own id, so a fragment the
+     channel delivers twice can be recognised as the same one. */
+  const chunkId = stringAt(event.item, "id");
+  return chunkId
+    ? { kind: "transcript", role, text, final: false, chunkId }
+    : { kind: "transcript", role, text, final: false };
 }
 
 export function parseCodexRealtimeEvent(value: unknown): ParsedRealtimeEvent {
   const event = object(value);
   if (!event) return { kind: "ignored" };
   const type = stringAt(event, "type") ?? stringAt(event, "method") ?? "";
-  if (type === "input_transcript.added") {
-    const text = eventText(event);
-    return text ? { kind: "transcript", role: "user", text, final: false } : { kind: "ignored" };
-  }
-  if (type === "output_transcript.added") {
-    const text = eventText(event);
-    return text ? { kind: "transcript", role: "assistant", text, final: false } : { kind: "ignored" };
-  }
+  if (type === "input_transcript.added") return transcriptChunk(event, "user");
+  if (type === "output_transcript.added") return transcriptChunk(event, "assistant");
   if (type === "turn.done") {
     const text = eventText(event);
-    return text
-      ? { kind: "transcript", role: eventRole(event, "assistant"), text, final: true }
-      : { kind: "ignored" };
+    const role = namedRole(event);
+    /* A done with no words still ends its speaker's turn — native closes that
+       speaker's canonical segment on it (#1658), and a caption left open would
+       swallow the next turn into this one. Without words it is only a boundary
+       when it says whose. */
+    if (!text) return role ? { kind: "transcript", role, text: "", final: true } : { kind: "ignored" };
+    return { kind: "transcript", role: role ?? "assistant", text, final: true };
   }
   if (type === "delegation.created" || type === "conversation.handoff.requested") {
     /* Both events name the same handoff; `delegation.created` nests the
@@ -229,11 +334,13 @@ class CodexRealtimeClient {
   private workerDeliveryWakeEpoch: number | null = null;
   private unloadHangup: (() => void) | null = null;
   private lineSequence = 0;
-  /** The line each speaker is still streaming into, by line id. Held here
-      rather than read off the end of the list because a delegating turn
+  /** The current call's utterances, held here because a delegating turn
       interleaves both speakers with worker progress, so "the last line" is
-      almost never the line an update belongs to. */
-  private readonly openTranscriptLines = new Map<TranscriptSpeaker, string>();
+      almost never the line an update belongs to. Kept through the hangup and
+      replaced when the next call starts: a canonical segment the backend
+      commits just after the hangup still belongs on this call's lines. */
+  private transcript: TranscriptLedger = newTranscriptLedger();
+  private readonly retiredTranscriptSessions: string[] = [];
   /* #1629: the utterance boundary this peer is currently publishing for. The
      server cannot mint it — the operator's audio never reaches it — and without
      one a retried publication counts as a second utterance and a slow one
@@ -250,9 +357,6 @@ class CodexRealtimeClient {
      that claimed a fresh utterance is how card B answered a question asked about
      card A after the operator spoke again. */
   private readonly reportedHandoffKeys = new Set<string>();
-  /* Which panel line each canonical transcript segment owns, so a segment that
-     is republished updates its own line instead of stacking a second copy. */
-  private readonly canonicalLines = new Map<string, string>();
   /* Set once this peer sees a handoff it cannot attribute, and never cleared
      within the call. Every unattributed utterance may still produce a handoff,
      so nothing arriving afterwards can be shown to be anyone's. */
@@ -307,6 +411,13 @@ class CodexRealtimeClient {
       return;
     }
     this.cleanupTransport();
+    /* A new call is a new turn order. The last call's lines stay on screen,
+       but nothing of this call may be attached to them, and that call's own
+       late segments are kept out of this one. */
+    if (this.transcript.sessionId) {
+      boundedPush(this.retiredTranscriptSessions, this.transcript.sessionId, MAX_RETIRED_SESSIONS);
+    }
+    this.transcript = newTranscriptLedger();
     /* `notice` is cleared with `error` for the same reason: it describes the
        call that is starting, and a warning carried over from the previous one
        would tell the operator about a limit this call has not reported. */
@@ -413,6 +524,8 @@ class CodexRealtimeClient {
          peer just ran. Held for the life of the session and presented on every write
          into it (#691 §6). */
       this.realtimeSessionId = typeof answer.realtimeSessionId === "string" ? answer.realtimeSessionId : null;
+      /* The same id the host tags every canonical segment of this call with. */
+      if (this.realtimeSessionId) this.transcript.sessionId = this.realtimeSessionId;
       await peer.setRemoteDescription({ type: "answer", sdp: answer.sdp });
     } catch (error) {
       if (epoch !== this.epoch) return;
@@ -454,7 +567,7 @@ class CodexRealtimeClient {
        answer once per tick as a ladder of ever-longer prefixes. The turn id
        also survives the line being finalized when the turn ends, so a trailing
        tick reuses it instead of opening a second copy. */
-    this.writeLine(`progress:${turnId}`, "progress", text, !running, "replace");
+    this.writeLine(`progress:${turnId}`, "progress", text, !running);
   }
 
   reconcileWorkerDeliveries(
@@ -735,7 +848,7 @@ class CodexRealtimeClient {
     }
     const event = parseCodexRealtimeEvent(value);
     if (event.kind === "transcript") {
-      this.writeTranscript(event.role, event.text, event.final);
+      this.writeCaption(event.role, event.text, event.final, event.chunkId);
       /* THE UTTERANCE BOUNDARY (#844 §2). The operator's speech never passes
          through our server — it rides the WebRTC leg straight to the model — so
          this is the one moment in the whole system where a spoken turn can be
@@ -743,8 +856,9 @@ class CodexRealtimeClient {
          instant the transcript goes final, for the same reason the composer
          reads it inside its submit handler: everything the reference will say
          is decided by the state that existed when the operator finished
-         speaking. */
-      if (event.role === "user" && event.final) {
+         speaking. A done with no words ends the caption but publishes nothing,
+         exactly as when such a done was not read at all. */
+      if (event.role === "user" && event.final && event.text) {
         this.publishOperatorActivity();
         this.publishSelectedContext();
       }
@@ -769,89 +883,147 @@ class CodexRealtimeClient {
    * showed nothing of what the backend had actually recorded. Both now reach
    * here, and the whole job is not showing the operator every sentence twice.
    *
-   * A canonical segment carries its WHOLE text each time, so:
+   * A canonical segment carries its WHOLE text each time, and is placed ONCE
+   * (#1658):
    *
-   * - a segment already merged updates the line it owns, in place. That is what
-   *   makes a redelivered frame, a `done` completing its own deltas, and a
-   *   replay after reconnect converge on one line instead of three.
-   * - a segment arriving for the first time ADOPTS the most recent line of the
-   *   same speaker whose text it continues — the data-channel line for the same
-   *   words — and takes ownership of it. The canonical text wins, because it is
-   *   the record the thread keeps.
-   * - anything else is a line this panel never saw, and it is appended. That is
-   *   the case a dropped data channel produces, and it is the reason for all of
-   *   this.
+   * - a segment already placed updates its own utterance, in place. That is what
+   *   makes a redelivered frame, a `done` completing its own deltas, and the
+   *   store handing over its whole tail again converge on one line.
+   * - a segment seen for the first time is the speaker's next turn on the
+   *   canonical stream, so it joins that speaker's oldest captioned turn still
+   *   waiting for one — the same turn, by the turn order both sources share.
+   *   Nothing is matched by words, so the same sentence said twice stays two
+   *   lines.
+   * - a segment the caption has not reached is a line of its own, and the
+   *   caption joins it when it gets there. That is the case a dropped data
+   *   channel produces, and it is the reason for all of this.
+   *
+   * A segment with no words yet takes no line and no place in the order: native
+   * opens every segment empty, and an empty one used to claim a line before the
+   * caption with its words could be joined.
    */
   reconcileCanonicalTranscript(segments: readonly RuntimeVoiceTranscriptSegment[] | null | undefined): void {
+    const changed = new Set<Utterance>();
     for (const segment of segments ?? []) {
       if (!segment?.segmentId || typeof segment.text !== "string") continue;
       if (segment.role !== "user" && segment.role !== "assistant") continue;
-      const owned = this.canonicalLines.get(segment.segmentId);
-      const key = owned ?? this.adoptableLineFor(segment) ?? `canonical:${segment.segmentId}`;
-      if (!owned) {
-        this.canonicalLines.set(segment.segmentId, key);
-        /* The canonical record owns this line now, so a later data-channel
-           fragment for the same speaker opens a fresh one rather than appending
-           to text the backend has already committed. */
-        if (this.openTranscriptLines.get(segment.role) === key) this.openTranscriptLines.delete(segment.role);
+      let utterance = this.transcript.segments.get(segment.segmentId);
+      if (!utterance) {
+        if (!segment.text || !this.belongsToThisCall(segment.realtimeSessionId)) continue;
+        utterance = this.transcript.awaitingCanonical[segment.role].shift()
+          ?? this.newUtterance(segment.role, this.transcript.awaitingCaption[segment.role]);
+        this.placeSegment(segment.segmentId, utterance);
       }
-      this.writeLine(key, segment.role, segment.text, segment.final, "replace");
+      /* A settled segment is not reopened by a late non-final frame of it. */
+      if (utterance.canonical?.final && !segment.final) continue;
+      utterance.canonical = { text: segment.text.slice(0, MAX_LINE_CHARS), final: segment.final };
+      changed.add(utterance);
     }
+    this.draw(changed);
   }
 
   /**
-   * The line this segment is the committed form of, if the panel already has it.
+   * Whether a canonical segment from this realtime session belongs on the
+   * current call's lines.
    *
-   * Matched by speaker and by prefix, newest first, and never a line another
-   * segment already owns. Prefix rather than equality because the data channel
-   * streams: when the canonical `done` lands, the line usually holds a leading
-   * part of the same sentence.
+   * The runtime store keeps the last calls' segments too, and a new call must
+   * not attach them to its own turns. The call's own id comes from its answer;
+   * an answer without one binds the first session that is not an earlier call's,
+   * and nothing binds while the answer is still on its way.
    */
-  private adoptableLineFor(segment: RuntimeVoiceTranscriptSegment): string | null {
-    const owned = new Set(this.canonicalLines.values());
-    for (let index = this.snapshot.lines.length - 1; index >= 0; index -= 1) {
-      const line = this.snapshot.lines[index]!;
-      if (line.role !== segment.role || owned.has(line.id)) continue;
-      return line.text && segment.text.startsWith(line.text) ? line.id : null;
+  private belongsToThisCall(sessionId: string): boolean {
+    if (this.transcript.sessionId !== null) return sessionId === this.transcript.sessionId;
+    if (this.snapshot.phase === "connecting" || this.retiredTranscriptSessions.includes(sessionId)) return false;
+    this.transcript.sessionId = sessionId;
+    return true;
+  }
+
+  private placeSegment(segmentId: string, utterance: Utterance): void {
+    const placed = this.transcript.segments;
+    placed.set(segmentId, utterance);
+    if (placed.size > MAX_CANONICAL_SEGMENTS) {
+      const oldest = placed.keys().next().value as string | undefined;
+      if (oldest !== undefined) placed.delete(oldest);
     }
-    return null;
+  }
+
+  /** A turn only one source has reached so far, queued for the other. */
+  private newUtterance(role: TranscriptSpeaker, waitingFor: Utterance[]): Utterance {
+    const utterance: Utterance = {
+      lineId: `${role}:${++this.lineSequence}`, role, caption: null, canonical: null, drawn: false,
+    };
+    boundedPush(waitingFor, utterance, MAX_UNPAIRED_UTTERANCES);
+    return utterance;
   }
 
   /**
-   * Route a speaker's text to the line that speaker currently owns. Barge-in
-   * puts the operator's turn after the agent's half-finished one, and worker
-   * progress lands between the two, so position says nothing about ownership.
-   * Whoever speaks closes the other's line: an interrupted turn that resumes
-   * opens a fresh line instead of growing the one it abandoned.
+   * Route a caption fragment to the turn its speaker is taking.
+   *
+   * Each speaker streams into its own turn until that speaker's `turn.done`,
+   * which is exactly where native closes the canonical segment. The other
+   * speaker talking does not end it: in a duplex call the two overlap word by
+   * word, and ending a turn there left every overlapping sentence in pieces
+   * with the whole of it repeated underneath. Worker progress lands between
+   * them too, so position says nothing about ownership.
    */
-  private writeTranscript(role: TranscriptSpeaker, text: string, final: boolean): void {
-    this.openTranscriptLines.delete(role === "user" ? "assistant" : "user");
-    const key = this.openTranscriptLines.get(role) ?? `${role}:${++this.lineSequence}`;
-    if (final) this.openTranscriptLines.delete(role);
-    else this.openTranscriptLines.set(role, key);
-    /* A final event carries the complete turn, a streamed one only the new
-       fragment — except on backends that resend the whole text, which the
-       prefix check below absorbs. */
-    this.writeLine(key, role, text, final, final ? "replace" : "append");
+  private writeCaption(role: TranscriptSpeaker, text: string, final: boolean, chunkId?: string): void {
+    const ledger = this.transcript;
+    let streaming = ledger.streaming.get(role);
+    /* The same fragment delivered twice is one fragment. */
+    if (chunkId && streaming?.chunkIds.has(chunkId)) return;
+    if (!streaming) {
+      /* A done with no words and nothing streamed before it is no turn. */
+      if (!text) return;
+      const utterance = ledger.awaitingCaption[role].shift() ?? this.newUtterance(role, ledger.awaitingCanonical[role]);
+      streaming = { utterance, chunkIds: new Set() };
+      if (!final) ledger.streaming.set(role, streaming);
+    }
+    if (chunkId) {
+      if (streaming.chunkIds.size >= MAX_TURN_CHUNKS) streaming.chunkIds.clear();
+      streaming.chunkIds.add(chunkId);
+    }
+    const { utterance } = streaming;
+    const previous = utterance.caption?.text ?? "";
+    /* A final event carries the complete turn — an empty one keeps what was
+       streamed — and a streamed one only the new fragment, except on backends
+       that resend the whole text, which the prefix check absorbs. */
+    const combined = final
+      ? text || previous
+      : text.startsWith(previous) ? text : `${previous}${text}`;
+    utterance.caption = { text: combined.slice(-MAX_LINE_CHARS), final };
+    if (final) ledger.streaming.delete(role);
+    this.draw([utterance]);
   }
 
-  private writeLine(
-    key: string,
-    role: CodexRealtimeRole,
-    text: string,
-    final: boolean,
-    mode: "replace" | "append",
-  ): void {
+  /** Put these utterances on the panel, in one update. */
+  private draw(utterances: Iterable<Utterance>): void {
+    let lines: CodexRealtimeLine[] | null = null;
+    for (const utterance of utterances) {
+      const text = utteranceText(utterance);
+      if (!text) continue;
+      const final = utterance.caption?.final === true || utterance.canonical?.final === true;
+      const current = lines ?? this.snapshot.lines;
+      const index = current.findIndex((line) => line.id === utterance.lineId);
+      if (index < 0 && utterance.drawn) continue;
+      if (index >= 0 && current[index]!.text === text && current[index]!.final === final) continue;
+      lines ??= [...this.snapshot.lines];
+      if (index < 0) {
+        lines.push({ id: utterance.lineId, role: utterance.role, text, final });
+        utterance.drawn = true;
+      } else {
+        lines[index] = { ...lines[index]!, text, final };
+      }
+    }
+    if (lines) this.update({ lines: lines.slice(-MAX_LINES) });
+  }
+
+  private writeLine(key: string, role: CodexRealtimeRole, text: string, final: boolean): void {
     const lines = [...this.snapshot.lines];
     const index = lines.findIndex((line) => line.id === key);
     if (index < 0) {
       lines.push({ id: key, role, text: text.slice(-MAX_LINE_CHARS), final });
     } else {
-      const previous = lines[index]!;
-      const combined = mode === "replace" || text.startsWith(previous.text)
-        ? text
-        : `${previous.text}${text}`;
-      lines[index] = { ...previous, text: combined.slice(-MAX_LINE_CHARS), final };
+      lines[index] = { ...lines[index]!, text: text.slice(-MAX_LINE_CHARS), final };
     }
     this.update({ lines: lines.slice(-MAX_LINES) });
   }
@@ -900,9 +1072,10 @@ class CodexRealtimeClient {
   realtimeSession = (): string | null => this.realtimeSessionId;
 
   private cleanupTransport(): void {
-    /* No line survives a dead transport as "still streaming": the next call
-       opens its own rather than appending to a turn nobody can finish. */
-    this.openTranscriptLines.clear();
+    /* No turn survives a dead transport as "still streaming". Its canonical
+       half can still arrive, so the turn order itself is kept until the next
+       call replaces it. */
+    this.transcript.streaming.clear();
     if (this.unloadHangup) window.removeEventListener("pagehide", this.unloadHangup);
     this.unloadHangup = null;
     this.events?.close();
@@ -922,8 +1095,6 @@ class CodexRealtimeClient {
     this.utterancesAwaitingHandoff = [];
     this.reportedHandoffKeys.clear();
     this.handoffCorrelationLost = false;
-    this.canonicalLines.clear();
-    this.openTranscriptLines.clear();
   }
 }
 

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -88,6 +88,8 @@ const MAX_OPEN_TURNS = 32;
 /** Fragment ids one call remembers, so a fragment delivered again is known
     however long ago its turn ended. */
 const MAX_SEEN_FRAGMENTS = 2_048;
+/** Turn ids of the dones that closed a turn, remembered for the same reason. */
+const MAX_SEEN_COMPLETIONS = 512;
 /** Earlier calls whose late canonical segments must stay out of the current one. */
 const MAX_RETIRED_SESSIONS = 8;
 
@@ -102,8 +104,6 @@ interface CaptionTurn {
   /** The words of the `turn.done` that closed the turn: the provider's final
       transcript. Null while the turn is open, and when that done had none. */
   finalText: string | null;
-  /** The turn id that done carried, to know the same done delivered again. */
-  closedBy: string | null;
   closed: boolean;
   /** The panel line it is on, once drawn. */
   line: string | null;
@@ -115,6 +115,11 @@ interface CanonicalTurn {
   /** The whole segment so far, as the store carries it. */
   text: string;
   final: boolean;
+  /** What the segment said before a repair rewrote it, when this client saw
+      it: the words its fragments accumulated, which is what the caption of
+      the same turn streamed. Null until a text arrives that does not continue
+      the one before. */
+  unrepaired: { text: string; final: boolean } | null;
   line: string | null;
   /** The caption turn it was last aligned with. */
   caption: CaptionTurn | null;
@@ -138,8 +143,6 @@ interface TranscriptLedger {
       speaker's line whenever the other spoke split every overlapping sentence
       into fragments. */
   streaming: Map<TranscriptSpeaker, CaptionTurn>;
-  /** Each speaker's latest caption turn, open or closed. */
-  lastCaption: Map<TranscriptSpeaker, CaptionTurn>;
   /** Each speaker's turns still open to alignment, per source, in the order
       that source took them. Everything older has settled on its line. */
   open: Record<TranscriptSpeaker, { captions: CaptionTurn[]; canonicals: CanonicalTurn[] }>;
@@ -147,16 +150,18 @@ interface TranscriptLedger {
   segments: Map<string, CanonicalTurn>;
   /** Fragment ids already applied. */
   fragments: Set<string>;
+  /** Turn ids of the dones that already closed a turn. */
+  completions: Set<string>;
 }
 
 function newTranscriptLedger(sessionId: string | null = null): TranscriptLedger {
   return {
     sessionId,
     streaming: new Map(),
-    lastCaption: new Map(),
     open: { user: { captions: [], canonicals: [] }, assistant: { captions: [], canonicals: [] } },
     segments: new Map(),
     fragments: new Set(),
+    completions: new Set(),
   };
 }
 
@@ -183,11 +188,18 @@ function continues(longer: string, shorter: string): boolean {
 
 /* How strongly a caption turn and a canonical segment are shown to be one turn. */
 const DIFFERENT_TURNS = 0;
-/** Only their first words agree. That is all a final segment whose text its
-    repair rewrote shares with a caption that has no final text of its own. */
-const SAME_OPENING = 1;
+/** Only one end of their words agrees: the first words, or every word after
+    the first. That is all a final segment whose repair rewrote the other end
+    shares with a caption that has no final text of its own. */
+const SAME_EDGE = 1;
 /** Their words agree past the opening. */
 const SAME_WORDS = 2;
+
+/** The words of a text, as a repair can leave them: case and punctuation are
+    the provider's to change. */
+function words(text: string): string[] {
+  return comparable(text).toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, "").split(" ").filter(Boolean);
+}
 
 /**
  * Whether a caption turn and a canonical segment are the same spoken turn.
@@ -199,9 +211,20 @@ const SAME_WORDS = 2;
  * fragments as the caption, one a little ahead of the other; a final one is what
  * those fragments accumulated or, once repaired, the provider's final text. A
  * pair that fits none of that is two turns, whatever order they arrived in.
+ *
+ * A repair replaces the segment's text, so the text it replaced is kept and
+ * weighed too: it is the fragments themselves, and the evidence the caption of
+ * the same turn still carries.
  */
 function sameTurn(caption: CaptionTurn, canonical: CanonicalTurn): number {
-  const committed = comparable(canonical.text);
+  const now = agreement(caption, canonical.text, canonical.final);
+  return canonical.unrepaired
+    ? Math.max(now, agreement(caption, canonical.unrepaired.text, canonical.unrepaired.final))
+    : now;
+}
+
+function agreement(caption: CaptionTurn, text: string, final: boolean): number {
+  const committed = comparable(text);
   const opening = comparable(caption.opening);
   const finalText = caption.finalText === null ? null : comparable(caption.finalText);
   /* A turn that streamed nothing is only its final text. */
@@ -210,9 +233,18 @@ function sameTurn(caption: CaptionTurn, canonical: CanonicalTurn): number {
   if (!committed.startsWith(opening) && !opening.startsWith(committed)) {
     /* A different start. The provider's final text can still show one turn,
        because a repair may rewrite how the turn began. */
-    return canonical.final && finalText === committed ? SAME_WORDS : DIFFERENT_TURNS;
+    if (!final) return DIFFERENT_TURNS;
+    if (finalText !== null) return finalText === committed ? SAME_WORDS : DIFFERENT_TURNS;
+    /* A caption whose done had no words has only its fragments, and a repair
+       of the opening word keeps every word after it. */
+    const said = words(streamed);
+    const kept = words(committed);
+    return caption.closed && said.length > 1 && said.length === kept.length
+      && said.every((word, index) => index === 0 || word === kept[index])
+      ? SAME_EDGE
+      : DIFFERENT_TURNS;
   }
-  if (!canonical.final) {
+  if (!final) {
     /* A closed caption already holds every fragment the segment can reach. */
     return streamed.startsWith(committed) || (!caption.closed && committed.startsWith(streamed))
       ? SAME_WORDS
@@ -223,7 +255,7 @@ function sameTurn(caption: CaptionTurn, canonical: CanonicalTurn): number {
   }
   /* A caption with a final text of its own that still disagrees is another
      turn; one without it can be checked no further than its opening. */
-  return finalText === null ? SAME_OPENING : DIFFERENT_TURNS;
+  return finalText === null ? SAME_EDGE : DIFFERENT_TURNS;
 }
 
 /**
@@ -1033,7 +1065,9 @@ class CodexRealtimeClient {
       const placed = ledger.segments.get(segment.segmentId);
       if (!placed) {
         if (!comparable(text) || !this.belongsToThisCall(segment.realtimeSessionId)) continue;
-        const turn: CanonicalTurn = { role: segment.role, text, final: segment.final, line: null, caption: null };
+        const turn: CanonicalTurn = {
+          role: segment.role, text, final: segment.final, unrepaired: null, line: null, caption: null,
+        };
         ledger.segments.set(segment.segmentId, turn);
         forgetOldest(ledger.segments, MAX_CANONICAL_SEGMENTS);
         ledger.open[segment.role].canonicals.push(turn);
@@ -1043,6 +1077,10 @@ class CodexRealtimeClient {
       /* A settled segment is not reopened by a late non-final frame of it. */
       if (!comparable(text) || (placed.final && !segment.final)) continue;
       if (placed.text === text && placed.final === segment.final) continue;
+      /* A repair replaces the words; the ones it replaced still name the turn. */
+      if (!placed.unrepaired && !continues(text, placed.text)) {
+        placed.unrepaired = { text: placed.text, final: placed.final };
+      }
       placed.text = text;
       placed.final = segment.final;
       if (ledger.open[placed.role].canonicals.includes(placed)) realign.add(placed.role);
@@ -1086,30 +1124,33 @@ class CodexRealtimeClient {
       ledger.fragments.add(chunkId);
       forgetOldest(ledger.fragments, MAX_SEEN_FRAGMENTS);
     }
+    /* So is a done: the one that closed a turn, delivered again, is known by
+       the turn id it carries, and ends neither that turn a second time nor the
+       one streaming now. */
+    if (final && turnId && ledger.completions.has(turnId)) return;
     let turn = ledger.streaming.get(role);
     if (!turn) {
       /* A done with no words and nothing streamed before it is no turn. */
       if (!text) return;
-      /* Nor is the done that closed the last turn, delivered again, known by
-         the turn id it carries. */
-      const last = ledger.lastCaption.get(role);
-      if (final && turnId && last?.closedBy === turnId && last.finalText !== null
-        && comparable(last.finalText) === comparable(text)) return;
-      turn = { role, streamed: "", opening: text, finalText: null, closedBy: null, closed: false, line: null };
+      turn = { role, streamed: "", opening: text, finalText: null, closed: false, line: null };
       ledger.open[role].captions.push(turn);
-      ledger.lastCaption.set(role, turn);
       if (!final) ledger.streaming.set(role, turn);
     }
     if (final) {
       /* A done carries the complete turn; an empty one keeps what streamed. */
       turn.finalText = text ? text.slice(0, MAX_LINE_CHARS) : null;
-      turn.closedBy = turnId ?? null;
       turn.closed = true;
       ledger.streaming.delete(role);
+      if (turnId) {
+        ledger.completions.add(turnId);
+        forgetOldest(ledger.completions, MAX_SEEN_COMPLETIONS);
+      }
     } else {
-      /* A fragment carries only the new words, except on backends that resend
-         the whole text, which the prefix check absorbs. */
-      turn.streamed = (text.startsWith(turn.streamed) ? text : `${turn.streamed}${text}`).slice(-MAX_LINE_CHARS);
+      /* A fragment with its own id is one delta, so a word said twice in a row
+         is two of them. Only a fragment without one may be a backend resending
+         the whole text so far, which the prefix check absorbs. */
+      const whole = !chunkId && text.startsWith(turn.streamed);
+      turn.streamed = (whole ? text : `${turn.streamed}${text}`).slice(-MAX_LINE_CHARS);
       if (!comparable(turn.opening)) turn.opening = text;
     }
     this.draw(this.realign(role));

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -1126,8 +1126,13 @@ class CodexRealtimeClient {
     }
     /* So is a done: the one that closed a turn, delivered again, is known by
        the turn id it carries, and ends neither that turn a second time nor the
-       one streaming now. */
-    if (final && turnId && ledger.completions.has(turnId)) return;
+       one streaming now. That holds for a done that drew nothing, too, because
+       every fragment of its turn was lost. */
+    if (final && turnId) {
+      if (ledger.completions.has(turnId)) return;
+      ledger.completions.add(turnId);
+      forgetOldest(ledger.completions, MAX_SEEN_COMPLETIONS);
+    }
     let turn = ledger.streaming.get(role);
     if (!turn) {
       /* A done with no words and nothing streamed before it is no turn. */
@@ -1141,10 +1146,6 @@ class CodexRealtimeClient {
       turn.finalText = text ? text.slice(0, MAX_LINE_CHARS) : null;
       turn.closed = true;
       ledger.streaming.delete(role);
-      if (turnId) {
-        ledger.completions.add(turnId);
-        forgetOldest(ledger.completions, MAX_SEEN_COMPLETIONS);
-      }
     } else {
       /* A fragment with its own id is one delta, so a word said twice in a row
          is two of them. Only a fragment without one may be a backend resending

--- a/src/lib/realtime/fixtures/voice-duplex-call.jsonl
+++ b/src/lib/realtime/fixtures/voice-duplex-call.jsonl
@@ -1,0 +1,150 @@
+{"at": 0, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-001", "type": "input_transcript", "text": " Please"}, "start_ms": 0, "end_ms": 200}}
+{"at": 83, "source": "app-server", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-01", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"at": 83, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-002", "type": "input_transcript", "text": " repeat the"}, "start_ms": 83, "end_ms": 283}}
+{"at": 100, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-01", "delta": " Please"}}
+{"at": 100, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " Please"}}
+{"at": 146, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-01", "delta": " repeat the"}}
+{"at": 146, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " repeat the"}}
+{"at": 146, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-003", "type": "input_transcript", "text": " read"}, "start_ms": 146, "end_ms": 346}}
+{"at": 153, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-004", "type": "input_transcript", "text": "-only"}, "start_ms": 153, "end_ms": 353}}
+{"at": 177, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-005", "type": "output_transcript", "text": " I'm the"}, "start_ms": 177, "end_ms": 377}}
+{"at": 178, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-006", "type": "output_transcript", "text": " dedicated"}, "start_ms": 178, "end_ms": 378}}
+{"at": 215, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-01", "delta": " read"}}
+{"at": 215, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " read"}}
+{"at": 223, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-007", "type": "output_transcript", "text": " Voice"}, "start_ms": 223, "end_ms": 423}}
+{"at": 299, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-01", "delta": "-only"}}
+{"at": 299, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": "-only"}}
+{"at": 351, "source": "app-server", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-02", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"at": 371, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " I'm the"}}
+{"at": 371, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " I'm the"}}
+{"at": 408, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " dedicated"}}
+{"at": 408, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " dedicated"}}
+{"at": 460, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " Voice"}}
+{"at": 460, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " Voice"}}
+{"at": 487, "source": "data-channel", "event": {"type": "turn.done", "turn": {"id": "turn-01", "role": "user", "transcript": " Please repeat the read-only"}}}
+{"at": 579, "source": "app-server", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-01", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "user", "text": " Please repeat the read-only"}}}
+{"at": 579, "source": "app-server", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " Please repeat the read-only"}}
+{"at": 654, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-008", "type": "output_transcript", "text": " regression"}, "start_ms": 654, "end_ms": 854}}
+{"at": 715, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " regression"}}
+{"at": 715, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " regression"}}
+{"at": 962, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-009", "type": "input_transcript", "text": " status"}, "start_ms": 962, "end_ms": 1162}}
+{"at": 1062, "source": "data-channel", "event": {"type": "turn.done", "turn": {"id": "turn-02", "role": "assistant", "transcript": " I'm the dedicated Voice regression"}}}
+{"at": 1185, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-010", "type": "input_transcript", "text": " check from"}, "start_ms": 1185, "end_ms": 1385}}
+{"at": 1292, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-011", "type": "input_transcript", "text": " our"}, "start_ms": 1292, "end_ms": 1492}}
+{"at": 1319, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-012", "type": "output_transcript", "text": " QA"}, "start_ms": 1319, "end_ms": 1519}}
+{"at": 1688, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-013", "type": "output_transcript", "text": " orchestrator"}, "start_ms": 1688, "end_ms": 1888}}
+{"at": 1882, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-014", "type": "input_transcript", "text": " setup"}, "start_ms": 1882, "end_ms": 2082}}
+{"at": 1882, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-015", "type": "output_transcript", "text": ","}, "start_ms": 1882, "end_ms": 2082}}
+{"at": 2088, "source": "app-server", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-03", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"at": 2117, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " status"}}
+{"at": 2117, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " status"}}
+{"at": 2179, "source": "app-server", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-02", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "assistant", "text": " I'm the dedicated Voice regression"}}}
+{"at": 2179, "source": "app-server", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " I'm the dedicated Voice regression"}}
+{"at": 2250, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " check from"}}
+{"at": 2250, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " check from"}}
+{"at": 2314, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " our"}}
+{"at": 2314, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " our"}}
+{"at": 2383, "source": "app-server", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-04", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"at": 2417, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " QA"}}
+{"at": 2417, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " QA"}}
+{"at": 2458, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-016", "type": "input_transcript", "text": " using"}, "start_ms": 2458, "end_ms": 2658}}
+{"at": 2476, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " orchestrator"}}
+{"at": 2476, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " orchestrator"}}
+{"at": 2543, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " setup"}}
+{"at": 2543, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " setup"}}
+{"at": 2574, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-017", "type": "input_transcript", "text": " the"}, "start_ms": 2574, "end_ms": 2774}}
+{"at": 2636, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": ","}}
+{"at": 2636, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": ","}}
+{"at": 2715, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " using"}}
+{"at": 2715, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " using"}}
+{"at": 2791, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " the"}}
+{"at": 2791, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " the"}}
+{"at": 2958, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-018", "type": "input_transcript", "text": " tool"}, "start_ms": 2958, "end_ms": 3158}}
+{"at": 3459, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-019", "type": "input_transcript", "text": " again"}, "start_ms": 3459, "end_ms": 3659}}
+{"at": 3571, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-020", "type": "input_transcript", "text": " now"}, "start_ms": 3571, "end_ms": 3771}}
+{"at": 4106, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-021", "type": "output_transcript", "text": " Checking"}, "start_ms": 4106, "end_ms": 4306}}
+{"at": 4298, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-022", "type": "output_transcript", "text": " it now"}, "start_ms": 4298, "end_ms": 4498}}
+{"at": 4444, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-023", "type": "input_transcript", "text": " Tell"}, "start_ms": 4444, "end_ms": 4644}}
+{"at": 4445, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-024", "type": "output_transcript", "text": "."}, "start_ms": 4445, "end_ms": 4645}}
+{"at": 4670, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-025", "type": "input_transcript", "text": " me"}, "start_ms": 4670, "end_ms": 4870}}
+{"at": 4805, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-026", "type": "input_transcript", "text": " your"}, "start_ms": 4805, "end_ms": 5005}}
+{"at": 5190, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-027", "type": "input_transcript", "text": " role in"}, "start_ms": 5190, "end_ms": 5390}}
+{"at": 5338, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-028", "type": "input_transcript", "text": " this"}, "start_ms": 5338, "end_ms": 5538}}
+{"at": 6216, "source": "data-channel", "event": {"type": "turn.done", "turn": {"id": "turn-03", "role": "user", "transcript": " status check from our setup using the tool again now Tell me your role in this"}}}
+{"at": 6472, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-029", "type": "input_transcript", "text": " conversation"}, "start_ms": 6472, "end_ms": 6672}}
+{"at": 6473, "source": "data-channel", "event": {"type": "turn.done", "turn": {"id": "turn-04", "role": "assistant", "transcript": " QA orchestrator, Checking it now."}}}
+{"at": 6682, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-030", "type": "output_transcript", "text": " One sec"}, "start_ms": 6682, "end_ms": 6882}}
+{"at": 6824, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-031", "type": "output_transcript", "text": "."}, "start_ms": 6824, "end_ms": 7024}}
+{"at": 7074, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-032", "type": "input_transcript", "text": " Do"}, "start_ms": 7074, "end_ms": 7274}}
+{"at": 7384, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " tool"}}
+{"at": 7384, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " tool"}}
+{"at": 8376, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-033", "type": "input_transcript", "text": " not"}, "start_ms": 8376, "end_ms": 8576}}
+{"at": 8427, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-034", "type": "input_transcript", "text": " change"}, "start_ms": 8427, "end_ms": 8627}}
+{"at": 8435, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-035", "type": "input_transcript", "text": " anything"}, "start_ms": 8435, "end_ms": 8635}}
+{"at": 8568, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-036", "type": "input_transcript", "text": " or"}, "start_ms": 8568, "end_ms": 8768}}
+{"at": 8771, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " again"}}
+{"at": 8771, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " again"}}
+{"at": 8837, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " now"}}
+{"at": 8837, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " now"}}
+{"at": 8950, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " Checking"}}
+{"at": 8950, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " Checking"}}
+{"at": 8976, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-037", "type": "input_transcript", "text": " launch"}, "start_ms": 8976, "end_ms": 9176}}
+{"at": 9145, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " it now"}}
+{"at": 9145, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " it now"}}
+{"at": 9159, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-038", "type": "input_transcript", "text": " any"}, "start_ms": 9159, "end_ms": 9359}}
+{"at": 9201, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " Tell"}}
+{"at": 9201, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " Tell"}}
+{"at": 9297, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": "."}}
+{"at": 9297, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": "."}}
+{"at": 9386, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " me"}}
+{"at": 9386, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " me"}}
+{"at": 9466, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " your"}}
+{"at": 9466, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " your"}}
+{"at": 9634, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " role in"}}
+{"at": 9634, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " role in"}}
+{"at": 9668, "source": "data-channel", "event": {"type": "input_transcript.added", "item": {"id": "chunk-039", "type": "input_transcript", "text": " agents"}, "start_ms": 9668, "end_ms": 9868}}
+{"at": 9877, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-040", "type": "output_transcript", "text": " Still looking"}, "start_ms": 9877, "end_ms": 10077}}
+{"at": 10039, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-041", "type": "output_transcript", "text": "."}, "start_ms": 10039, "end_ms": 10239}}
+{"at": 10359, "source": "data-channel", "event": {"type": "turn.done", "turn": {"id": "turn-05", "role": "user", "transcript": " conversation Do not change anything or launch any agents"}}}
+{"at": 10878, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " this"}}
+{"at": 10878, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " this"}}
+{"at": 11486, "source": "app-server", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-03", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "user", "text": " status check from our setup using the tool again now Tell me your role in this"}}}
+{"at": 11486, "source": "app-server", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " status check from our setup using the tool again now Tell me your role in this"}}
+{"at": 11858, "source": "app-server", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-05", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"at": 11908, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " conversation"}}
+{"at": 11908, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " conversation"}}
+{"at": 11981, "source": "app-server", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-04", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "assistant", "text": " QA orchestrator, Checking it now."}}}
+{"at": 11981, "source": "app-server", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " QA orchestrator, Checking it now."}}
+{"at": 12160, "source": "app-server", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-06", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"at": 12179, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-06", "delta": " One sec"}}
+{"at": 12179, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " One sec"}}
+{"at": 12207, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-06", "delta": "."}}
+{"at": 12207, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": "."}}
+{"at": 12214, "source": "data-channel", "event": {"type": "turn.done", "turn": {"id": "turn-06", "role": "assistant", "transcript": " One sec. Still looking."}}}
+{"at": 12261, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " Do"}}
+{"at": 12261, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " Do"}}
+{"at": 12347, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " not"}}
+{"at": 12347, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " not"}}
+{"at": 12418, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " change"}}
+{"at": 12418, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " change"}}
+{"at": 12473, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " anything"}}
+{"at": 12473, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " anything"}}
+{"at": 12526, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " or"}}
+{"at": 12526, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " or"}}
+{"at": 12590, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " launch"}}
+{"at": 12590, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " launch"}}
+{"at": 12645, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " any"}}
+{"at": 12645, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " any"}}
+{"at": 12690, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-042", "type": "output_transcript", "text": " Let me"}, "start_ms": 12690, "end_ms": 12890}}
+{"at": 12690, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " agents"}}
+{"at": 12690, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " agents"}}
+{"at": 12725, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-06", "delta": " Still looking"}}
+{"at": 12725, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " Still looking"}}
+{"at": 12813, "source": "app-server", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-06", "delta": "."}}
+{"at": 12813, "source": "app-server", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": "."}}
+{"at": 12838, "source": "app-server", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-05", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "user", "text": " conversation Do not change anything or launch any agents"}}}
+{"at": 12838, "source": "app-server", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " conversation Do not change anything or launch any agents"}}
+{"at": 12855, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-043", "type": "output_transcript", "text": " check that"}, "start_ms": 12855, "end_ms": 13055}}
+{"at": 13049, "source": "data-channel", "event": {"type": "output_transcript.added", "item": {"id": "chunk-044", "type": "output_transcript", "text": " again."}, "start_ms": 13049, "end_ms": 13249}}
+{"at": 13724, "source": "app-server", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-06", "realtimeSessionId": "call-live", "type": "transcriptSegment", "role": "assistant", "text": " One sec. Still looking."}}}
+{"at": 13724, "source": "app-server", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " One sec. Still looking."}}

--- a/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
+++ b/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
@@ -557,3 +557,199 @@ test("both speakers talking at once keep one line each", async () => {
   ]);
   await client.stop();
 });
+
+/* ------------------------------------------------------------------------ *
+ * A TURN ONE SOURCE MISSED (#1658).
+ *
+ * The two sources share no identifier, only the order a speaker takes turns in
+ * and the provider's own fragments and final text. Pairing the k-th caption with
+ * the k-th segment shifted every later turn onto its neighbour's line as soon as
+ * either source missed one: the earlier answer was overwritten and the later one
+ * shown twice.
+ * ------------------------------------------------------------------------ */
+
+const spoken = (client: Client) => shown(client).map((line) => `${line.role}:${line.text}`);
+
+function completedSegment(client: Client, id: string, role: "user" | "assistant", text: string): void {
+  canonical(client, "thread/realtime/item/started", {
+    threadId: THREAD, item: { id, realtimeSessionId: "realtime-1", type: "transcriptSegment", role, text: "" },
+  });
+  canonical(client, "thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: id, delta: text });
+  canonical(client, "thread/realtime/item/completed", {
+    threadId: THREAD, item: { id, realtimeSessionId: "realtime-1", type: "transcriptSegment", role, text },
+  });
+  canonical(client, "thread/realtime/transcript/done", { threadId: THREAD, role, text });
+}
+
+for (const first of ["caption", "canonical"] as const) {
+  test(`a turn the data channel never captioned keeps its line, and the next turn pairs with its own (${first} first)`, async () => {
+    const client = await panel();
+    completedSegment(client, "segment-first", "assistant", " First answer.");
+    const caption = () => {
+      channel({ type: "output_transcript.added", item: { id: "chunk-second", type: "output_transcript", text: " Second answer." } });
+      channel({ type: "turn.done", turn: { id: "turn-second", role: "assistant", transcript: " Second answer." } });
+    };
+    if (first === "caption") caption();
+    completedSegment(client, "segment-second", "assistant", " Second answer.");
+    if (first === "canonical") caption();
+    expect(spoken(client)).toEqual(["assistant: First answer.", "assistant: Second answer."]);
+    await client.stop();
+  });
+}
+
+/** The recorded native events with one of `call-one`'s turns taken out of one source. */
+function withoutTurn(source: Recorded["source"], matches: (record: Recorded) => boolean): Recorded[] {
+  return NATIVE_WIRE.filter((record) => record.call === "call-one" && !(record.source === source && matches(record)));
+}
+
+const captionOf = (chunks: string[], turn: string) => (record: Recorded) => {
+  const event = record.event as { item?: { id?: string }; turn?: { id?: string } };
+  return chunks.includes(event.item?.id ?? "") || event.turn?.id === turn;
+};
+
+test("native's events with one assistant turn never captioned still show every turn once", async () => {
+  const records = withoutTurn("data-channel", captionOf(["chunk-003", "chunk-005", "chunk-006"], "bidi-a1"));
+  const committedFirst = await panel("call-one");
+  replay(committedFirst, [...records.filter((r) => r.source === "app-server"), ...records.filter((r) => r.source === "data-channel")]);
+  expect(shown(committedFirst)).toEqual(NATIVE_TURNS);
+  await committedFirst.stop();
+
+  const captionFirst = codexRealtimeClient(`${conversationId}-caption-first`);
+  await call(captionFirst, "call-one");
+  for (const record of records.filter((r) => r.source === "data-channel")) channel(record.event!);
+  reducer.begin("call-one");
+  for (const record of records.filter((r) => r.source === "app-server")) notified(record.method!, record.params!);
+  captionFirst.reconcileCanonicalTranscript(carried());
+  /* Each turn once. The uncaptioned one arrives after everything the channel
+     said, and takes its place ahead of the next answer the channel did caption. */
+  expect(shown(captionFirst)).toEqual([
+    NATIVE_TURNS[0]!, NATIVE_TURNS[2]!, NATIVE_TURNS[1]!, ...NATIVE_TURNS.slice(3),
+  ]);
+  await captionFirst.stop();
+});
+
+test("the recorded duplex call with one answer never captioned still shows every turn once", async () => {
+  const records = DUPLEX_CALL.filter((record) => {
+    const event = record.event as { type?: string; item?: { text?: string }; turn?: { id?: string } } | undefined;
+    if (record.source !== "data-channel") return true;
+    if (event?.turn?.id === "turn-02") return false;
+    return !(event?.type === "output_transcript.added"
+      && [" I'm the", " dedicated", " Voice", " regression"].includes(event.item?.text ?? ""));
+  });
+  const client = await panel("call-live");
+  replay(client, records);
+  expect(shown(client)).toEqual(DUPLEX_TURNS);
+  await client.stop();
+});
+
+test("the recorded duplex call with one answer never committed still shows every turn once", async () => {
+  const records = DUPLEX_CALL.filter((record) => {
+    const params = record.params as { itemId?: string; item?: { id?: string }; role?: string; text?: string; delta?: string } | undefined;
+    if (record.source !== "app-server") return true;
+    if (params?.itemId === "segment-02" || params?.item?.id === "segment-02") return false;
+    /* Its flat mirror goes with it. */
+    return !(params?.role === "assistant"
+      && [" I'm the", " dedicated", " Voice", " regression", " I'm the dedicated Voice regression"]
+        .includes(params.delta ?? params.text ?? ""));
+  });
+  const client = await panel("call-live");
+  replay(client, records);
+  expect(shown(client)).toEqual(DUPLEX_TURNS);
+  await client.stop();
+});
+
+for (const missing of ["caption", "canonical"] as const) {
+  test(`a missed turn that opens with the same words is not given the next turn's line (${missing} missed)`, async () => {
+    /* The first fragment alone cannot tell these two turns apart; what follows
+       it can, and the pairing follows the evidence as it arrives. */
+    const client = await panel();
+    const said = [
+      { turn: "turn-a", chunks: [" Okay", "."], done: " Okay." },
+      { turn: "turn-b", chunks: [" Okay", ", go."], done: " Okay, go." },
+    ];
+    for (const [index, { turn, chunks, done }] of said.entries()) {
+      if (missing === "canonical" || index > 0) {
+        for (const [part, text] of chunks.entries()) {
+          channel({ type: "output_transcript.added", item: { id: `${turn}-${part}`, type: "output_transcript", text } });
+        }
+        channel({ type: "turn.done", turn: { id: turn, role: "assistant", transcript: done } });
+      }
+      if (missing === "caption" || index > 0) {
+        const id = `segment-${turn}`;
+        canonical(client, "thread/realtime/item/started", {
+          threadId: THREAD, item: { id, realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: "" },
+        });
+        for (const text of chunks) canonical(client, "thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: id, delta: text });
+        canonical(client, "thread/realtime/item/completed", {
+          threadId: THREAD, item: { id, realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: done },
+        });
+        canonical(client, "thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: done });
+      }
+    }
+    expect(shown(client)).toEqual([
+      { role: "assistant", text: " Okay.", final: true },
+      { role: "assistant", text: " Okay, go.", final: true },
+    ]);
+    await client.stop();
+  });
+}
+
+for (const first of ["caption", "canonical"] as const) {
+  test(`an empty caption done does not hold back the committed repair of a word never streamed (${first} first)`, async () => {
+    const client = await panel();
+    const caption = () => {
+      channel({ type: "output_transcript.added", item: { id: "chunk-hello", type: "output_transcript", text: " Hello" } });
+      channel({ type: "output_transcript.added", item: { id: "chunk-world", type: "output_transcript", text: " world" } });
+      channel({ type: "turn.done", turn: { id: "turn-hello", role: "assistant", transcript: "" } });
+    };
+    const committed = () => {
+      canonical(client, "thread/realtime/item/started", {
+        threadId: THREAD, item: { id: "segment-hello", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: "" },
+      });
+      canonical(client, "thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "segment-hello", delta: " Hello" });
+      canonical(client, "thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "segment-hello", delta: " world" });
+      canonical(client, "thread/realtime/item/completed", {
+        threadId: THREAD, item: { id: "segment-hello", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: " Hello world" },
+      });
+      canonical(client, "thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: " Hello big world" });
+    };
+    if (first === "caption") { caption(); committed(); } else { committed(); caption(); }
+    expect(shown(client)).toEqual([{ role: "assistant", text: " Hello big world", final: true }]);
+    await client.stop();
+  });
+}
+
+test("a completion its mirrored done has not repaired yet never takes the caption's final words away", async () => {
+  const client = await panel();
+  const seen: string[] = [];
+  const unsubscribe = client.subscribe(() => seen.push(client.getSnapshot().lines.map((line) => line.text).join(" | ")));
+  channel({ type: "output_transcript.added", item: { id: "chunk-hello", type: "output_transcript", text: " Hello" } });
+  channel({ type: "output_transcript.added", item: { id: "chunk-world", type: "output_transcript", text: " world" } });
+  channel({ type: "turn.done", turn: { id: "turn-hello", role: "assistant", transcript: " Hello big world" } });
+  const repaired = seen.length;
+  completedSegment(client, "segment-hello", "assistant", " Hello world");
+  canonical(client, "thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: " Hello big world" });
+  unsubscribe();
+  expect(seen.slice(repaired - 1).every((line) => line === " Hello big world")).toBe(true);
+  expect(shown(client)).toEqual([{ role: "assistant", text: " Hello big world", final: true }]);
+  await client.stop();
+});
+
+test("a fragment or done delivered again after its turn ended changes nothing, and the same words said again are a new turn", async () => {
+  const client = await panel();
+  const fragment = { type: "input_transcript.added", item: { id: "chunk-yes", type: "input_transcript", text: " yes" } };
+  const done = { type: "turn.done", turn: { id: "turn-yes", role: "user", transcript: " yes" } };
+  channel(fragment);
+  channel(done);
+  completedSegment(client, "segment-yes", "user", " yes");
+  channel(fragment);
+  channel(done);
+  expect(spoken(client)).toEqual(["user: yes"]);
+
+  channel({ type: "input_transcript.added", item: { id: "chunk-yes-again", type: "input_transcript", text: " yes" } });
+  channel({ type: "turn.done", turn: { id: "turn-yes-again", role: "user", transcript: " yes" } });
+  completedSegment(client, "segment-yes-again", "user", " yes");
+  channel(fragment);
+  expect(spoken(client)).toEqual(["user: yes", "user: yes"]);
+  await client.stop();
+});

--- a/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
+++ b/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
@@ -1,14 +1,19 @@
-import { afterAll, beforeEach, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 import { Window } from "happy-dom";
+import { createElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
 
 import { applyEvent, emptyStore, type RuntimeStore } from "@/components/runtime/runtimeModel";
+import { VoiceConversationPanel } from "@/components/VoiceConversation";
+import { translate, type TFunction } from "@/lib/i18n";
 import { CodexRealtimeTranscript } from "@/lib/runtime/codexRealtimeTranscript";
 import { projectEngineHostEvent } from "@/lib/runtime/engineHostEvents";
 import type { RuntimeEvent } from "@/lib/runtime/engineHost";
 
-import { codexRealtimeClient } from "./codexRealtimeClient";
+import { codexRealtimeClient, type CodexRealtimeRole } from "./codexRealtimeClient";
 
 /**
  * The canonical transcript's whole path to the panel (#1629).
@@ -27,6 +32,9 @@ import { codexRealtimeClient } from "./codexRealtimeClient";
  * 3. `applyRuntimeEvent` folds it into the browser's session store,
  * 4. the real `CodexRealtimeClient` merges what the store carries into its lines.
  *
+ * 5. `VoiceConversationPanel` renders those lines, and every assertion reads
+ *    what it rendered.
+ *
  * The one seam is the socket between 2 and 3, which is the same transport every
  * other runtime event uses and is covered by the runtime bus's own suite. The
  * host's own emission of step 1's output is pinned in
@@ -37,6 +45,9 @@ const dom = new Window();
 Object.assign(globalThis, {
   window: dom,
   document: dom.document,
+  Node: dom.Node,
+  Element: dom.Element,
+  HTMLElement: dom.HTMLElement,
   Audio: dom.Audio,
   MediaStream: dom.MediaStream ?? class {},
 });
@@ -188,6 +199,59 @@ async function call(client: ReturnType<typeof codexRealtimeClient>, session: str
   StubPeerConnection.latest!.channel.onopen?.();
 }
 
+const t: TFunction = (key, params) => translate("en", key, params);
+const ROLE_BY_LABEL = new Map<string, CodexRealtimeRole>(
+  (["user", "assistant", "progress"] as const).map((role) => [
+    t(role === "user" ? "voice.you" : role === "assistant" ? "voice.agent" : "voice.progress"),
+    role,
+  ]),
+);
+const mounts = new Map<Client, { host: HTMLElement; root: Root }>();
+
+afterEach(() => {
+  for (const { host, root } of mounts.values()) {
+    flushSync(() => root.unmount());
+    host.remove();
+  }
+  mounts.clear();
+});
+
+interface Shown {
+  role: CodexRealtimeRole;
+  text: string;
+  final: boolean;
+}
+
+/**
+ * What the operator reads: the client's lines rendered by the real panel.
+ *
+ * Read off the DOM rather than the snapshot, so a line the panel draws twice or
+ * not at all fails here. A speaker's label opens each run of that speaker's
+ * lines, and an unfinished line carries the caret.
+ */
+function shown(client: Client): Shown[] {
+  let mount = mounts.get(client);
+  if (!mount) {
+    const host = document.createElement("div");
+    document.body.append(host);
+    mount = { host, root: createRoot(host) };
+    mounts.set(client, mount);
+  }
+  const { phase, lines, error } = client.getSnapshot();
+  const { root, host } = mount;
+  flushSync(() => root.render(createElement(VoiceConversationPanel, { phase, lines, error, t })));
+  let role: CodexRealtimeRole | null = null;
+  return [...host.querySelectorAll("section [aria-live] > div")].map((row) => {
+    const label = row.querySelector("span.uppercase")?.textContent;
+    if (label) role = ROLE_BY_LABEL.get(label) ?? null;
+    const text = row.querySelector("span.text-label")!;
+    if (!role) throw new Error("the panel drew a line with no speaker");
+    return { role, text: text.textContent ?? "", final: !text.querySelector("[aria-hidden]") };
+  });
+}
+
+const spoken = (client: Client) => shown(client).map((line) => `${line.role}:${line.text}`);
+
 test("a call whose data channel says nothing still shows what the backend committed", async () => {
   /* The failure this closes. Nothing arrives on the data channel at all, and the
      panel used to stay empty for the whole call. */
@@ -200,7 +264,7 @@ test("a call whose data channel says nothing still shows what the backend commit
   });
 
   client.reconcileCanonicalTranscript(carried());
-  expect(client.getSnapshot().lines.map((line) => ({ role: line.role, text: line.text, final: line.final }))).toEqual([
+  expect(shown(client)).toEqual([
     { role: "user", text: "look at that card", final: true },
     { role: "assistant", text: "Reading it now.", final: true },
   ]);
@@ -219,7 +283,7 @@ test("the same sentence from both sources is one line, not two", async () => {
   peer.channel.onmessage?.({
     data: JSON.stringify({ type: "output_transcript.added", item: { text: "is gre" } }),
   });
-  expect(client.getSnapshot().lines).toHaveLength(1);
+  expect(shown(client)).toHaveLength(1);
 
   notified("thread/realtime/item/completed", {
     threadId: THREAD,
@@ -227,7 +291,7 @@ test("the same sentence from both sources is one line, not two", async () => {
   });
   client.reconcileCanonicalTranscript(carried());
 
-  expect(client.getSnapshot().lines.map((line) => ({ role: line.role, text: line.text, final: line.final }))).toEqual([
+  expect(shown(client)).toEqual([
     { role: "assistant", text: "The build is green.", final: true },
   ]);
   await client.stop();
@@ -250,7 +314,7 @@ test("a redelivered segment updates its own line rather than repeating it", asyn
   client.reconcileCanonicalTranscript(carried());
 
   expect(carried()).toHaveLength(1);
-  expect(client.getSnapshot().lines).toHaveLength(1);
+  expect(shown(client)).toHaveLength(1);
   await client.stop();
 });
 
@@ -261,7 +325,7 @@ test("barge-in keeps the two speakers on their own lines", async () => {
   notified("thread/realtime/transcript/done", { threadId: THREAD, role: "user", text: "no, stop" });
   client.reconcileCanonicalTranscript(carried());
 
-  expect(client.getSnapshot().lines.map((line) => `${line.role}:${line.text}`)).toEqual([
+  expect(spoken(client)).toEqual([
     "assistant:I am looking at",
     "user:no, stop",
   ]);
@@ -281,7 +345,7 @@ test("a segment the panel never saw is appended, and one it did is adopted", asy
   });
   client.reconcileCanonicalTranscript(carried());
 
-  expect(client.getSnapshot().lines.map((line) => `${line.role}:${line.text}`)).toEqual([
+  expect(spoken(client)).toEqual([
     "user:read that one",
     "assistant:Reading.",
   ]);
@@ -334,10 +398,6 @@ function replay(client: Client, records: readonly Recorded[]): void {
     else canonical(client, record.method!, record.params!);
   }
 }
-
-const shown = (client: Client) =>
-  client.getSnapshot().lines.map((line) => ({ role: line.role, text: line.text, final: line.final }));
-type Shown = ReturnType<typeof shown>[number];
 
 const DUPLEX_TURNS: Shown[] = [
   { role: "user", text: " Please repeat the read-only", final: true },
@@ -568,8 +628,6 @@ test("both speakers talking at once keep one line each", async () => {
  * shown twice.
  * ------------------------------------------------------------------------ */
 
-const spoken = (client: Client) => shown(client).map((line) => `${line.role}:${line.text}`);
-
 function completedSegment(client: Client, id: string, role: "user" | "assistant", text: string): void {
   canonical(client, "thread/realtime/item/started", {
     threadId: THREAD, item: { id, realtimeSessionId: "realtime-1", type: "transcriptSegment", role, text: "" },
@@ -722,7 +780,7 @@ for (const first of ["caption", "canonical"] as const) {
 test("a completion its mirrored done has not repaired yet never takes the caption's final words away", async () => {
   const client = await panel();
   const seen: string[] = [];
-  const unsubscribe = client.subscribe(() => seen.push(client.getSnapshot().lines.map((line) => line.text).join(" | ")));
+  const unsubscribe = client.subscribe(() => seen.push(shown(client).map((line) => line.text).join(" | ")));
   channel({ type: "output_transcript.added", item: { id: "chunk-hello", type: "output_transcript", text: " Hello" } });
   channel({ type: "output_transcript.added", item: { id: "chunk-world", type: "output_transcript", text: " world" } });
   channel({ type: "turn.done", turn: { id: "turn-hello", role: "assistant", transcript: " Hello big world" } });
@@ -751,5 +809,113 @@ test("a fragment or done delivered again after its turn ended changes nothing, a
   completedSegment(client, "segment-yes-again", "user", " yes");
   channel(fragment);
   expect(spoken(client)).toEqual(["user: yes", "user: yes"]);
+  await client.stop();
+});
+
+/* ------------------------------------------------------------------------ *
+ * A DONE DELIVERED AGAIN, A REPAIR OF THE OPENING WORDS, A WORD SAID TWICE.
+ *
+ * A turn id names the turn its `turn.done` closed, so the same done delivered
+ * again is that finished turn, never the one streaming now. A repair may rewrite
+ * how a turn began, and the caption whose done had no words is still that turn.
+ * A fragment with its own id is one delta, whatever words it repeats.
+ * ------------------------------------------------------------------------ */
+
+test("an earlier turn's done delivered again neither ends the turn streaming now nor adds a line", async () => {
+  const client = await panel();
+  const firstDone = { type: "turn.done", turn: { id: "turn-first", role: "assistant", transcript: " First answer." } };
+  channel({ type: "output_transcript.added", item: { id: "chunk-first", type: "output_transcript", text: " First answer." } });
+  channel(firstDone);
+  completedSegment(client, "segment-first", "assistant", " First answer.");
+
+  channel({ type: "output_transcript.added", item: { id: "chunk-second", type: "output_transcript", text: " Second" } });
+  channel(firstDone);
+  channel({ type: "output_transcript.added", item: { id: "chunk-second-more", type: "output_transcript", text: " answer." } });
+  expect(shown(client)).toEqual([
+    { role: "assistant", text: " First answer.", final: true },
+    { role: "assistant", text: " Second answer.", final: false },
+  ]);
+
+  channel({ type: "turn.done", turn: { id: "turn-second", role: "assistant", transcript: " Second answer." } });
+  completedSegment(client, "segment-second", "assistant", " Second answer.");
+  channel(firstDone);
+  expect(shown(client)).toEqual([
+    { role: "assistant", text: " First answer.", final: true },
+    { role: "assistant", text: " Second answer.", final: true },
+  ]);
+  await client.stop();
+});
+
+for (const order of ["caption", "canonical"] as const) {
+  test(`native's events with an answer's done delivered again mid-turn and after the call still show every turn once (${order} first)`, async () => {
+    const captions = sources("call-one", "data-channel");
+    const again = captions.find((record) => (record.event as { turn?: { id?: string } }).turn?.id === "bidi-a1")!;
+    /* Redelivered while " Interrupted" is still being said, and once more at the end. */
+    const streaming = captions.findIndex((record) => (record.event as { item?: { id?: string } }).item?.id === "chunk-017");
+    const redelivered = [...captions.slice(0, streaming + 1), again, ...captions.slice(streaming + 1), again];
+    const committed = sources("call-one", "app-server");
+    const client = await panel("call-one");
+    replay(client, order === "caption" ? [...redelivered, ...committed] : [...committed, ...redelivered]);
+    expect(shown(client)).toEqual(NATIVE_TURNS);
+    await client.stop();
+  });
+}
+
+for (const first of ["caption", "canonical"] as const) {
+  for (const delivery of ["event by event", "in one batch"] as const) {
+    test(`a repair that rewrote the opening words stays the captioned turn's one line (${first} first, ${delivery})`, async () => {
+      const client = await panel();
+      const caption = () => {
+        channel({ type: "output_transcript.added", item: { id: "chunk-their", type: "output_transcript", text: " Their answer" } });
+        channel({ type: "turn.done", turn: { id: "turn-their", role: "assistant", transcript: "" } });
+      };
+      const committed = () => {
+        const deliver = delivery === "event by event"
+          ? (method: string, params: Record<string, unknown>) => canonical(client, method, params)
+          : notified;
+        deliver("thread/realtime/item/started", {
+          threadId: THREAD, item: { id: "segment-their", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: "" },
+        });
+        deliver("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "segment-their", delta: " Their answer" });
+        deliver("thread/realtime/item/completed", {
+          threadId: THREAD, item: { id: "segment-their", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: " Their answer" },
+        });
+        deliver("thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: " The answer." });
+        client.reconcileCanonicalTranscript(carried());
+      };
+      if (first === "caption") { caption(); committed(); } else { committed(); caption(); }
+      expect(shown(client)).toEqual([{ role: "assistant", text: " The answer.", final: true }]);
+      await client.stop();
+    });
+  }
+}
+
+test("a repair that rewrote the opening words does not join a different turn missed by the other source", async () => {
+  /* The caption's done kept its words, and they are not the repair's. The
+     segment no caption is takes its place ahead of the caption turn. */
+  const client = await panel();
+  channel({ type: "output_transcript.added", item: { id: "chunk-their", type: "output_transcript", text: " Their answer" } });
+  channel({ type: "turn.done", turn: { id: "turn-their", role: "assistant", transcript: " Their answer" } });
+  for (const [method, params] of [
+    ["thread/realtime/item/completed", {
+      threadId: THREAD, item: { id: "segment-other", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: " Other answer" },
+    }],
+    ["thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: " The answer." }],
+  ] as const) notified(method, params);
+  client.reconcileCanonicalTranscript(carried());
+  expect(spoken(client)).toEqual(["assistant: The answer.", "assistant: Their answer"]);
+  await client.stop();
+});
+
+test("a word said twice in a row keeps both, one fragment each", async () => {
+  const client = await panel();
+  for (const [index, text] of [" very", " very", " good"].entries()) {
+    channel({ type: "output_transcript.added", item: { id: `chunk-word-${index}`, type: "output_transcript", text } });
+  }
+  expect(shown(client)).toEqual([{ role: "assistant", text: " very very good", final: false }]);
+  channel({ type: "output_transcript.added", item: { id: "chunk-word-1", type: "output_transcript", text: " very" } });
+  channel({ type: "turn.done", turn: { id: "turn-very", role: "assistant", transcript: "" } });
+  completedSegment(client, "segment-very", "assistant", " very very good");
+  expect(shown(client)).toEqual([{ role: "assistant", text: " very very good", final: true }]);
   await client.stop();
 });

--- a/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
+++ b/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
 import { Window } from "happy-dom";
 
 import { applyEvent, emptyStore, type RuntimeStore } from "@/components/runtime/runtimeModel";
@@ -93,8 +95,11 @@ let conversationId = "";
 let store: RuntimeStore;
 let reducer: CodexRealtimeTranscript;
 let hostSequence = 0;
+/** The realtime session the next call's answer names, as the host would. */
+let callSession = "realtime-1";
 
 beforeEach(() => {
+  callSession = "realtime-1";
   conversationSequence += 1;
   conversationId = `conversation_canonical_${conversationSequence}`;
   hostSequence = 0;
@@ -126,7 +131,7 @@ beforeEach(() => {
   globalThis.fetch = (async () => ({
     ok: true,
     status: 200,
-    json: async () => ({ ok: true, sdp: "v=0\r\nanswer", realtimeSessionId: "realtime-1" }),
+    json: async () => ({ ok: true, sdp: "v=0\r\nanswer", realtimeSessionId: callSession }),
   })) as unknown as typeof fetch;
 });
 
@@ -169,11 +174,18 @@ function applied(envelope: Record<string, unknown>): RuntimeStore {
 /** What the browser's session projection now carries for this conversation. */
 const carried = () => store.sessions[conversationId]?.voiceTranscript ?? [];
 
-async function panel() {
+async function panel(session = "realtime-1") {
   const client = codexRealtimeClient(conversationId);
+  await call(client, session);
+  return client;
+}
+
+/** Start a call on this client, with the host beginning the same session. */
+async function call(client: ReturnType<typeof codexRealtimeClient>, session: string): Promise<void> {
+  callSession = session;
+  reducer.begin(session);
   await client.start();
   StubPeerConnection.latest!.channel.onopen?.();
-  return client;
 }
 
 test("a call whose data channel says nothing still shows what the backend committed", async () => {
@@ -272,6 +284,276 @@ test("a segment the panel never saw is appended, and one it did is adopted", asy
   expect(client.getSnapshot().lines.map((line) => `${line.role}:${line.text}`)).toEqual([
     "user:read that one",
     "assistant:Reading.",
+  ]);
+  await client.stop();
+});
+
+/* ------------------------------------------------------------------------ *
+ * ONE LINE PER SPOKEN TURN (#1658).
+ *
+ * A live call rendered the same sentence three times — the data-channel caption,
+ * a line for native's item, and a line for native's flat mirror of that item —
+ * and the two speakers' overlapping words left the caption in fragments with the
+ * whole sentence repeated underneath. What follows replays captured calls
+ * through every production link above, and reads what the panel shows.
+ * ------------------------------------------------------------------------ */
+
+interface Recorded {
+  source: "data-channel" | "app-server";
+  call?: string;
+  method?: string;
+  params?: Record<string, unknown>;
+  event?: Record<string, unknown>;
+}
+
+function recorded(file: string): Recorded[] {
+  return fs.readFileSync(file, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Recorded);
+}
+
+/** Recorded in a live call: both speakers talking over each other, word by word. */
+const DUPLEX_CALL = recorded(path.join(import.meta.dir, "fixtures/voice-duplex-call.jsonl"));
+/** Native 0.154.0's own notifications for known provider events. */
+const NATIVE_WIRE = recorded(path.join(import.meta.dir, "../runtime/fixtures/codex-realtime-transcript-v0.154.0.jsonl"));
+
+type Client = ReturnType<typeof codexRealtimeClient>;
+
+function channel(event: Record<string, unknown>): void {
+  StubPeerConnection.latest!.channel.onmessage?.({ data: JSON.stringify(event) });
+}
+
+/** One notification reaching the store, and the composer's effect handing the
+    store's tail to the client, as `useCodexRealtime` does on every change. */
+function canonical(client: Client, method: string, params: Record<string, unknown>): void {
+  notified(method, params);
+  client.reconcileCanonicalTranscript(carried());
+}
+
+function replay(client: Client, records: readonly Recorded[]): void {
+  for (const record of records) {
+    if (record.source === "data-channel") channel(record.event!);
+    else canonical(client, record.method!, record.params!);
+  }
+}
+
+const shown = (client: Client) =>
+  client.getSnapshot().lines.map((line) => ({ role: line.role, text: line.text, final: line.final }));
+type Shown = ReturnType<typeof shown>[number];
+
+const DUPLEX_TURNS: Shown[] = [
+  { role: "user", text: " Please repeat the read-only", final: true },
+  { role: "assistant", text: " I'm the dedicated Voice regression", final: true },
+  { role: "user", text: " status check from our setup using the tool again now Tell me your role in this", final: true },
+  { role: "assistant", text: " QA orchestrator, Checking it now.", final: true },
+  { role: "user", text: " conversation Do not change anything or launch any agents", final: true },
+  { role: "assistant", text: " One sec. Still looking.", final: true },
+  /* Still being spoken when the recording stopped. */
+  { role: "assistant", text: " Let me check that again.", final: false },
+];
+
+test("the recorded duplex call shows each spoken turn once", async () => {
+  const client = await panel("call-live");
+  replay(client, DUPLEX_CALL);
+  expect(shown(client)).toEqual(DUPLEX_TURNS);
+  await client.stop();
+});
+
+test("the recorded call reads the same when the committed transcript lands in one batch", async () => {
+  /* The store coalesces, and the effect can run once for many notifications. */
+  const client = await panel("call-live");
+  for (const record of DUPLEX_CALL) if (record.source === "data-channel") channel(record.event!);
+  for (const record of DUPLEX_CALL) if (record.source === "app-server") notified(record.method!, record.params!);
+  client.reconcileCanonicalTranscript(carried());
+  expect(shown(client)).toEqual(DUPLEX_TURNS);
+  await client.stop();
+});
+
+test("the recorded call reads the same when the committed transcript arrives first", async () => {
+  const client = await panel("call-live");
+  for (const record of DUPLEX_CALL) if (record.source === "app-server") canonical(client, record.method!, record.params!);
+  for (const record of DUPLEX_CALL) if (record.source === "data-channel") channel(record.event!);
+  expect(shown(client)).toEqual(DUPLEX_TURNS);
+  await client.stop();
+});
+
+const NATIVE_TURNS: Shown[] = [
+  { role: "user", text: " Please repeat the read-only", final: true },
+  { role: "assistant", text: " I'm the dedicated Voice regression", final: true },
+  { role: "user", text: " status check from our", final: true },
+  { role: "assistant", text: " QA orchestrator,", final: true },
+  { role: "user", text: " yes", final: true },
+  { role: "assistant", text: " ok", final: true },
+  { role: "user", text: " yes", final: true },
+  { role: "assistant", text: " Unstreamed answer.", final: true },
+  { role: "assistant", text: " Hello big world", final: true },
+  { role: "assistant", text: " Resumed", final: true },
+  { role: "user", text: " wait", final: true },
+];
+
+const sources = (call: string, source: Recorded["source"]) =>
+  NATIVE_WIRE.filter((record) => record.call === call && record.source === source);
+
+for (const order of ["caption", "canonical"] as const) {
+  test(`native's own events show each turn once when the ${order} arrives first`, async () => {
+    /* Both sources carry the SAME provider events here, so this is the claim
+       the join rests on: the two describe one turn order. The same words said
+       twice are two turns and stay two lines. */
+    const client = await panel("call-one");
+    const captions = sources("call-one", "data-channel");
+    const committed = sources("call-one", "app-server");
+    replay(client, order === "caption" ? [...captions, ...committed] : [...committed, ...captions]);
+    expect(shown(client)).toEqual(NATIVE_TURNS);
+    await client.stop();
+  });
+}
+
+test("a new call starts its own turn order and leaves the last call's lines alone", async () => {
+  const client = await panel("call-one");
+  replay(client, [...sources("call-one", "data-channel"), ...sources("call-one", "app-server")]);
+  await client.stop();
+
+  /* The store still carries the first call's segments into the second, and the
+     second's committed transcript arrives before its captions. */
+  await call(client, "call-two");
+  replay(client, [...sources("call-two", "app-server"), ...sources("call-two", "data-channel")]);
+  /* A segment the first call's backend commits late belongs to the first call. */
+  const late = new CodexRealtimeTranscript();
+  late.begin("call-one");
+  const stray = late.observe("thread/realtime/item/completed", {
+    threadId: THREAD,
+    item: { id: "segment-late", realtimeSessionId: "call-one", type: "transcriptSegment", role: "user", text: " late words" },
+  })!;
+  store = applied({
+    seq: ++hostSequence,
+    ...projectEngineHostEvent(conversationId, `codex:${THREAD}`, {
+      kind: "voice-transcript",
+      realtimeSessionId: stray.realtimeSessionId,
+      segmentId: stray.id,
+      role: stray.role,
+      text: stray.text,
+      final: stray.final,
+      seq: hostSequence,
+    })!,
+    recordedAt: new Date().toISOString(),
+  });
+  client.reconcileCanonicalTranscript(carried());
+
+  expect(shown(client)).toEqual([
+    ...NATIVE_TURNS,
+    { role: "user", text: " second call", final: true },
+    { role: "assistant", text: " reply", final: true },
+  ]);
+  await client.stop();
+});
+
+test("an empty canonical segment takes no line ahead of the caption with its words", async () => {
+  const client = await panel();
+  channel({ type: "input_transcript.added", item: { id: "chunk-a", type: "input_transcript", text: " Please" } });
+  /* What an empty `item/started` looked like to the client before the host
+     stopped publishing it. */
+  client.reconcileCanonicalTranscript([
+    { segmentId: "segment-empty", realtimeSessionId: "realtime-1", role: "user", text: "", final: false },
+  ]);
+  expect(shown(client)).toEqual([{ role: "user", text: " Please", final: false }]);
+
+  client.reconcileCanonicalTranscript([
+    { segmentId: "segment-empty", realtimeSessionId: "realtime-1", role: "user", text: " Please repeat", final: false },
+  ]);
+  channel({ type: "input_transcript.added", item: { id: "chunk-b", type: "input_transcript", text: " repeat that" } });
+  expect(shown(client)).toEqual([{ role: "user", text: " Please repeat that", final: false }]);
+  await client.stop();
+});
+
+for (const first of ["caption", "canonical"] as const) {
+  test(`whichever source finishes the turn first, the other finishes the same line (${first} first)`, async () => {
+    const client = await panel();
+    channel({ type: "output_transcript.added", item: { id: "chunk-1", type: "output_transcript", text: "The build" } });
+    canonical(client, "thread/realtime/item/started", {
+      threadId: THREAD, item: { id: "segment-done", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: "" },
+    });
+    canonical(client, "thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "segment-done", delta: "The build" });
+    const captionDone = () => channel({ type: "turn.done", turn: { id: "turn-1", role: "assistant", transcript: "The build is green." } });
+    const canonicalDone = () => {
+      canonical(client, "thread/realtime/item/completed", {
+        threadId: THREAD,
+        item: { id: "segment-done", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text: "The build" },
+      });
+      canonical(client, "thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: "The build is green." });
+    };
+    if (first === "caption") {
+      captionDone();
+      expect(shown(client)).toEqual([{ role: "assistant", text: "The build is green.", final: true }]);
+      canonicalDone();
+    } else {
+      canonicalDone();
+      expect(shown(client)).toEqual([{ role: "assistant", text: "The build is green.", final: true }]);
+      captionDone();
+    }
+    expect(shown(client)).toEqual([{ role: "assistant", text: "The build is green.", final: true }]);
+    await client.stop();
+  });
+}
+
+test("a replayed fragment and a replayed canonical tail change nothing", async () => {
+  const client = await panel();
+  channel({ type: "input_transcript.added", item: { id: "chunk-w", type: "input_transcript", text: " can" } });
+  const fragment = { type: "input_transcript.added", item: { id: "chunk-x", type: "input_transcript", text: " you check" } };
+  channel(fragment);
+  channel(fragment);
+  expect(shown(client)).toEqual([{ role: "user", text: " can you check", final: false }]);
+
+  const completed = {
+    threadId: THREAD,
+    item: { id: "segment-x", realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "user", text: " can you check" },
+  };
+  canonical(client, "thread/realtime/item/completed", completed);
+  canonical(client, "thread/realtime/item/completed", completed);
+  client.reconcileCanonicalTranscript(carried());
+  client.reconcileCanonicalTranscript(carried());
+  expect(shown(client)).toEqual([{ role: "user", text: " can you check", final: true }]);
+  await client.stop();
+});
+
+test("the committed transcript two turns behind still lands on the right lines", async () => {
+  /* Two identical answers, then a different one, all captioned before any of
+     them is committed. Words would pair the first commit with the wrong "yes". */
+  const client = await panel();
+  for (const [index, text] of [" yes", " yes", " no"].entries()) {
+    channel({ type: "output_transcript.added", item: { id: `chunk-${index}`, type: "output_transcript", text } });
+    channel({ type: "turn.done", turn: { id: `turn-${index}`, role: "assistant", transcript: text } });
+  }
+  expect(shown(client).map((line) => line.text)).toEqual([" yes", " yes", " no"]);
+  for (const [index, text] of [" yes", " yes", " no"].entries()) {
+    canonical(client, "thread/realtime/item/completed", {
+      threadId: THREAD,
+      item: { id: `segment-${index}`, realtimeSessionId: "realtime-1", type: "transcriptSegment", role: "assistant", text },
+    });
+  }
+  expect(shown(client)).toEqual([
+    { role: "assistant", text: " yes", final: true },
+    { role: "assistant", text: " yes", final: true },
+    { role: "assistant", text: " no", final: true },
+  ]);
+  await client.stop();
+});
+
+test("both speakers talking at once keep one line each", async () => {
+  const client = await panel();
+  const words: [string, string][] = [
+    ["input", " can"], ["output", " Sure,"], ["input", " you"], ["output", " one"], ["input", " check"], ["output", " moment."],
+  ];
+  for (const [index, [kind, text]] of words.entries()) {
+    channel({ type: `${kind}_transcript.added`, item: { id: `chunk-${index}`, type: `${kind}_transcript`, text } });
+  }
+  expect(shown(client)).toEqual([
+    { role: "user", text: " can you check", final: false },
+    { role: "assistant", text: " Sure, one moment.", final: false },
+  ]);
+  channel({ type: "turn.done", turn: { id: "turn-u", role: "user", transcript: " can you check" } });
+  channel({ type: "output_transcript.added", item: { id: "chunk-late", type: "output_transcript", text: " Looking" } });
+  channel({ type: "turn.done", turn: { id: "turn-a", role: "assistant", transcript: " Sure, one moment. Looking" } });
+  expect(shown(client)).toEqual([
+    { role: "user", text: " can you check", final: true },
+    { role: "assistant", text: " Sure, one moment. Looking", final: true },
   ]);
   await client.stop();
 });

--- a/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
+++ b/src/lib/realtime/voiceCanonicalTranscript.dom.test.ts
@@ -846,6 +846,33 @@ test("an earlier turn's done delivered again neither ends the turn streaming now
   await client.stop();
 });
 
+for (const again of [false, true]) {
+  test(`a done whose turn lost every caption fragment, ${again ? "delivered again" : "delivered once"}, neither ends the next turn nor adds a line`, async () => {
+    /* The done has no words and nothing streamed before it, so it draws nothing;
+       its id still names a turn that has ended. */
+    const client = await panel();
+    const emptyDone = { type: "turn.done", turn: { id: "turn-uncaptioned", role: "assistant", transcript: "" } };
+    completedSegment(client, "segment-uncaptioned", "assistant", " First answer.");
+    channel(emptyDone);
+    channel({ type: "output_transcript.added", item: { id: "chunk-second", type: "output_transcript", text: " Second" } });
+    if (again) channel(emptyDone);
+    channel({ type: "output_transcript.added", item: { id: "chunk-second-more", type: "output_transcript", text: " answer." } });
+    expect(shown(client)).toEqual([
+      { role: "assistant", text: " First answer.", final: true },
+      { role: "assistant", text: " Second answer.", final: false },
+    ]);
+
+    channel({ type: "turn.done", turn: { id: "turn-second", role: "assistant", transcript: " Second answer." } });
+    completedSegment(client, "segment-second", "assistant", " Second answer.");
+    if (again) channel(emptyDone);
+    expect(shown(client)).toEqual([
+      { role: "assistant", text: " First answer.", final: true },
+      { role: "assistant", text: " Second answer.", final: true },
+    ]);
+    await client.stop();
+  });
+}
+
 for (const order of ["caption", "canonical"] as const) {
   test(`native's events with an answer's done delivered again mid-turn and after the call still show every turn once (${order} first)`, async () => {
     const captions = sources("call-one", "data-channel");

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -646,7 +646,8 @@ describe("CodexAppServerHost", () => {
       { kind: "voice-transcript", realtimeSessionId: "realtime-1", segmentId: published[0]!.segmentId, role: "user", text: "look at ", final: false },
       { kind: "voice-transcript", realtimeSessionId: "realtime-1", segmentId: published[0]!.segmentId, role: "user", text: "look at that card", final: false },
       { kind: "voice-transcript", realtimeSessionId: "realtime-1", segmentId: published[0]!.segmentId, role: "user", text: "look at that card", final: true },
-      { kind: "voice-transcript", realtimeSessionId: "realtime-1", segmentId: "seg-9", role: "assistant", text: "", final: false },
+      /* The empty `item/started` publishes nothing (#1658): a segment with no
+         words must not take a line ahead of the words it is for. */
       { kind: "voice-transcript", realtimeSessionId: "realtime-1", segmentId: "seg-9", role: "assistant", text: "Reading it now.", final: true },
     ]);
     /* One id for the whole spoken segment, so the browser updates one line. */

--- a/src/lib/runtime/codexRealtimeTranscript.test.ts
+++ b/src/lib/runtime/codexRealtimeTranscript.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
 
-import { CodexRealtimeTranscript } from "./codexRealtimeTranscript";
+import { CodexRealtimeTranscript, type CanonicalVoiceSegment } from "./codexRealtimeTranscript";
 
 /**
  * The canonical transcript reducer (#1629), over the app-server's published
@@ -67,12 +69,14 @@ test("a per-item stream keeps native's own item id", () => {
   /* The canonical id is what makes a redelivered or replayed segment converge on
      one line instead of stacking copies. */
   const reducer = transcript();
-  const started = reducer.observe("thread/realtime/item/started", {
+  /* Native opens every segment empty. Nothing is published until it has words:
+     an empty segment used to take a line before the caption with those words
+     could be joined to it (#1658). */
+  expect(reducer.observe("thread/realtime/item/started", {
     threadId: THREAD, item: { id: "item-7", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "assistant", text: "" },
-  });
-  expect(started).toMatchObject({ id: "item-7", role: "assistant", final: false });
+  })).toBeNull();
   expect(reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "item-7", delta: "half " }))
-    .toMatchObject({ id: "item-7", text: "half " });
+    .toMatchObject({ id: "item-7", role: "assistant", text: "half ", final: false });
   expect(reducer.observe("thread/realtime/item/completed", {
     threadId: THREAD, item: { id: "item-7", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "assistant", text: "half a sentence" },
   })).toEqual({ id: "item-7", realtimeSessionId: "rt-1", role: "assistant", text: "half a sentence", final: true });
@@ -124,4 +128,153 @@ test("a malformed or unrelated notification produces nothing", () => {
   expect(reducer.observe("thread/realtime/transcript/delta", { threadId: THREAD, role: "user" })).toBeNull();
   expect(reducer.observe("thread/realtime/started", { threadId: THREAD })).toBeNull();
   expect(reducer.observe("thread/realtime/transcript/delta", "not an object")).toBeNull();
+});
+
+/**
+ * NATIVE'S OWN WIRE (#1658). Captured from the installed app-server 0.154.0
+ * driven by a credential-free loopback realtime fixture: the `data-channel`
+ * records are the provider events the fixture sent, the `app-server` records
+ * the notifications native published for them. Identifiers are invented; the
+ * order and the texts are native's.
+ *
+ * What it established: every segment is published on BOTH families, each
+ * per-item event followed at once by its flat mirror, and each speaker's
+ * segment stays open until that speaker's `turn.done` — both speakers at once
+ * in a duplex exchange.
+ */
+interface FixtureRecord {
+  source: "data-channel" | "app-server";
+  call: string;
+  method?: string;
+  params?: Record<string, unknown>;
+  event?: Record<string, unknown>;
+}
+
+function nativeFixture(): FixtureRecord[] {
+  return fs.readFileSync(path.join(import.meta.dir, "fixtures/codex-realtime-transcript-v0.154.0.jsonl"), "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as FixtureRecord);
+}
+
+function replayNative(call: string): CanonicalVoiceSegment[] {
+  const reducer = new CodexRealtimeTranscript();
+  reducer.begin(call);
+  const published: CanonicalVoiceSegment[] = [];
+  for (const record of nativeFixture()) {
+    if (record.source !== "app-server" || record.call !== call) continue;
+    const segment = reducer.observe(record.method!, record.params);
+    if (segment) published.push(segment);
+  }
+  return published;
+}
+
+/** The last state of each segment, in the order each was first published. */
+function settled(published: readonly CanonicalVoiceSegment[]): CanonicalVoiceSegment[] {
+  const last = new Map<string, CanonicalVoiceSegment>();
+  for (const segment of published) last.set(segment.id, segment);
+  return [...last.values()];
+}
+
+test("native's two mirrored families reduce to one segment per spoken turn", () => {
+  const published = replayNative("call-one");
+  const itemIds = new Set(nativeFixture()
+    .filter((record) => record.call === "call-one" && record.method === "thread/realtime/item/started")
+    .map((record) => (record.params!.item as { id: string }).id));
+  /* Every segment is native's own item: the flat mirror minted none of its own,
+     which is what used to put each sentence on the panel a second time. */
+  expect(published.every((segment) => itemIds.has(segment.id))).toBe(true);
+  expect(published.every((segment) => segment.text.length > 0)).toBe(true);
+  expect(settled(published).map(({ role, text, final }) => ({ role, text, final }))).toEqual([
+    { role: "user", text: " Please repeat the read-only", final: true },
+    { role: "assistant", text: " I'm the dedicated Voice regression", final: true },
+    { role: "user", text: " status check from our", final: true },
+    { role: "assistant", text: " QA orchestrator,", final: true },
+    /* The same words twice are two turns, and stay two segments. */
+    { role: "user", text: " yes", final: true },
+    { role: "assistant", text: " ok", final: true },
+    { role: "user", text: " yes", final: true },
+    { role: "assistant", text: " Unstreamed answer.", final: true },
+    /* The provider streamed " Hello", " world" and finished " Hello big world".
+       Native's completion carries only what streamed; the mirrored done repairs it. */
+    { role: "assistant", text: " Hello big world", final: true },
+    { role: "assistant", text: " Resumed", final: true },
+    { role: "user", text: " wait", final: true },
+  ]);
+});
+
+test("a new call's native segments are its own", () => {
+  const published = settled(replayNative("call-two"));
+  expect(published.map(({ realtimeSessionId, role, text }) => ({ realtimeSessionId, role, text }))).toEqual([
+    { realtimeSessionId: "call-two", role: "user", text: " second call" },
+    { realtimeSessionId: "call-two", role: "assistant", text: " reply" },
+  ]);
+});
+
+test("the mirrored done repairs a completion, and an empty one keeps the words", () => {
+  const reducer = transcript();
+  const item = (id: string, text: string) => ({ id, realtimeSessionId: "rt-1", type: "transcriptSegment", role: "assistant", text });
+  reducer.observe("thread/realtime/item/started", { threadId: THREAD, item: item("seg-a", "") });
+  reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-a", delta: "Hello world" });
+  expect(reducer.observe("thread/realtime/item/completed", { threadId: THREAD, item: item("seg-a", "Hello world") }))
+    .toMatchObject({ id: "seg-a", text: "Hello world", final: true });
+  expect(reducer.observe("thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: "Hello big world" }))
+    .toEqual({ id: "seg-a", realtimeSessionId: "rt-1", role: "assistant", text: "Hello big world", final: true });
+
+  reducer.observe("thread/realtime/item/started", { threadId: THREAD, item: item("seg-b", "") });
+  reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-b", delta: "alpha" });
+  reducer.observe("thread/realtime/item/completed", { threadId: THREAD, item: item("seg-b", "alpha") });
+  /* Nothing to repair and nothing new to say: the mirror publishes nothing. */
+  expect(reducer.observe("thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: "" })).toBeNull();
+  expect(reducer.observe("thread/realtime/transcript/done", { threadId: THREAD, role: "assistant", text: "alpha" })).toBeNull();
+});
+
+test("a flat mirror that arrives first is adopted by the item it mirrors", () => {
+  /* The other source order. The item takes over the id already published, so
+     the utterance keeps one segment, and its line never shrinks while the item
+     catches up with what the mirror already said. */
+  const reducer = transcript();
+  const first = reducer.observe("thread/realtime/transcript/delta", { threadId: THREAD, role: "user", delta: "look at" });
+  expect(first).toMatchObject({ role: "user", text: "look at", final: false });
+  const item = (text: string) => ({ id: "seg-c", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "user", text });
+  const started = reducer.observe("thread/realtime/item/started", { threadId: THREAD, item: item("") });
+  expect(started).toMatchObject({ id: first!.id, text: "look at" });
+  expect(reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-c", delta: "look at" }))
+    .toMatchObject({ id: first!.id, text: "look at" });
+  expect(reducer.observe("thread/realtime/transcript/delta", { threadId: THREAD, role: "user", delta: " that" })).toBeNull();
+  expect(reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-c", delta: " that" }))
+    .toMatchObject({ id: first!.id, text: "look at that" });
+  expect(reducer.observe("thread/realtime/item/completed", { threadId: THREAD, item: item("look at that") }))
+    .toMatchObject({ id: first!.id, text: "look at that", final: true });
+  expect(reducer.observe("thread/realtime/transcript/done", { threadId: THREAD, role: "user", text: "look at that" })).toBeNull();
+});
+
+test("a replayed completion republishes the same segment, never a second one", () => {
+  const reducer = transcript();
+  const item = { id: "seg-d", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "assistant", text: "Once." };
+  const first = reducer.observe("thread/realtime/item/completed", { threadId: THREAD, item });
+  expect(reducer.observe("thread/realtime/item/completed", { threadId: THREAD, item })).toEqual(first);
+  expect(reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-d", delta: " again" })).toBeNull();
+});
+
+test("an item that streams before it is named waits for its speaker", () => {
+  /* Guessing a speaker would draw the words on the wrong side of the panel. */
+  const reducer = transcript();
+  expect(reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-e", delta: "early " })).toBeNull();
+  expect(reducer.observe("thread/realtime/item/started", {
+    threadId: THREAD, item: { id: "seg-e", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "user", text: "" },
+  })).toMatchObject({ id: "seg-e", role: "user", text: "early ", final: false });
+});
+
+test("a completion after the call ended keeps native's id", () => {
+  /* Native publishes the last open segment's completion after the stop reply. */
+  const reducer = transcript();
+  reducer.observe("thread/realtime/item/started", {
+    threadId: THREAD, item: { id: "seg-f", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "assistant", text: "" },
+  });
+  reducer.observe("thread/realtime/item/transcript/delta", { threadId: THREAD, itemId: "seg-f", delta: "last words" });
+  reducer.end();
+  expect(reducer.observe("thread/realtime/item/completed", {
+    threadId: THREAD, item: { id: "seg-f", realtimeSessionId: "rt-1", type: "transcriptSegment", role: "assistant", text: "last words" },
+  })).toEqual({ id: "seg-f", realtimeSessionId: "rt-1", role: "assistant", text: "last words", final: true });
 });

--- a/src/lib/runtime/codexRealtimeTranscript.ts
+++ b/src/lib/runtime/codexRealtimeTranscript.ts
@@ -23,6 +23,23 @@
  * `transcript/done` carries `role` and the complete `text`, the per-item pair
  * carries `itemId`, and `item/completed` carries a `transcriptSegment` item with
  * `role`, `text` and the canonical item `id`.
+ *
+ * ONE SEGMENT PER UTTERANCE, WHICHEVER FAMILY DESCRIBES IT (#1658). Native
+ * 0.154 publishes every segment on BOTH families: `item/started` names the
+ * segment, and each `item/transcript/delta` and `item/completed` is followed at
+ * once by its flat `transcript/delta` / `transcript/done` mirror. Reducing the
+ * two independently put every sentence on the panel twice. The per-item family
+ * is the one with an identity, so it owns the segment; the flat family is read
+ * for what only it carries, and is the whole transcript only on a server that
+ * never publishes items:
+ *
+ * - `item/completed` carries what the item deltas accumulated, and the flat
+ *   `transcript/done` after it carries the provider's own final text. A delta
+ *   the provider never streamed is repaired only by the second, so it is applied
+ *   to the segment it mirrors — the role's current one.
+ * - native opens a segment with an empty `item/started`. Nothing is published
+ *   until the segment has words, so an empty line never takes a place on the
+ *   panel ahead of the words it is for.
  */
 
 type JsonObject = Record<string, unknown>;
@@ -46,10 +63,10 @@ export interface CanonicalVoiceSegment {
     data-channel line can never disagree merely about where they were cut. */
 const MAX_SEGMENT_CHARS = 12_000;
 
-/** Open segments one call may accumulate at once. Native interleaves at most a
-    handful (one per role, plus the items it is committing), so this is a guard
+/** Segments one call remembers by item id. Native keeps at most one open per
+    role, plus the one whose flat mirror has not arrived yet, so this is a guard
     against a malformed stream rather than a working limit. */
-const MAX_OPEN_SEGMENTS = 32;
+const MAX_TRACKED_SEGMENTS = 32;
 
 function object(value: unknown): JsonObject | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
@@ -64,26 +81,59 @@ function role(value: unknown): CanonicalVoiceRole | null {
   return value === "user" || value === "assistant" ? value : null;
 }
 
-interface OpenSegment {
+function clip(text: string): string {
+  return text.slice(0, MAX_SEGMENT_CHARS);
+}
+
+interface Segment {
   id: string;
   role: CanonicalVoiceRole;
+  /** What this segment's own family accumulated: item deltas once native named
+      an item, flat deltas on a server that never does. */
   text: string;
+  /** Flat text published under this id before native named the item, when the
+      flat mirror happened to arrive first. Kept as a floor so a newly-named item
+      that has not caught up yet never shortens a line already on screen. */
+  floor: string;
+  /** The provider's final text, from the flat `transcript/done`. */
+  doneText: string;
+  final: boolean;
+  /** Bound to a native item. Its flat mirror only repairs it from then on. */
+  item: boolean;
+  /** Completed, with the flat `transcript/done` mirroring that completion still
+      to come. */
+  awaitingDone: boolean;
 }
 
 export class CodexRealtimeTranscript {
-  private readonly open = new Map<string, OpenSegment>();
+  /** Segments by native item id. */
+  private readonly items = new Map<string, Segment>();
+  /** Item deltas that arrived before any notification named their role. */
+  private readonly unattributed = new Map<string, string>();
+  /** Each speaker's current segment — the one its flat events mirror. */
+  private readonly current = new Map<CanonicalVoiceRole, Segment>();
+  /** This call has published a per-item transcript, so its flat stream only
+      mirrors that one. */
+  private itemFamily = false;
   private sequence = 0;
   private realtimeSessionId = "";
 
   /** A new call is a new transcript: nothing from the last one may be extended,
       and the ids it minted must not be reused. */
   begin(realtimeSessionId: string): void {
-    this.open.clear();
+    this.reset();
     this.realtimeSessionId = realtimeSessionId;
   }
 
   end(): void {
-    this.open.clear();
+    this.reset();
+  }
+
+  private reset(): void {
+    this.items.clear();
+    this.unattributed.clear();
+    this.current.clear();
+    this.itemFamily = false;
   }
 
   /**
@@ -91,7 +141,9 @@ export class CodexRealtimeTranscript {
    *
    * Null for anything this does not describe, including a notification for
    * another thread — the caller has already filtered by thread, and this keeps
-   * the reducer usable on its own.
+   * the reducer usable on its own — and for a change nobody could see: a
+   * segment with no words yet, or a flat event mirroring what its item already
+   * said.
    */
   observe(method: string, params: unknown): CanonicalVoiceSegment | null {
     const body = object(params);
@@ -99,25 +151,32 @@ export class CodexRealtimeTranscript {
     if (method === "thread/realtime/transcript/delta") {
       const speaker = role(body.role);
       const delta = typeof body.delta === "string" ? body.delta : "";
-      if (!speaker || !delta) return null;
-      return this.append(`role:${speaker}`, speaker, delta);
+      if (!speaker || !delta || this.itemFamily) return null;
+      return this.flatDelta(speaker, delta);
     }
     if (method === "thread/realtime/transcript/done") {
       const speaker = role(body.role);
       const text = typeof body.text === "string" ? body.text : "";
       if (!speaker) return null;
-      return this.finish(`role:${speaker}`, speaker, text);
+      return this.itemFamily ? this.repair(speaker, text) : this.flatDone(speaker, text);
     }
     if (method === "thread/realtime/item/transcript/delta") {
       const itemId = string(body, "itemId");
       const delta = typeof body.delta === "string" ? body.delta : "";
       if (!itemId || !delta) return null;
-      /* The per-item stream can begin before its `item/started` names a role.
-         Assistant is the only role native streams this way — the operator's own
-         speech arrives on the flat channel — and a segment that is later
-         completed carries its canonical role with it. */
-      const speaker = this.open.get(`item:${itemId}`)?.role ?? "assistant";
-      return this.append(`item:${itemId}`, speaker, delta, itemId);
+      const segment = this.items.get(itemId);
+      if (!segment) {
+        /* Native names the item before it streams into it. A delta for an item
+           nobody has named yet waits for the started or completed notification
+           that carries its role; a guessed speaker would draw the words on the
+           wrong side of the panel. */
+        if (this.unattributed.size >= MAX_TRACKED_SEGMENTS) this.unattributed.clear();
+        this.unattributed.set(itemId, clip((this.unattributed.get(itemId) ?? "") + delta));
+        return null;
+      }
+      if (segment.final) return null;
+      segment.text = clip(segment.text + delta);
+      return this.publish(segment);
     }
     if (method === "thread/realtime/item/started" || method === "thread/realtime/item/completed") {
       const item = object(body.item);
@@ -126,56 +185,121 @@ export class CodexRealtimeTranscript {
       const speaker = role(item?.role);
       if (!itemId || !speaker) return null;
       const text = typeof item?.text === "string" ? item.text : "";
-      return method === "thread/realtime/item/completed"
-        ? this.finish(`item:${itemId}`, speaker, text, itemId)
-        : this.open.has(`item:${itemId}`)
-          ? null
-          : this.start(`item:${itemId}`, speaker, text, itemId);
+      const known = this.items.get(itemId);
+      if (method === "thread/realtime/item/started") {
+        /* Native repeats `item/started` for a segment it has already opened. */
+        return known ? null : this.publish(this.bind(itemId, speaker, text));
+      }
+      const segment = known ?? this.bind(itemId, speaker, "");
+      /* The completion carries the whole segment as native accumulated it. An
+         empty one keeps what was streamed, because losing the words would be the
+         worse reading of a sparse event. */
+      segment.text = clip(text || segment.text);
+      if (!segment.final) segment.awaitingDone = true;
+      segment.final = true;
+      this.current.set(speaker, segment);
+      return this.publish(segment);
     }
     return null;
   }
 
-  private start(key: string, speaker: CanonicalVoiceRole, text: string, canonicalId?: string): CanonicalVoiceSegment {
-    if (this.open.size >= MAX_OPEN_SEGMENTS) {
-      const oldest = this.open.keys().next().value as string | undefined;
-      if (oldest !== undefined) this.open.delete(oldest);
+  /**
+   * Bind a native item to a segment.
+   *
+   * The speaker's current segment is adopted when only the flat family has
+   * described it so far: that is the same utterance, reached through its mirror
+   * first, and a second segment for it is exactly the duplicate this exists to
+   * prevent. It keeps the id already published, so its line stays where it is.
+   */
+  private bind(itemId: string, speaker: CanonicalVoiceRole, text: string): Segment {
+    this.itemFamily = true;
+    const flat = this.current.get(speaker);
+    const pending = this.unattributed.get(itemId) ?? "";
+    this.unattributed.delete(itemId);
+    const segment: Segment = flat && !flat.item && !flat.final
+      ? { ...flat, text: "", floor: flat.text, item: true }
+      : {
+        id: itemId, role: speaker, text: "", floor: "", doneText: "", final: false, item: true, awaitingDone: false,
+      };
+    segment.text = clip(text + pending);
+    if (this.items.size >= MAX_TRACKED_SEGMENTS) {
+      const oldest = this.items.keys().next().value as string | undefined;
+      if (oldest !== undefined) this.items.delete(oldest);
     }
-    this.sequence += 1;
-    const segment: OpenSegment = {
-      id: canonicalId ?? `${this.realtimeSessionId}:${speaker}:${this.sequence}`,
-      role: speaker,
-      text: text.slice(0, MAX_SEGMENT_CHARS),
-    };
-    this.open.set(key, segment);
-    return { ...segment, realtimeSessionId: this.realtimeSessionId, final: false };
+    this.items.set(itemId, segment);
+    this.current.set(speaker, segment);
+    return segment;
   }
 
-  private append(key: string, speaker: CanonicalVoiceRole, delta: string, canonicalId?: string): CanonicalVoiceSegment {
-    const existing = this.open.get(key);
-    if (!existing) return this.start(key, speaker, delta, canonicalId);
-    existing.text = (existing.text + delta).slice(0, MAX_SEGMENT_CHARS);
-    return { ...existing, realtimeSessionId: this.realtimeSessionId, final: false };
+  /**
+   * The flat `transcript/done` mirroring the speaker's current item.
+   *
+   * Its text is the provider's complete one, and the item's own completion is
+   * only what its deltas accumulated, so this is the repair for a delta that
+   * never streamed. A done that is the second copy of what the item already
+   * says changes nothing and publishes nothing.
+   */
+  private repair(speaker: CanonicalVoiceRole, text: string): CanonicalVoiceSegment | null {
+    const segment = this.current.get(speaker);
+    if (!segment || (segment.final && !segment.awaitingDone)) return null;
+    segment.awaitingDone = false;
+    const before = this.shown(segment);
+    const wasFinal = segment.final;
+    if (text) segment.doneText = clip(text);
+    segment.final = true;
+    return wasFinal && this.shown(segment) === before ? null : this.publish(segment);
   }
 
-  private finish(key: string, speaker: CanonicalVoiceRole, text: string, canonicalId?: string): CanonicalVoiceSegment {
-    const existing = this.open.get(key);
+  private flatDelta(speaker: CanonicalVoiceRole, delta: string): CanonicalVoiceSegment | null {
+    const open = this.current.get(speaker);
+    const segment = open && !open.final ? open : this.mint(speaker);
+    segment.text = clip(segment.text + delta);
+    return this.publish(segment);
+  }
+
+  private flatDone(speaker: CanonicalVoiceRole, text: string): CanonicalVoiceSegment | null {
+    const open = this.current.get(speaker);
+    /* A done with no words and nothing streamed before it is no segment. */
+    if ((!open || open.final) && !text) return null;
+    const segment = open && !open.final ? open : this.mint(speaker);
     /* The done event carries the WHOLE segment, so it wins over what the deltas
        accumulated: a dropped frame is repaired here rather than left as a hole
-       in the middle of a sentence. An empty final text keeps what was streamed,
-       because losing the words would be the worse reading of a sparse event. */
-    const segment: OpenSegment = existing
-      ? { ...existing, text: (text || existing.text).slice(0, MAX_SEGMENT_CHARS) }
-      : this.newSegment(speaker, text, canonicalId);
-    this.open.delete(key);
-    return { ...segment, realtimeSessionId: this.realtimeSessionId, final: true };
+       in the middle of a sentence. An empty final text keeps what was streamed. */
+    if (text) segment.doneText = clip(text);
+    segment.final = true;
+    return this.publish(segment);
   }
 
-  private newSegment(speaker: CanonicalVoiceRole, text: string, canonicalId?: string): OpenSegment {
+  private mint(speaker: CanonicalVoiceRole): Segment {
     this.sequence += 1;
-    return {
-      id: canonicalId ?? `${this.realtimeSessionId}:${speaker}:${this.sequence}`,
+    const segment: Segment = {
+      id: `${this.realtimeSessionId}:${speaker}:${this.sequence}`,
       role: speaker,
-      text: text.slice(0, MAX_SEGMENT_CHARS),
+      text: "",
+      floor: "",
+      doneText: "",
+      final: false,
+      item: false,
+      awaitingDone: false,
+    };
+    this.current.set(speaker, segment);
+    return segment;
+  }
+
+  private shown(segment: Segment): string {
+    if (segment.doneText) return segment.doneText;
+    return !segment.final && segment.floor.startsWith(segment.text) ? segment.floor : segment.text;
+  }
+
+  private publish(segment: Segment): CanonicalVoiceSegment | null {
+    const text = this.shown(segment);
+    if (!text) return null;
+    return {
+      id: segment.id,
+      realtimeSessionId: this.realtimeSessionId,
+      role: segment.role,
+      text,
+      final: segment.final,
     };
   }
 }

--- a/src/lib/runtime/fixtures/codex-realtime-transcript-v0.154.0.jsonl
+++ b/src/lib/runtime/fixtures/codex-realtime-transcript-v0.154.0.jsonl
@@ -1,0 +1,128 @@
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-001", "type": "input_transcript", "text": " Please"}, "start_ms": 200, "end_ms": 400}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-002", "type": "input_transcript", "text": " repeat the"}, "start_ms": 400, "end_ms": 600}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-003", "type": "output_transcript", "text": " I'm the"}, "start_ms": 600, "end_ms": 800}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-004", "type": "input_transcript", "text": " read-only"}, "start_ms": 800, "end_ms": 1000}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-005", "type": "output_transcript", "text": " dedicated Voice"}, "start_ms": 1000, "end_ms": 1200}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-u1", "role": "user", "transcript": " Please repeat the read-only"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-006", "type": "output_transcript", "text": " regression"}, "start_ms": 1200, "end_ms": 1400}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-007", "type": "input_transcript", "text": " status"}, "start_ms": 1400, "end_ms": 1600}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-a1", "role": "assistant", "transcript": " I'm the dedicated Voice regression"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-008", "type": "input_transcript", "text": " check from"}, "start_ms": 1600, "end_ms": 1800}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-009", "type": "output_transcript", "text": " QA"}, "start_ms": 1800, "end_ms": 2000}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-010", "type": "input_transcript", "text": " our"}, "start_ms": 2000, "end_ms": 2200}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-011", "type": "output_transcript", "text": " orchestrator,"}, "start_ms": 2200, "end_ms": 2400}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-u2", "role": "user", "transcript": " status check from our"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-a2", "role": "assistant", "transcript": " QA orchestrator,"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-012", "type": "input_transcript", "text": " yes"}, "start_ms": 2400, "end_ms": 2600}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-u3", "role": "user", "transcript": " yes"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-013", "type": "output_transcript", "text": " ok"}, "start_ms": 2600, "end_ms": 2800}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-a3", "role": "assistant", "transcript": " ok"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-014", "type": "input_transcript", "text": " yes"}, "start_ms": 2800, "end_ms": 3000}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-u4", "role": "user", "transcript": " yes"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-a4", "role": "assistant", "transcript": " Unstreamed answer."}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-015", "type": "output_transcript", "text": " Hello"}, "start_ms": 3000, "end_ms": 3200}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-016", "type": "output_transcript", "text": " world"}, "start_ms": 3200, "end_ms": 3400}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-a5", "role": "assistant", "transcript": " Hello big world"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-017", "type": "output_transcript", "text": " Interrupted"}, "start_ms": 3400, "end_ms": 3600}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "input_transcript.added", "item": {"id": "chunk-018", "type": "input_transcript", "text": " wait"}, "start_ms": 3600, "end_ms": 3800}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-u5", "role": "user", "transcript": " wait"}}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "output_transcript.added", "item": {"id": "chunk-019", "type": "output_transcript", "text": " Resumed"}, "start_ms": 3800, "end_ms": 4000}}
+{"source": "data-channel", "call": "call-one", "event": {"type": "turn.done", "turn": {"id": "bidi-a6", "role": "assistant", "transcript": " Resumed"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-01", "realtimeSessionId": "call-one", "type": "realtimeSessionStarted"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-01", "realtimeSessionId": "call-one", "type": "realtimeSessionStarted"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/started", "params": {"threadId": "thread-fixture", "realtimeSessionId": "call-one", "version": "v3"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-02", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " Please"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " Please"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " repeat the"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " repeat the"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-03", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " I'm the"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " I'm the"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-02", "delta": " read-only"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " read-only"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " dedicated Voice"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " dedicated Voice"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-02", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": " Please repeat the read-only"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " Please repeat the read-only"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-03", "delta": " regression"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " regression"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-04", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " status"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " status"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-03", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": " I'm the dedicated Voice regression"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " I'm the dedicated Voice regression"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " check from"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " check from"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-05", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " QA"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " QA"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-04", "delta": " our"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " our"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-05", "delta": " orchestrator,"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " orchestrator,"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-04", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": " status check from our"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " status check from our"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-05", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": " QA orchestrator,"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " QA orchestrator,"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-06", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-06", "delta": " yes"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " yes"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-06", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": " yes"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " yes"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-07", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-07", "delta": " ok"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " ok"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-07", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": " ok"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " ok"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-08", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-08", "delta": " yes"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " yes"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-08", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": " yes"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " yes"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-09", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-09", "delta": " Unstreamed answer."}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-09", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": " Unstreamed answer."}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " Unstreamed answer."}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-10", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-10", "delta": " Hello"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " Hello"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-10", "delta": " world"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " world"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-10", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": " Hello world"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " Hello big world"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-11", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-11", "delta": " Interrupted"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " Interrupted"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-12", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-12", "delta": " wait"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " wait"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-12", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "user", "text": " wait"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " wait"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-11", "delta": " Resumed"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " Resumed"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-11", "realtimeSessionId": "call-one", "type": "transcriptSegment", "role": "assistant", "text": " Interrupted Resumed"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " Resumed"}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-13", "realtimeSessionId": "call-one", "type": "realtimeSessionClosed", "outcome": "ended"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-13", "realtimeSessionId": "call-one", "type": "realtimeSessionClosed", "outcome": "ended"}}}
+{"source": "app-server", "call": "call-one", "method": "thread/realtime/closed", "params": {"threadId": "thread-fixture", "reason": "requested"}}
+{"source": "data-channel", "call": "call-two", "event": {"type": "input_transcript.added", "item": {"id": "chunk-020", "type": "input_transcript", "text": " second call"}, "start_ms": 4000, "end_ms": 4200}}
+{"source": "data-channel", "call": "call-two", "event": {"type": "turn.done", "turn": {"id": "bidi-u6", "role": "user", "transcript": " second call"}}}
+{"source": "data-channel", "call": "call-two", "event": {"type": "output_transcript.added", "item": {"id": "chunk-021", "type": "output_transcript", "text": " reply"}, "start_ms": 4200, "end_ms": 4400}}
+{"source": "data-channel", "call": "call-two", "event": {"type": "turn.done", "turn": {"id": "bidi-a7", "role": "assistant", "transcript": " reply"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-14", "realtimeSessionId": "call-two", "type": "realtimeSessionStarted"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-14", "realtimeSessionId": "call-two", "type": "realtimeSessionStarted"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/started", "params": {"threadId": "thread-fixture", "realtimeSessionId": "call-two", "version": "v3"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-15", "realtimeSessionId": "call-two", "type": "transcriptSegment", "role": "user", "text": ""}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-15", "delta": " second call"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "user", "delta": " second call"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-15", "realtimeSessionId": "call-two", "type": "transcriptSegment", "role": "user", "text": " second call"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "user", "text": " second call"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-16", "realtimeSessionId": "call-two", "type": "transcriptSegment", "role": "assistant", "text": ""}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/transcript/delta", "params": {"threadId": "thread-fixture", "itemId": "segment-16", "delta": " reply"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/transcript/delta", "params": {"threadId": "thread-fixture", "role": "assistant", "delta": " reply"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-16", "realtimeSessionId": "call-two", "type": "transcriptSegment", "role": "assistant", "text": " reply"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/transcript/done", "params": {"threadId": "thread-fixture", "role": "assistant", "text": " reply"}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/started", "params": {"threadId": "thread-fixture", "item": {"id": "segment-17", "realtimeSessionId": "call-two", "type": "realtimeSessionClosed", "outcome": "ended"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/item/completed", "params": {"threadId": "thread-fixture", "item": {"id": "segment-17", "realtimeSessionId": "call-two", "type": "realtimeSessionClosed", "outcome": "ended"}}}
+{"source": "app-server", "call": "call-two", "method": "thread/realtime/closed", "params": {"threadId": "thread-fixture", "reason": "requested"}}


### PR DESCRIPTION
Closes #1658.

A live native Voice call showed each sentence up to three times: the data-channel caption, a line for native's transcript item, and a line for native's flat mirror of that item. When both speakers talked at once, the caption broke into fragments and the whole sentence was repeated underneath. This PR makes each spoken turn one line, whichever source reaches the panel first, and keeps it that way when either source misses a turn.

## Causes

Each cause was checked against native's own wire and against the recorded call. The native wire came from the installed Codex app-server 0.154.0, driven by a loopback realtime fixture with no credentials and isolated state.

1. **Both notification families became segments.** Native publishes every segment twice: each `thread/realtime/item/*` event is followed at once by its flat `transcript/delta` / `transcript/done` mirror. The host reducer turned both into segments, so every utterance got two canonical ids.
2. **Empty starts claimed a line.** Native opens every segment with an empty `item/started`. The client gave that empty segment its own line before it could adopt the caption that held the words.
3. **The other speaker closed your line.** The client ended a speaker's caption line whenever the other speaker spoke. In a duplex call the two overlap word by word, so each sentence ended up in pieces, and its `turn.done` text landed on a new line below them.
4. **Matching looked at text and only the newest line.** The client matched a canonical segment to a caption by text prefix, checking only the newest line of that speaker.

The review of the first round found three more, all in the pairing that replaced cause 4:

5. **A turn one source missed shifted every later turn.** Captions and segments were paired k-th to k-th. A committed answer the data channel never captioned took the next caption, so the earlier answer was overwritten and the later one shown twice.
6. **An empty caption `turn.done` held back the committed repair.** A finished caption outranked a finished segment even when its done carried no words, so a word the provider never streamed stayed missing.
7. **A fragment replayed after its turn ended opened a new line**, because fragment ids were remembered only while their turn streamed.

## Ownership strategy

- **Host reducer (`codexRealtimeTranscript.ts`).** The per-item family owns the segment, because it carries native's identity. The flat family is the full transcript only on a server that never publishes items. Otherwise it only repairs: `item/completed` carries what the deltas accumulated, and only the mirrored `transcript/done` carries the provider's final text. Segments with no words are not published. If the flat mirror arrives first, the item takes over the id already published.
- **Client (`codexRealtimeClient.ts`): one line per spoken turn, by verified in-order alignment.**
  - **What the sources share.** A caption and a segment share no identifier; native 0.154's schema gives a transcript segment only `id`, `realtimeSessionId`, `role` and `text`. They share the provider's evidence instead. Native builds each segment from the same fragments the data channel delivers, in the same order, and its mirrored done carries the same final text as the channel's `turn.done`.
  - **How turns pair.** The client keeps each speaker's open caption turns and segments in their own order. It aligns the two in order, maximising the pairs that evidence supports. A segment still streaming must be the same fragments as the caption, one a little ahead of the other. A final one must be what those fragments accumulated, or the provider's repaired final text.
  - **Missed turns and repeats.** A turn one source missed keeps a line of its own, and the turns around it still pair. Identical words said twice stay two turns because each turn pairs once. Text never merges two turns from the same source.
  - **Stable lines.** A turn keeps the line it was first drawn on. When alignment joins two lines, the earlier one stays. A turn supplied late by one source is placed before the next turn of the same speaker.
- **Which text shows.** While both stream, the caption leads (it's the low-latency source). A caption's final text leads a segment that is still streaming. A final segment wins, because its mirrored done has repaired any word the provider never streamed. The one exception is the moment between native's completion and that repair. It's recognisable because the segment still equals the caption's fragments, so the line never flickers back.
- **Calls and replays.** A new call starts its own turn order, and late segments from an earlier session are ignored. Segments that arrive just after hangup still land on that call's lines. Fragment ids are remembered for the whole call, and a done delivered again is recognised by its turn id.
- **Bounded state.** A pair whose halves have both finished and agree settles on its line. That keeps the alignment to the few turns the sources are apart. Open turns are capped per speaker and source, as are remembered segment ids and fragment ids.
- **Unchanged:** `appendSpeech`/`deliverWorkerResponse`, worker progress lines, persona, tools, input policy, voice authorization, and the selected-context and handoff ledger.

## Evidence

Every scenario is replayed offline through the real reducer, runtime projection, browser store and client, then rendered with `VoiceConversationPanel` under the product CSS. The captures were made locally (the privacy gate keeps rasters out of the repository).

| Scenario | Merge base | First round | This PR |
| --- | --- | --- | --- |
| Recorded duplex call (`src/lib/realtime/fixtures/voice-duplex-call.jsonl`) | 35 lines | 7 | 7, one per turn |
| Committed "First answer." never captioned, then "Second answer." from both sources | 4 | "Second answer." twice, first answer lost | "First answer.", "Second answer." |
| Native 0.154 events with the first answer's caption dropped | 37 | 11, shifted: "I'm the dedicated Voice regression" lost, "Resumed" twice | 11, each turn once |
| Caption "Hello world" with an empty done, committed repair "Hello big world" | 3 | "Hello world" | "Hello big world" |
| A fragment replayed after its turn completed | 3 | 2 | 1 |

After, the recorded duplex call:

```
YOU    Please repeat the read-only
AGENT  I'm the dedicated Voice regression
YOU    status check from our setup using the tool again now Tell me your role in this
AGENT  QA orchestrator, Checking it now.
YOU    conversation Do not change anything or launch any agents
AGENT  One sec. Still looking.
       Let me check that again.             (still streaming when the recording stopped)
```

## Tests

`voiceCanonicalTranscript.dom.test.ts` drives the whole path through the product client. The eleven tests added in this round all fail on the merge base, eight of them also fail on the first round's commit, and all pass here:

- A turn the data channel never captioned, with the next turn's caption arriving first or its segment arriving first.
- Native's recorded events with one answer's caption dropped, in both source orders.
- The recorded duplex call with one answer never captioned, and with one never committed.
- A missed turn that opens with the same words as the next, missed on either side.
- An empty caption done followed by the committed repair, in both source orders.
- A completion that its mirrored done has not repaired yet never taking the caption's final words away (every intermediate panel state is checked).
- A fragment and a done replayed after their turn ended, next to the same words genuinely said again.

The first round's tests still pass: the recorded duplex call interleaved, in one batch and committed first; native's own events in both orders; an empty canonical start; either source finishing first; replayed fragments and canonical tails; the canonical stream two turns behind with repeated words; overlapping speakers; and a call restart with a late segment from the previous call.

Run file by file under Bun 1.4.0 with isolated HOME, XDG and state, all passing:

- the reducer, client, transport (`.ts`/`.tsx`), selected-context, selected-context binding, card-chain and canonical-transcript suites;
- `VoiceConversation`, the composer voice button and `useCodexRealtime` ambient suites;
- `codexAppServerHost` (136 tests).

`tsc --noEmit` is clean, and the privacy gate passes from the merge base with `--check-commits --require-known-values`.

## Third round

The second review reproduced two more ownership failures through the mounted panel, plus one older loss of repeated words:

8. **A replayed `turn.done` was checked only against the newest caption, and only when no turn was streaming.** Replaying an earlier turn's done while the next answer streamed closed that answer early with the earlier text ("First answer." / "First answer." / "answer."). Replaying it after the next answer had finished added a third line. Every done that closes a turn is now remembered by its turn id (bounded to 512 per call). A replay is refused before the current turn is touched. The same words under a new turn id are still a new turn.
9. **A repair that rewrote a turn's opening words, paired with an empty caption done, showed both versions.** Native streamed "Their answer" and its mirrored done repaired it to "The answer."; with the committed events first, the caption stayed on a line of its own. A canonical segment now keeps the text a repair replaced, which is exactly what its fragments and the caption said, and pairing weighs it alongside the repaired text. The pre-repair text never reaches the client when the store hands it the repaired segment in one batch. For that case, a caption whose done had no words still pairs with a final segment that changed only its first word (case and punctuation ignored, same word count). It is the weak match, used only when nothing better aligns, the same as a shared opening.
10. **Distinct fragments " very" / " very" / " good" collapsed to " very good"** (inherited from the MVP). A fragment with its own id is one delta. Only an id-less fragment is still treated as a possible resend of the whole text.

`voiceCanonicalTranscript.dom.test.ts` now mounts `VoiceConversationPanel` for every assertion. It reads the speaker labels, line text and the unfinished-line caret from the DOM instead of the client snapshot. New cases:

- an earlier done replayed while the next answer streams, and again after it finishes;
- native 0.154's recorded events with an answer's done redelivered mid-turn and after the call, in both source orders;
- the opening-word repair in both source orders, delivered event by event and in one batch;
- a caption whose done kept different words stays apart from a repaired segment;
- a word said twice in a row.

Seven of these fail on `2dab499a`; the other two pass there as controls. All 37 tests in the file pass here, and the reviewer's own mounted-panel probes and controls all pass (38/38). Run file by file under Bun 1.4.0 with isolated HOME, XDG and state, also passing: the client, transport (`.ts`/`.tsx`), selected-context, selected-context binding, card-chain and reducer suites; `VoiceConversation`, the composer voice button and `useCodexRealtime` ambient suites; and `codexAppServerHost` (136). `tsc --noEmit` is clean, and the privacy gate passes from the merge base with `--check-commits --require-known-values`.

## Not verified here

No provider, microphone or live call was used, so a live acceptance call is still needed after deploy. Wire evidence that is still missing:

1. **Live `turn.done` frames.** The second live capture's data-channel recorder saved only `*_transcript.added`, although the panel showed lines only a `turn.done` creates. The raw frame's shape, including whether it carries `turn.id`, is unrecorded. Offline, with every data-channel `turn.done` removed from the recorded call, each committed turn still renders once. The only cost is that a turn still being spoken shows up once its segment arrives, not before.
2. **Barge-in.** Does the provider send `turn.done` for a truncated assistant response? Both native and this client end an agent turn only at its own `turn.done`.
3. **Live app-server notifications.** The native probe used websocket transport. A raw capture from a real WebRTC call would confirm the item-then-mirror order and per-speaker boundaries on the sideband.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

