### PR TITLE
Preserve native queue recovery through journal compaction (#1664)

### DIFF
--- a/scripts/verify-native-codex-runtime.ts
+++ b/scripts/verify-native-codex-runtime.ts
@@ -22,6 +22,9 @@ const files = [
   "src/lib/runtime/nativeQueueRuntime.test.ts",
   "src/lib/runtime/nativeQueueContent.test.ts",
   "src/runtime-host/nativeQueueJournal.test.ts",
+  // #1664: native entries through journal compaction, and evidence-only recovery.
+  "src/runtime-host/nativeQueueCompaction.test.ts",
+  "src/lib/runtime/nativeQueueCompaction.integration.test.ts",
   "src/lib/runtime/nativeQueueHost.integration.test.ts",
   "src/lib/runtime/codexTurnProfile.test.ts",
   "src/lib/runtime/codexAppServerHost.test.ts",

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -1,4 +1,4 @@
-import type { NativeQueueRecord, NativeQueueTransition } from "./nativeQueueContracts";
+import type { NativeQueueCompactedProof, NativeQueueCompactedSettlement, NativeQueueRecord, NativeQueueTransition } from "./nativeQueueContracts";
 import net from "node:net";
 
 import type { RuntimeDeliveryAction, RuntimeDeliveryActionClaim, RuntimeEventInput, RuntimeOperationCommand, RuntimeOperationResult, RuntimePendingEffect, RuntimeReceiptStatus, RuntimeReplay, RuntimeRetryOptions, RuntimeSnapshot, RuntimeSocketRequest, RuntimeSocketResponse, RuntimeTransitionOptions, ViewerDeploymentReceipt, ViewerDeploymentRequest, ViewerDeploymentStatus } from "./contracts";
@@ -87,6 +87,9 @@ export function isRuntimeHostTransportFailure(error: unknown): boolean {
 export interface RuntimeHostClient {
   nativeQueueRead?(conversationId: string): Promise<NativeQueueRecord[]>;
   nativeQueueTransition?(operationId: string, transition: NativeQueueTransition): Promise<RuntimeOperationResult>;
+  /** Canonical proof for an entry whose add operation was compacted (#1664).
+      Answers the settled entry; there is no operation receipt to answer. */
+  nativeQueueSettleCompacted?(request: NativeQueueCompactedProof): Promise<NativeQueueCompactedSettlement>;
   snapshot(signal?: AbortSignal): Promise<RuntimeSnapshot>;
   events(after: number, signal?: AbortSignal): Promise<RuntimeReplay>;
   waitEvents(after: number, timeoutMs?: number, signal?: AbortSignal): Promise<RuntimeReplay>;
@@ -123,6 +126,9 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
   }
   nativeQueueTransition(operationId: string, transition: NativeQueueTransition): Promise<RuntimeOperationResult> {
     return this.call("native-queue-transition", { operationId, transition }) as Promise<RuntimeOperationResult>;
+  }
+  nativeQueueSettleCompacted(request: NativeQueueCompactedProof): Promise<NativeQueueCompactedSettlement> {
+    return this.call("native-queue-settle-compacted", { ...request }) as Promise<NativeQueueCompactedSettlement>;
   }
   snapshot(signal?: AbortSignal): Promise<RuntimeSnapshot> { return this.call("snapshot", undefined, this.snapshotTimeoutMs, signal) as Promise<RuntimeSnapshot>; }
   events(after: number, signal?: AbortSignal): Promise<RuntimeReplay> { return this.call("events", { after }, this.timeoutMs, signal) as Promise<RuntimeReplay>; }

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -760,7 +760,7 @@ export interface RuntimeReplay {
 
 export interface RuntimeSocketRequest {
   id: string;
-  method: "runtime-host-health" | "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-delivery-action" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "viewer-deployment-cancel" | "mcp-health-probe-admission" | "native-queue-read" | "native-queue-transition";
+  method: "runtime-host-health" | "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-delivery-action" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "viewer-deployment-cancel" | "mcp-health-probe-admission" | "native-queue-read" | "native-queue-transition" | "native-queue-settle-compacted";
   params?: Record<string, unknown>;
 }
 

--- a/src/lib/runtime/nativeQueueCompaction.integration.test.ts
+++ b/src/lib/runtime/nativeQueueCompaction.integration.test.ts
@@ -1,0 +1,319 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createServer, type ServerResponse } from "node:http";
+import { PassThrough } from "node:stream";
+import { createInterface } from "node:readline";
+import { afterAll, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+/* #1664 against the real journal, the real agent registry and (when a Codex
+   binary is supplied) the real app-server. Isolated state only: nothing here
+   may address the operator's registry, journal or engine homes. */
+const isolated = fs.mkdtempSync(path.join(os.tmpdir(), "llv-nq-compaction-"));
+const isolatedEnvironment = {
+  HOME: path.join(isolated, "home"),
+  XDG_CONFIG_HOME: path.join(isolated, "config"),
+  LLV_STATE_DIR: path.join(isolated, "state"),
+  TMPDIR: path.join(isolated, "tmp"),
+};
+const ambientEnvironment = Object.fromEntries(Object.keys(isolatedEnvironment).map(name => [name, process.env[name]]));
+for (const [name, directory] of Object.entries(isolatedEnvironment)) {
+  fs.mkdirSync(directory, { recursive: true });
+  process.env[name] = directory;
+}
+
+const { AgentRegistry } = await import("@/lib/agent/registry");
+const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+const { RuntimeJournal } = await import("@/runtime-host/journal");
+const { NativeQueueExecutor } = await import("./nativeQueueExecutor");
+const { NativeCodexQueue } = await import("./nativeCodexQueue");
+const { CodexAppServerHost } = await import("./codexAppServerHost");
+const { FileRuntimeEventStore } = await import("./eventStore");
+const { parseRuntimeCommand } = await import("./commands");
+type AgentRegistryType = import("@/lib/agent/registry").AgentRegistry;
+type RuntimeJournalType = import("@/runtime-host/journal").RuntimeJournal;
+type RuntimeHostClient = import("./client").RuntimeHostClient;
+type EngineHost = import("./engineHost").EngineHost;
+type NativeQueueCommand = import("./nativeQueueContracts").NativeQueueCommand;
+type NativeQueueRecord = import("./nativeQueueContracts").NativeQueueRecord;
+type NativeQueueProof = import("./nativeQueueContracts").NativeQueueProof;
+type NativeQueuedSubmission = import("./nativeCodexQueue").NativeQueuedSubmission;
+type ViewerConversationId = `conversation_${string}`;
+
+afterAll(() => {
+  for (const [name, value] of Object.entries(ambientEnvironment)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  fs.rmSync(isolated, { recursive: true, force: true });
+});
+
+const UNVERIFIED = "delivery was accepted and the runtime host could not give it a terminal answer";
+
+function journalClient(journal: () => RuntimeJournalType): RuntimeHostClient {
+  return {
+    operationStatus: async (id: string) => journal().operationResult(id),
+    nativeQueueRead: async (id: string) => journal().nativeQueueRead(id),
+    nativeQueueTransition: async (id: string, transition: Parameters<RuntimeJournalType["nativeQueueTransition"]>[1]) => journal().nativeQueueTransition(id, transition),
+    nativeQueueSettleCompacted: async (request: Parameters<RuntimeJournalType["nativeQueueSettleCompacted"]>[0]) => journal().nativeQueueSettleCompacted(request),
+  } as RuntimeHostClient;
+}
+
+/** The two registry ports exactly as the structured delivery controller wires them. */
+function registryPorts(registry: AgentRegistryType) {
+  return {
+    settled: (entry: NativeQueueRecord) => {
+      registry.recordDeliveryOutcomeForOperation(entry.conversationId as ViewerConversationId, entry.entryId,
+        entry.state === "removed" ? "failed" : "delivered", entry.state === "removed" ? "delivery-discarded" : null);
+    },
+    binding: (conversationId: string) => {
+      const conversation = registry.readOnlySnapshot().conversations[conversationId];
+      const generation = conversation?.generations.at(-1);
+      if (!conversation || conversation.engine !== "codex" || !generation) return null;
+      return { threadId: generation.id, accountId: generation.accountId };
+    },
+  };
+}
+
+function registryConversation(registry: AgentRegistryType, transcriptPath: string, accountId: string) {
+  registry.reconcileConversations([{
+    engine: "codex", path: transcriptPath, accountId, launchProfile: emptyLaunchProfile({ cwd: path.dirname(transcriptPath) }),
+    turn: { state: "idle", source: "assistant", terminalAt: null }, observedAt: "2026-09-11T00:00:00.000Z",
+  }]);
+  const conversation = Object.values(registry.snapshot().conversations).find(row => row.generations.at(-1)?.path === transcriptPath)!;
+  return { conversationId: conversation.id as ViewerConversationId, generation: conversation.generations.at(-1)! };
+}
+
+function publishNative(journal: RuntimeJournalType, conversationId: string, threadId: string, accountId: string, activeTurnId: string | null) {
+  journal.append({ scope: `session:${conversationId}`, kind: "session-status", payload: {
+    conversationId, sessionKey: { engine: "codex", sessionId: threadId }, hostKind: "codex-app-server", host: "hosted",
+    turn: activeTurnId ? "running" : "idle", activeTurnId, accountId, capabilities: { steer: true, structuredAttention: true, nativeQueue: true },
+  } });
+}
+
+/** A composer send exactly as the structured send path admits it: reservation, claimed attempt, journal operation. */
+function composerSend(registry: AgentRegistryType, journal: RuntimeJournalType, conversationId: ViewerConversationId, generationId: string, key: string, text: string) {
+  const operationId = `op-${key}`;
+  const reservation = registry.holdDelivery(conversationId, text, key, "text", [], null, { operationId, kind: "send", policy: "queue" });
+  if (!registry.beginDeliveryAttempt(reservation.id, generationId)) throw new Error("fixture attempt was not claimed");
+  expect(journal.executeOperation(parseRuntimeCommand("send", { conversationId, operationId, idempotencyKey: key, text, policy: "queue" })).receipt.status).toBe("queued");
+  const effect = journal.effectBatch(100, ["runtime.native-queue"]).find(row => row.id === `effect:${operationId}`)!;
+  return { operationId, deliveryId: reservation.id, command: effect.payload as unknown as NativeQueueCommand & { operationId: string } };
+}
+
+/** The residue a journal compacted before #1664 left: the entry and its reservation, no operation. */
+function compactedBeforeHolds(filename: string, operationIds: string[]) {
+  const db = new Database(filename);
+  for (const id of operationIds) {
+    db.query("DELETE FROM operations WHERE operation_id = ?").run(id);
+    db.query("DELETE FROM entities WHERE kind = 'operation' AND id = ?").run(id);
+    db.query("DELETE FROM outbox WHERE id = ?").run(`effect:${id}`);
+  }
+  db.close();
+}
+
+function ownerOf(registry: AgentRegistryType, operationId: string) {
+  const snapshot = registry.readOnlySnapshot();
+  const owner = snapshot.deliveryOperationOwners[operationId]!;
+  const delivery = snapshot.heldDeliveries[owner.deliveryId];
+  return { state: delivery?.state ?? null, error: delivery?.error ?? null, terminalState: owner.terminalState, terminalDisposition: owner.terminalDisposition };
+}
+
+test("registry: canonical proof settles an unverified historical reservation delivered; a discarded one stays discarded", async () => {
+  const directory = fs.mkdtempSync(path.join(isolated, "registry-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const { conversationId, generation } = registryConversation(registry, path.join(directory, "historical.jsonl"), "account-a");
+  const ports = registryPorts(registry);
+  const binding = ports.binding(conversationId)!;
+  const filename = path.join(directory, "runtime.sqlite");
+  let journal = new RuntimeJournal(filename, { structuredHosts: true, maxEvents: 12 });
+  publishNative(journal, conversationId, binding.threadId, "account-a", "active-a");
+  const writes: string[] = [];
+  const queue = new NativeCodexQueue({ rpc: async (method, params) => {
+    if (method === "thread/queue/list") return { data: [], nextCursor: null };
+    writes.push(method);
+    if (method !== "thread/queue/add") throw new Error(`unexpected ${method}`);
+    return { queuedSubmission: { id: `native-${writes.length}`, clientUserMessageId: params.clientUserMessageId, input: params.input } };
+  } }, binding.threadId);
+  let answer: (entry: NativeQueueRecord) => NativeQueueProof | null = () => null;
+  const host = { health: async () => ({ status: "active", activeTurnRef: "active-a" }), nativeQueue: {
+    queue, prepare: async (_entry: NativeQueueRecord, version: NativeQueueRecord["versions"][number]) => [{ type: "text" as const, text: version.text }],
+    evidence: async (entry: NativeQueueRecord) => answer(entry), sendWithdrawn: async () => { throw new Error("unused"); },
+  } } as unknown as EngineHost;
+  const executor = () => new NativeQueueExecutor({ client: journalClient(() => journal), resolveHost: () => host, ...ports });
+
+  const unverified = composerSend(registry, journal, conversationId, generation.id, "unverified-key", "the audit request");
+  const discarded = composerSend(registry, journal, conversationId, generation.id, "discarded-key", "the retracted request");
+  const absent = composerSend(registry, journal, conversationId, generation.id, "absent-key", "never reached history");
+  for (const send of [unverified, discarded, absent]) await executor().execute(send.command);
+  expect(writes).toEqual(["thread/queue/add", "thread/queue/add", "thread/queue/add"]);
+  // Production's receipt deadline settles the first and third unverified; the operator discarded the second.
+  registry.terminalizeHeldDelivery(unverified.deliveryId, UNVERIFIED);
+  registry.terminalizeHeldDelivery(absent.deliveryId, UNVERIFIED);
+  registry.recordDeliveryOutcomeForOperation(conversationId, discarded.operationId, "failed", "delivery-discarded");
+  expect(ownerOf(registry, unverified.operationId)).toMatchObject({ state: "failed", terminalDisposition: "unverified" });
+  expect(ownerOf(registry, discarded.operationId)).toMatchObject({ state: "failed", error: "delivery-discarded" });
+  journal.close();
+  compactedBeforeHolds(filename, [unverified.operationId, discarded.operationId, absent.operationId]);
+  journal = new RuntimeJournal(filename, { structuredHosts: true, maxEvents: 12 });
+  const absentBefore = JSON.stringify(journal.nativeQueueRead(conversationId).find(entry => entry.entryId === absent.operationId));
+
+  answer = entry => entry.entryId === absent.operationId ? null : { threadId: binding.threadId, clientUserMessageId: entry.clientUserMessageId,
+    revision: entry.revision, turnId: "canonical-turn", itemId: `item-${entry.entryId}`, input: entry.versions.at(-1)!.input! };
+  expect(await executor().reconcile(conversationId)).toBeTrue();
+
+  const states = Object.fromEntries(journal.nativeQueueRead(conversationId).map(entry => [entry.entryId, entry.state]));
+  expect(states).toEqual({ [absent.operationId]: "queued", [unverified.operationId]: "delivered", [discarded.operationId]: "delivered" });
+  expect(JSON.stringify(journal.nativeQueueRead(conversationId).find(entry => entry.entryId === absent.operationId))).toBe(absentBefore);
+  expect(ownerOf(registry, unverified.operationId)).toEqual({ state: "delivered", error: null, terminalState: "delivered", terminalDisposition: "delivered" });
+  // The journal records what history shows; the operator's discard is not overwritten.
+  expect(ownerOf(registry, discarded.operationId)).toMatchObject({ state: "failed", error: "delivery-discarded", terminalState: "failed" });
+  expect(ownerOf(registry, absent.operationId)).toMatchObject({ state: "failed", terminalDisposition: "unverified" });
+  for (const id of [unverified.operationId, discarded.operationId, absent.operationId]) expect(journal.operationResult(id)).toBeNull();
+  expect(journal.effectBatch(100)).toEqual([]);
+  expect(writes).toHaveLength(3);
+  // The registry's own recovery cannot re-arm what compaction left: the id is the retained entry's.
+  expect(() => journal.executeOperation(parseRuntimeCommand("send", { conversationId, operationId: absent.operationId, idempotencyKey: "absent-key", text: "never reached history", policy: "queue" })))
+    .toThrow("retained native queue entry");
+  journal.close();
+});
+
+const binary = process.env.NATIVE_CODEX_QUEUE_TEST_BINARY;
+
+test.skipIf(!binary)("real Codex: a compacted historical entry converges from canonical history with no engine write; an undispatched one stays queued", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "nqch-"));
+  const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin", LANG: "C.UTF-8", NODE_ENV: "test" };
+  for (const key of ["HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "CODEX_HOME", "CLAUDE_CONFIG_DIR", "GEMINI_CLI_HOME", "LLV_STATE_DIR", "TMPDIR"]) {
+    env[key] = path.join(base, key.toLowerCase()); fs.mkdirSync(env[key]!);
+  }
+  const cwd = path.join(base, "workspace"); fs.mkdirSync(cwd);
+  const responses: ServerResponse[] = [];
+  const backend = createServer((request, response) => {
+    request.resume(); response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.write('event: response.created\ndata: {"type":"response.created","response":{"id":"fixture-response"}}\n\n');
+    responses.push(response);
+  });
+  await new Promise<void>(resolve => backend.listen(0, "127.0.0.1", resolve));
+  const address = backend.address(); if (!address || typeof address === "string") throw new Error("fixture bind failed");
+  fs.writeFileSync(path.join(env.CODEX_HOME!, "config.toml"), `model = "fixture-model"
+model_provider = "fixture"
+approval_policy = "never"
+sandbox_mode = "read-only"
+web_search = "disabled"
+[model_providers.fixture]
+name = "Runtime integration fixture"
+base_url = "http://127.0.0.1:${address.port}/v1"
+wire_api = "responses"
+requires_openai_auth = false
+supports_websockets = false
+[analytics]
+enabled = false
+[features]
+apps = false
+plugins = false
+`);
+  const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  let hideCanonicalClient: string | null = null;
+  // Only authentication/catalog projection is synthetic; queue, history and dispatch are the installed CLI's.
+  const spawnProcess = (_command: string, args: string[]) => {
+    const child = spawn(binary!, args, { cwd, env, detached: true, stdio: ["pipe", "pipe", "pipe"] });
+    const input = new PassThrough(); const output = new PassThrough();
+    const methods = new Map<number, string>();
+    const inbound = createInterface({ input });
+    inbound.on("line", line => {
+      const message = JSON.parse(line); if (typeof message.id === "number") methods.set(message.id, message.method);
+      if (message.method) requests.push({ method: message.method, params: message.params ?? {} });
+      child.stdin.write(line + "\n");
+    });
+    input.on("finish", () => child.stdin.end());
+    const outbound = createInterface({ input: child.stdout });
+    outbound.on("line", line => {
+      const message = JSON.parse(line); const method = methods.get(message.id);
+      if (method === "account/read") message.result = { account: { type: "chatgpt", planType: "fixture" }, requiresOpenaiAuth: false };
+      if (method === "model/list") message.result = { data: [{ id: "fixture-model", model: "fixture-model", isDefault: true, inputModalities: ["text", "image"], supportedReasoningEfforts: [{ reasoningEffort: "high" }] }] };
+      if (method === "thread/items/list" && hideCanonicalClient && Array.isArray(message.result?.data)) {
+        message.result.data = message.result.data.filter((entry: { item?: { clientId?: string } }) => entry.item?.clientId !== hideCanonicalClient);
+      }
+      if (method === "thread/turns/list" && hideCanonicalClient && Array.isArray(message.result?.data)) {
+        for (const turn of message.result.data) if (Array.isArray(turn.items)) turn.items = turn.items.filter((item: { clientId?: string }) => item.clientId !== hideCanonicalClient);
+      }
+      output.write(JSON.stringify(message) + "\n");
+    });
+    child.once("close", () => { inbound.close(); outbound.close(); output.end(); });
+    return new Proxy(child, { get(target, property) {
+      if (property === "stdin") return input;
+      if (property === "stdout") return output;
+      const value = Reflect.get(target, property); return typeof value === "function" ? value.bind(target) : value;
+    } }) as ChildProcessWithoutNullStreams;
+  };
+  const options = { cwd, binary, codexHome: env.CODEX_HOME, env, model: "fixture-model", requestTimeoutMs: 1000,
+    eventStore: new FileRuntimeEventStore(path.join(base, "events")), resolveImagePath: () => { throw new Error("no images here"); }, spawnProcess };
+  const filename = path.join(base, "journal.sqlite");
+  let journal = new RuntimeJournal(filename, { structuredHosts: true, maxEvents: 12 });
+  let host: import("./codexAppServerHost").CodexAppServerHost | undefined;
+  const registry = new AgentRegistry(path.join(base, "agent-registry.json"));
+  const until = async (predicate: () => boolean | Promise<boolean>) => {
+    const deadline = Date.now() + 5000;
+    while (!await predicate()) { if (Date.now() >= deadline) throw new Error("native fixture deadline"); await new Promise(resolve => setTimeout(resolve, 20)); }
+  };
+  try {
+    host = await CodexAppServerHost.start(options);
+    expect(host.nativeQueue).toBeDefined();
+    const threadId = host.identity.threadId;
+    const { conversationId, generation } = registryConversation(registry, host.identity.path!, "fixture-account");
+    const ports = registryPorts(registry);
+    expect(ports.binding(conversationId)).toEqual({ threadId, accountId: "fixture-account" });
+    const executor = new NativeQueueExecutor({ client: journalClient(() => journal), resolveHost: () => host!, ...ports });
+    const publish = async () => { publishNative(journal, conversationId, threadId, "fixture-account", (await host!.health()).activeTurnRef); };
+
+    // Idle: native dispatches the first queued send itself; the second waits behind the running turn.
+    await publish();
+    const dispatched = composerSend(registry, journal, conversationId, generation.id, "dispatched-key", "historical audit request Привіт 🌍");
+    await executor.execute(dispatched.command);
+    await until(() => responses.length === 1);
+    await publish();
+    const waiting = composerSend(registry, journal, conversationId, generation.id, "waiting-key", "still waiting behind the turn");
+    await executor.execute(waiting.command);
+    expect((await host.nativeQueue!.queue.refresh()).items?.map((item: NativeQueuedSubmission) => item.clientUserMessageId)).toEqual([waiting.operationId]);
+    registry.terminalizeHeldDelivery(dispatched.deliveryId, UNVERIFIED);
+    registry.terminalizeHeldDelivery(waiting.deliveryId, UNVERIFIED);
+
+    // The production residue: both entries retained, both operation rows compacted away before holds existed.
+    journal.close();
+    compactedBeforeHolds(filename, [dispatched.operationId, waiting.operationId]);
+    journal = new RuntimeJournal(filename, { structuredHosts: true, maxEvents: 12 });
+    for (const id of [dispatched.operationId, waiting.operationId]) expect(journal.operationResult(id)).toBeNull();
+    const before = Object.fromEntries(journal.nativeQueueRead(conversationId).map(entry => [entry.entryId, JSON.stringify(entry)]));
+    const mark = requests.length;
+    const writesSince = () => requests.slice(mark).map(r => r.method)
+      .filter(method => /^thread\/queue\/(add|update|delete|reorder|start)$/.test(method) || method === "turn/start" || method === "turn/steer");
+
+    // Absent canonical evidence changes nothing.
+    hideCanonicalClient = dispatched.operationId;
+    expect(await executor.reconcile(conversationId)).toBeTrue();
+    expect(Object.fromEntries(journal.nativeQueueRead(conversationId).map(entry => [entry.entryId, JSON.stringify(entry)]))).toEqual(before);
+    hideCanonicalClient = null;
+
+    await until(async () => {
+      await executor.reconcile(conversationId);
+      return journal.nativeQueueRead(conversationId).find(entry => entry.entryId === dispatched.operationId)?.state === "delivered";
+    });
+    const settled = journal.nativeQueueRead(conversationId).find(entry => entry.entryId === dispatched.operationId)!;
+    expect(settled.proof).toMatchObject({ threadId, clientUserMessageId: dispatched.operationId, revision: 1 });
+    expect(settled.proof!.input).toEqual(settled.versions[0]!.input!);
+    expect(JSON.stringify(journal.nativeQueueRead(conversationId).find(entry => entry.entryId === waiting.operationId))).toBe(before[waiting.operationId]);
+    expect(ownerOf(registry, dispatched.operationId)).toMatchObject({ state: "delivered", terminalDisposition: "delivered" });
+    expect(ownerOf(registry, waiting.operationId)).toMatchObject({ state: "failed", terminalDisposition: "unverified" });
+    expect(journal.operationResult(dispatched.operationId)).toBeNull();
+    expect(journal.effectBatch(100)).toEqual([]);
+    expect(writesSince()).toEqual([]);
+    expect(requests.filter(r => r.method === "thread/queue/add")).toHaveLength(2);
+    expect((await host.nativeQueue!.queue.refresh()).items?.map((item: NativeQueuedSubmission) => item.clientUserMessageId)).toEqual([waiting.operationId]);
+  } finally {
+    await host?.release(); journal.close();
+    for (const response of responses) response.end();
+    backend.closeAllConnections(); await new Promise<void>(resolve => backend.close(() => resolve()));
+  }
+}, 30_000);

--- a/src/lib/runtime/nativeQueueContracts.ts
+++ b/src/lib/runtime/nativeQueueContracts.ts
@@ -80,6 +80,28 @@ export type NativeQueueTransition =
   | { phase: "uncertain"; reason: string }
   | { phase: "proven"; proof: NativeQueueProof };
 
+/**
+ * Canonical proof for an entry whose add operation journal compaction already
+ * removed (#1664). The binding is the one the prover read the thread under.
+ */
+export interface NativeQueueCompactedProof {
+  conversationId: string;
+  entryId: string;
+  binding: NativeQueueBinding;
+  proof: NativeQueueProof;
+}
+/**
+ * What settling such an entry answers. It is NOT an operation receipt: the
+ * operation is gone, so the settled entry is the only record of the delivery,
+ * and nothing was admitted, queued or retried to produce it.
+ */
+export interface NativeQueueCompactedSettlement {
+  operation: "compacted";
+  entry: NativeQueueRecord;
+  /** True when this exact proof had already settled the entry. */
+  replayed: boolean;
+}
+
 export function sameNativeQueueBinding(a: NativeQueueBinding, b: NativeQueueBinding): boolean {
   return a.threadId === b.threadId && a.accountId === b.accountId;
 }

--- a/src/lib/runtime/nativeQueueContracts.ts
+++ b/src/lib/runtime/nativeQueueContracts.ts
@@ -102,6 +102,24 @@ export interface NativeQueueCompactedSettlement {
   replayed: boolean;
 }
 
+/**
+ * The proof with exactly the fields the history reader builds, or null when any
+ * of them is missing or of the wrong type. Every settlement stores what this
+ * returns, so a malformed identity is refused before anything is written and
+ * nothing a caller adds beyond these fields is persisted.
+ */
+export function canonicalNativeQueueProof(value: unknown): NativeQueueProof | null {
+  if (!value || typeof value !== "object") return null;
+  const proof = value as Record<string, unknown>;
+  const identity = (field: unknown): field is string => typeof field === "string" && field.length > 0;
+  if (!identity(proof.threadId) || !identity(proof.clientUserMessageId) || !identity(proof.turnId) || !identity(proof.itemId)) return null;
+  if (typeof proof.revision !== "number" || !Number.isSafeInteger(proof.revision) || proof.revision < 1) return null;
+  if (!Array.isArray(proof.input) || proof.input.length === 0
+    || !proof.input.every(item => item !== null && typeof item === "object" && !Array.isArray(item))) return null;
+  return { threadId: proof.threadId, clientUserMessageId: proof.clientUserMessageId, revision: proof.revision,
+    turnId: proof.turnId, itemId: proof.itemId, input: proof.input as NativeQueueInput[] };
+}
+
 export function sameNativeQueueBinding(a: NativeQueueBinding, b: NativeQueueBinding): boolean {
   return a.threadId === b.threadId && a.accountId === b.accountId;
 }

--- a/src/lib/runtime/nativeQueueExecutor.ts
+++ b/src/lib/runtime/nativeQueueExecutor.ts
@@ -148,7 +148,10 @@ export class NativeQueueExecutor {
     for (const entry of records) {
       if (entry.state === "removed") {
         const operation = await client.operationStatus(entry.entryId);
-        if (operation?.receipt.status !== "failed") await client.nativeQueueTransition(entry.entryId, { phase: "removed" });
+        /* A compacted add has no receipt left to fail. The removed entry is the
+           discard record, and asking for the transition anyway threw on every
+           pass, so no later entry of this conversation could ever converge. */
+        if (operation && operation.receipt.status !== "failed") await client.nativeQueueTransition(entry.entryId, { phase: "removed" });
         await this.port.settled?.(entry);
       }
     }
@@ -165,7 +168,22 @@ export class NativeQueueExecutor {
       if (!proof || this.port.resolveHost(conversationId) !== host) continue;
       const current = this.port.binding(conversationId);
       if (!current || !sameNativeQueueBinding(current, binding)) continue;
-      await client.nativeQueueTransition(entry.entryId, { phase: "proven", proof });
+      try {
+        if (await client.operationStatus(entry.entryId)) {
+          await client.nativeQueueTransition(entry.entryId, { phase: "proven", proof });
+        } else {
+          /* #1664: compaction removed the add before this proof could land. The
+             proof alone settles the entry: nothing is re-admitted and no engine
+             write follows, and only the reader bound to the entry's thread may
+             supply it. */
+          if (!client.nativeQueueSettleCompacted || host.nativeQueue.queue.threadId !== entry.binding.threadId) { pending = true; continue; }
+          await client.nativeQueueSettleCompacted({ conversationId, entryId: entry.entryId, binding: current, proof });
+        }
+      } catch {
+        // One entry the journal refuses leaves it unchanged and cannot hold up the rest.
+        pending = true;
+        continue;
+      }
       await this.port.settled?.({ ...entry, proof, state: "delivered" });
     }
     return pending;

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -1,4 +1,4 @@
-import type { NativeQueueCompactedProof, NativeQueueTransition } from "@/lib/runtime/nativeQueueContracts";
+import { canonicalNativeQueueProof, type NativeQueueCompactedProof, type NativeQueueTransition } from "@/lib/runtime/nativeQueueContracts";
 import { RUNTIME_RECEIPT_STATUSES, RuntimeIdempotencyConflictError, type RuntimeEvent, type RuntimeEventInput, type RuntimeOperationCommand, type RuntimeReceiptStatus, type RuntimeSocketRequest, type RuntimeSocketResponse } from "@/lib/runtime/contracts";
 import { structuredHostsEnabled } from "@/lib/runtime/flags";
 import { consumeRuntimeEvent, type RuntimeConsumerPorts } from "@/lib/runtime/consumers";
@@ -174,10 +174,10 @@ export class RuntimeHost {
         if (!this.structuredHosts) throw new Error("structured hosts are disabled");
         const params = request.params as Partial<NativeQueueCompactedProof> | undefined;
         const binding = params?.binding;
-        const proof = params?.proof;
+        const proof = canonicalNativeQueueProof(params?.proof);
         if (typeof params?.conversationId !== "string" || typeof params.entryId !== "string"
-          || !binding || typeof binding.threadId !== "string" || (binding.accountId !== null && typeof binding.accountId !== "string")
-          || !proof || typeof proof !== "object" || !Array.isArray(proof.input)) throw new Error("native queue compacted proof is invalid");
+          || !binding || typeof binding !== "object" || typeof binding.threadId !== "string" || (binding.accountId !== null && typeof binding.accountId !== "string")
+          || !proof) throw new Error("native queue compacted proof is invalid");
         result = this.journal.nativeQueueSettleCompacted({ conversationId: params.conversationId, entryId: params.entryId,
           binding: { threadId: binding.threadId, accountId: binding.accountId }, proof });
       } else if (request.method === "operation-transition") {

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -1,4 +1,4 @@
-import type { NativeQueueTransition } from "@/lib/runtime/nativeQueueContracts";
+import type { NativeQueueCompactedProof, NativeQueueTransition } from "@/lib/runtime/nativeQueueContracts";
 import { RUNTIME_RECEIPT_STATUSES, RuntimeIdempotencyConflictError, type RuntimeEvent, type RuntimeEventInput, type RuntimeOperationCommand, type RuntimeReceiptStatus, type RuntimeSocketRequest, type RuntimeSocketResponse } from "@/lib/runtime/contracts";
 import { structuredHostsEnabled } from "@/lib/runtime/flags";
 import { consumeRuntimeEvent, type RuntimeConsumerPorts } from "@/lib/runtime/consumers";
@@ -170,6 +170,16 @@ export class RuntimeHost {
         const transition = request.params?.transition as NativeQueueTransition | undefined;
         if (!transition || !["prepared", "acknowledged", "observed-queued", "withdrawn", "removed", "refused", "uncertain", "proven"].includes(transition.phase)) throw new Error("native queue transition is invalid");
         result = this.journal.nativeQueueTransition(String(request.params?.operationId ?? ""), transition);
+      } else if (request.method === "native-queue-settle-compacted") {
+        if (!this.structuredHosts) throw new Error("structured hosts are disabled");
+        const params = request.params as Partial<NativeQueueCompactedProof> | undefined;
+        const binding = params?.binding;
+        const proof = params?.proof;
+        if (typeof params?.conversationId !== "string" || typeof params.entryId !== "string"
+          || !binding || typeof binding.threadId !== "string" || (binding.accountId !== null && typeof binding.accountId !== "string")
+          || !proof || typeof proof !== "object" || !Array.isArray(proof.input)) throw new Error("native queue compacted proof is invalid");
+        result = this.journal.nativeQueueSettleCompacted({ conversationId: params.conversationId, entryId: params.entryId,
+          binding: { threadId: binding.threadId, accountId: binding.accountId }, proof });
       } else if (request.method === "operation-transition") {
         if (!this.structuredHosts) throw new Error("structured hosts are disabled");
         const status = request.params?.status;

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1,5 +1,5 @@
 import { NativeQueueJournal } from "./nativeQueueJournal";
-import type { NativeQueueCommand, NativeQueueRecord, NativeQueueTransition } from "@/lib/runtime/nativeQueueContracts";
+import type { NativeQueueCommand, NativeQueueCompactedProof, NativeQueueCompactedSettlement, NativeQueueRecord, NativeQueueTransition } from "@/lib/runtime/nativeQueueContracts";
 import { parseRuntimeCommand } from "@/lib/runtime/commands";
 import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs";
@@ -438,6 +438,13 @@ export class RuntimeJournal {
       }
       const operationOwner = this.db.query<{ idempotency_key: string }, [string]>("SELECT idempotency_key FROM operations WHERE operation_id = ?").get(operationId);
       if (operationOwner) throw new RuntimeIdempotencyConflictError("operationId already belongs to another request");
+      /* #1664: a native entry outlives its add operation once that operation is
+         settled and compacted. The entry still owns the id, so a late replay of
+         the original request must not admit it again: that would reset the
+         entry and hand the executor a second native write of the same input. */
+      if (this.nativeQueue.retains(operationId)) {
+        throw new RuntimeIdempotencyConflictError("operationId belongs to a retained native queue entry whose operation was compacted");
+      }
       beforeAdmission?.();
       const retryParent = retryOfOperationId
         ? this.db.query<{ receipt_json: string }, [string]>(
@@ -518,6 +525,39 @@ export class RuntimeJournal {
       transition.phase === "removed" ? { reason: RUNTIME_DELIVERY_DISCARDED_REASON }
         : "reason" in transition ? { reason: transition.reason } : {},
       transition.phase === "prepared" ? { fromStatuses: ["pending", "queued"] } : {}, transition);
+  }
+
+  /** Evidence-only settlement of an entry whose add operation compaction
+      already removed (#1664). It writes the entry and one native-queue-changed
+      event, and never an operation, receipt, effect or delivery action. An
+      entry whose operation still exists is refused here: that operation's
+      transition is the path that keeps its receipt truthful. */
+  nativeQueueSettleCompacted(request: NativeQueueCompactedProof): NativeQueueCompactedSettlement {
+    this.assertHealthy();
+    if (!this.structuredHosts) throw new Error("structured hosts are disabled");
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const operation = this.db.query<{ one: number }, [string]>("SELECT 1 AS one FROM operations WHERE operation_id = ?").get(request.entryId);
+      if (operation) throw new Error("native queue operation is retained; settle it through its operation");
+      const { entry, replayed } = this.nativeQueue.proveCompacted(request);
+      if (!replayed) {
+        this.appendInTransaction(normalizeRuntimeEventInput({
+          scope: { type: "session", id: entry.conversationId },
+          kind: "native-queue-changed",
+          producer: { kind: "runtime-effect", eventKey: `native-queue:${entry.entryId}:compacted-proof`, hostEpoch: Number(this.meta("host_epoch")) },
+          payload: { conversationId: entry.conversationId, threadId: entry.binding.threadId, entryId: entry.entryId, settledBy: "canonical-proof" },
+        }));
+      }
+      this.db.exec("COMMIT");
+      if (!replayed) {
+        this.compactIfNeeded();
+        this.notifyWaiters();
+      }
+      return { operation: "compacted", entry, replayed };
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
   }
 
   operationResult(operationId: string): RuntimeOperationResult | null {
@@ -1436,7 +1476,13 @@ export class RuntimeJournal {
       this.db.query("DELETE FROM events WHERE seq <= ?").run(anchor.seq);
       this.db.exec("DELETE FROM consumer_checkpoints WHERE NOT EXISTS (SELECT 1 FROM events WHERE events.event_id = consumer_checkpoints.event_id)");
       this.db.query("DELETE FROM outbox WHERE state = 'completed' AND event_seq <= ?").run(anchor.seq);
-      this.db.query("DELETE FROM operations WHERE event_seq <= ? AND operation_id NOT IN (SELECT substr(id, 8) FROM outbox WHERE state = 'pending' AND id LIKE 'effect:%')").run(anchor.seq);
+      /* A native entry that is not yet settled is still answered through its
+         add (and any unresolved mutation) operation after that effect stops
+         being pending, so those ids are held for as long as the entry needs
+         them (#1664). */
+      this.db.query(`DELETE FROM operations WHERE event_seq <= ?
+        AND operation_id NOT IN (SELECT substr(id, 8) FROM outbox WHERE state = 'pending' AND id LIKE 'effect:%')
+        AND operation_id NOT IN (SELECT operation_id FROM native_queue_operation_holds)`).run(anchor.seq);
       this.db.exec("DELETE FROM delivery_operation_actions WHERE operation_id NOT IN (SELECT operation_id FROM operations)");
       this.db.query("DELETE FROM entities WHERE kind = 'operation' AND checkpoint_seq <= ?").run(anchor.seq);
       this.metaSet("anchor_seq", String(anchor.seq));
@@ -2433,7 +2479,7 @@ export class RuntimeJournal {
 
   private verify(): void {
     try {
-      for (const table of ["journal_meta", "events", "scope_revisions", "projections", "entities", "outbox", "operations", "delivery_operation_actions", "native_queue_entries", "consumer_checkpoints", "viewer_deployments"]) {
+      for (const table of ["journal_meta", "events", "scope_revisions", "projections", "entities", "outbox", "operations", "delivery_operation_actions", "native_queue_entries", "native_queue_operation_holds", "consumer_checkpoints", "viewer_deployments"]) {
         const check = this.db.query<{ quick_check: string }, []>(`PRAGMA quick_check(${table})`).get();
         if (check?.quick_check !== "ok") throw new RuntimeJournalFault(`runtime journal SQLite check failed: ${table}`);
       }

--- a/src/runtime-host/nativeQueueCompaction.test.ts
+++ b/src/runtime-host/nativeQueueCompaction.test.ts
@@ -1,0 +1,532 @@
+import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { RuntimeJournal } from "./journal";
+import { RuntimeHost } from "./host";
+import { serveRuntimeHost } from "./socket";
+import { NativeCodexQueue, NativeQueueProtocolRefusal, type NativeQueuedSubmission } from "@/lib/runtime/nativeCodexQueue";
+import { NativeQueueExecutor } from "@/lib/runtime/nativeQueueExecutor";
+import { parseRuntimeCommand } from "@/lib/runtime/commands";
+import { UnixRuntimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
+import type { EngineHost } from "@/lib/runtime/engineHost";
+import type { NativeQueueCommand, NativeQueueProof, NativeQueueRecord } from "@/lib/runtime/nativeQueueContracts";
+
+/* #1664: a native queue entry outlives the `operations` row of the send that
+   owns it once journal compaction passes the row's last receipt. These run a
+   real journal on disk with a tiny event budget, so compaction happens inside
+   the test exactly as it does in production after 20 000 events. */
+
+const conversationId = "conversation_compacted";
+const binding = { threadId: "thread-compacted", accountId: "account-a" };
+const MAX_EVENTS = 12;
+
+function journalFile(): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "nqc-")), "journal.sqlite");
+}
+
+function open(filename: string, maxEvents = MAX_EVENTS): RuntimeJournal {
+  return new RuntimeJournal(filename, { structuredHosts: true, maxEvents });
+}
+
+function nativeSession(journal: RuntimeJournal, turn: { activeTurnId: string | null } = { activeTurnId: "active-a" }): void {
+  journal.append({ scope: `session:${conversationId}`, kind: "session-status", payload: {
+    conversationId, sessionKey: { engine: "codex", sessionId: binding.threadId }, hostKind: "codex-app-server",
+    host: "hosted", turn: turn.activeTurnId ? "running" : "idle", activeTurnId: turn.activeTurnId, accountId: binding.accountId,
+    capabilities: { steer: true, structuredAttention: true, nativeQueue: true },
+  } });
+}
+
+/** Unrelated traffic that pushes the compaction anchor past every operation row. */
+function churn(journal: RuntimeJournal, count = MAX_EVENTS * 3): void {
+  for (let index = 0; index < count; index++) {
+    journal.append({ scope: `session:churn-${index}`, kind: "session-status", payload: { host: "hosted", turn: "idle" } });
+  }
+}
+
+/** The residue a journal compacted BEFORE this fix left behind: the entry, and no operation. */
+function compactedBeforeHolds(filename: string, operationId: string): void {
+  const db = new Database(filename);
+  db.query("DELETE FROM operations WHERE operation_id = ?").run(operationId);
+  db.query("DELETE FROM entities WHERE kind = 'operation' AND id = ?").run(operationId);
+  db.query("DELETE FROM outbox WHERE id = ?").run(`effect:${operationId}`);
+  db.close();
+}
+
+function rawEntry(journal: RuntimeJournal, entryId: string): string {
+  return JSON.stringify(journal.nativeQueueRead(conversationId).find(row => row.entryId === entryId) ?? null);
+}
+
+function tailSeq(filename: string): number {
+  const db = new Database(filename, { readonly: true });
+  const seq = Number(db.query<{ value: string }, []>("SELECT value FROM journal_meta WHERE key = 'seq'").get()!.value);
+  db.close();
+  return seq;
+}
+
+function eventsAfter(filename: string, seq: number): Array<{ kind: string; scope: string; payload: unknown }> {
+  const db = new Database(filename, { readonly: true });
+  const rows = db.query<{ kind: string; scope: string; payload_json: string }, [number]>("SELECT kind, scope, payload_json FROM events WHERE seq > ? ORDER BY seq").all(seq);
+  db.close();
+  return rows.map(row => ({ kind: row.kind, scope: row.scope, payload: JSON.parse(row.payload_json) }));
+}
+
+function holds(filename: string): string[] {
+  const db = new Database(filename, { readonly: true });
+  const rows = db.query<{ operation_id: string }, []>("SELECT operation_id FROM native_queue_operation_holds ORDER BY operation_id").all();
+  db.close();
+  return rows.map(row => row.operation_id);
+}
+
+function harness(journal: RuntimeJournal) {
+  const writes: string[] = [];
+  let items: NativeQueuedSubmission[] = [];
+  let next = 0;
+  let active: string | null = "active-a";
+  let liveBinding = binding;
+  let loseNextReply = false;
+  let evidence: () => Promise<NativeQueueProof | null> = async () => null;
+  const queue = new NativeCodexQueue({ rpc: async (method, params) => {
+    if (method === "thread/queue/list") return { data: items, nextCursor: null };
+    writes.push(method);
+    const lose = loseNextReply;
+    loseNextReply = false;
+    let result: unknown;
+    if (method === "thread/queue/add") {
+      const queuedSubmission = { id: `native-${++next}`, clientUserMessageId: params.clientUserMessageId as string, input: params.input as NativeQueuedSubmission["input"] };
+      items.push(queuedSubmission);
+      result = { queuedSubmission };
+    } else if (method === "thread/queue/update") {
+      const item = items.find(row => row.id === params.queuedSubmissionId)!;
+      item.input = params.input as NativeQueuedSubmission["input"];
+      result = { queuedSubmission: item };
+    } else if (method === "thread/queue/delete") {
+      items = items.filter(row => row.id !== params.queuedSubmissionId);
+      result = { deleted: true };
+    } else if (method === "thread/queue/start") {
+      items = items.filter(row => row.id !== params.queuedSubmissionId);
+      result = { turn: { id: "started-turn", items: [], status: "inProgress" } };
+    } else throw new NativeQueueProtocolRefusal(-1, `unexpected native write ${method}`);
+    if (lose) throw new Error("lost native reply");
+    return result;
+  } }, binding.threadId);
+  const client = {
+    command: async (command: NativeQueueCommand) => journal.executeOperation(command),
+    operationStatus: async (id: string) => journal.operationResult(id),
+    nativeQueueRead: async (id: string) => journal.nativeQueueRead(id),
+    nativeQueueTransition: async (id: string, transition: Parameters<RuntimeJournal["nativeQueueTransition"]>[1]) => journal.nativeQueueTransition(id, transition),
+    nativeQueueSettleCompacted: async (request: Parameters<RuntimeJournal["nativeQueueSettleCompacted"]>[0]) => journal.nativeQueueSettleCompacted(request),
+  } as RuntimeHostClient;
+  const host = {
+    health: async () => ({ status: active ? "active" : "idle", activeTurnRef: active }),
+    nativeQueue: {
+      queue,
+      prepare: async (_entry: NativeQueueRecord, version: NativeQueueRecord["versions"][number]) => [{ type: "text" as const, text: `${version.text} v${version.revision}` }],
+      evidence: async () => evidence(),
+      sendWithdrawn: async () => { throw new Error("no withdrawn send in this fixture"); },
+    },
+  } as unknown as EngineHost;
+  const settled: NativeQueueRecord[] = [];
+  const executor = new NativeQueueExecutor({ client, resolveHost: () => host, binding: () => liveBinding, settled: entry => { settled.push(entry); } });
+  const proofFor = (entryId: string, change: Partial<NativeQueueProof> = {}): NativeQueueProof => {
+    const entry = journal.nativeQueueRead(conversationId).find(row => row.entryId === entryId)!;
+    const version = entry.versions.find(row => row.revision === (entry.dispatchedRevision ?? entry.revision))!;
+    return { threadId: binding.threadId, clientUserMessageId: entry.clientUserMessageId, revision: version.revision,
+      turnId: entry.dispatchedTurnId ?? "canonical-turn", itemId: `item-${entryId}`, input: version.input!, ...change };
+  };
+  return {
+    executor, client, writes, settled, proofFor,
+    get items() { return items; },
+    loseNextReply() { loseNextReply = true; },
+    idle() { active = null; nativeSession(journal, { activeTurnId: null }); },
+    switchAccount() { liveBinding = { ...binding, accountId: "account-b" }; },
+    /** Canonical history as the host reader would answer it, per entry. */
+    canonical(answer: (entry: NativeQueueRecord) => NativeQueueProof | null | Promise<NativeQueueProof | null>) {
+      evidence = async () => null;
+      (host.nativeQueue as { evidence: (entry: NativeQueueRecord) => Promise<NativeQueueProof | null> }).evidence = async entry => answer(entry);
+    },
+  };
+}
+
+function nativeEffect(journal: RuntimeJournal, operationId: string): NativeQueueCommand & { operationId: string } {
+  const effect = journal.effectBatch(100, ["runtime.native-queue"]).find(row => row.id === `effect:${operationId}`);
+  if (!effect) throw new Error(`no native effect for ${operationId}`);
+  return effect.payload as unknown as NativeQueueCommand & { operationId: string };
+}
+
+function mappedSend(id: string, text = `message ${id}`) {
+  return parseRuntimeCommand("send", { conversationId, operationId: id, idempotencyKey: `key-${id}`, text, policy: "queue" });
+}
+
+function nativeCommand(id: string, extra: Partial<NativeQueueCommand> = {}): NativeQueueCommand & { operationId: string } {
+  return parseRuntimeCommand("native-queue", { kind: "native-queue", conversationId, operationId: id, idempotencyKey: `key-${id}`,
+    action: "add", text: `native ${id}`, binding, ...extra }) as NativeQueueCommand & { operationId: string };
+}
+
+test("an ordinary queued send mapped to native keeps its operation through compaction and restart, then converges on canonical proof", async () => {
+  const filename = journalFile();
+  let journal = open(filename);
+  nativeSession(journal);
+  journal.executeOperation(mappedSend("op-mapped"));
+  await harness(journal).executor.execute(nativeEffect(journal, "op-mapped"));
+  expect(journal.operationResult("op-mapped")?.receipt.status).toBe("queued");
+
+  churn(journal);
+  journal.close();
+  journal = open(filename);
+  churn(journal);
+
+  expect(journal.operationResult("op-mapped")?.receipt).toMatchObject({ kind: "send", status: "queued" });
+  // The original key still replays its stored receipt; nothing is admitted again.
+  const replay = journal.executeOperation(mappedSend("op-mapped"));
+  expect(replay).toMatchObject({ operationId: "op-mapped", replayed: true });
+  expect(journal.effectBatch(100)).toEqual([]);
+  expect(() => journal.retryOperation("op-mapped")).toThrow("native queue");
+  expect(() => journal.claimDeliveryAction("op-mapped", "discard")).toThrow("native queue");
+
+  const h = harness(journal);
+  h.canonical(entry => h.proofFor(entry.entryId));
+  expect(await h.executor.reconcile(conversationId)).toBeFalse();
+  expect(journal.nativeQueueRead(conversationId)[0]).toMatchObject({ entryId: "op-mapped", state: "delivered", mutationOperationId: null });
+  expect(journal.operationResult("op-mapped")?.receipt.status).toBe("delivered");
+  expect(h.settled.map(entry => entry.entryId)).toEqual(["op-mapped"]);
+  expect(h.writes).toEqual([]);
+
+  // Settled, the entry holds nothing, and its operation compacts like any other.
+  expect(holds(filename)).toEqual([]);
+  churn(journal);
+  expect(journal.operationResult("op-mapped")).toBeNull();
+  journal.close();
+});
+
+test("every unsettled state holds exactly the ids it still answers through, across restart", async () => {
+  const filename = journalFile();
+  let journal = open(filename);
+  nativeSession(journal);
+  const h = harness(journal);
+  // Queued explicit add: its receipt is `applied` long before any delivery.
+  const queued = nativeCommand("op-queued");
+  journal.executeOperation(queued); await h.executor.execute(queued);
+  // Uncertain add: native accepted it but the reply was lost.
+  const lost = nativeCommand("op-lost");
+  journal.executeOperation(lost); h.loseNextReply(); await h.executor.execute(lost);
+  // An edit whose reply was lost: the add is queued, the edit is the unresolved fence.
+  const edited = nativeCommand("op-edited");
+  journal.executeOperation(edited); await h.executor.execute(edited);
+  const edit = nativeCommand("op-edit-leaf", { action: "update", entryId: "op-edited", expectedRevision: 1, text: "edited words" });
+  journal.executeOperation(edit); h.loseNextReply(); await h.executor.execute(edit);
+  // Dispatching: native started it, delivery not yet seen.
+  const started = nativeCommand("op-started");
+  journal.executeOperation(started); await h.executor.execute(started);
+  h.idle();
+  const start = nativeCommand("op-start-leaf", { action: "start", entryId: "op-started", expectedRevision: 1, turnId: null });
+  journal.executeOperation(start); await h.executor.execute(start);
+
+  expect(journal.nativeQueueRead(conversationId).map(entry => [entry.entryId, entry.state, entry.mutationOperationId])).toEqual([
+    ["op-queued", "queued", null],
+    ["op-lost", "uncertain", "op-lost"],
+    ["op-edited", "uncertain", "op-edit-leaf"],
+    ["op-started", "dispatching", null],
+  ]);
+  expect(holds(filename)).toEqual(["op-edit-leaf", "op-edited", "op-lost", "op-queued", "op-started"]);
+
+  churn(journal);
+  journal.close();
+  journal = open(filename);
+  churn(journal);
+
+  const statuses = Object.fromEntries(["op-queued", "op-lost", "op-edited", "op-edit-leaf", "op-started", "op-start-leaf"]
+    .map(id => [id, journal.operationResult(id)?.receipt.status ?? null]));
+  expect(statuses).toEqual({
+    "op-queued": "applied", "op-lost": "uncertain", "op-edited": "applied", "op-edit-leaf": "uncertain",
+    "op-started": "applied",
+    // Answered, and no entry answers through it any more.
+    "op-start-leaf": null,
+  });
+
+  const next = harness(journal);
+  // The lost edit is observed in native's own queue and resolves through its own id.
+  (next.items as NativeQueuedSubmission[]).push(...h.items);
+  next.canonical(entry => entry.entryId === "op-edited" || entry.entryId === "op-queued" ? null : next.proofFor(entry.entryId));
+  await next.executor.reconcile(conversationId);
+  const after = Object.fromEntries(journal.nativeQueueRead(conversationId).map(entry => [entry.entryId, [entry.state, entry.mutationOperationId]]));
+  expect(after).toEqual({
+    "op-queued": ["queued", null],
+    "op-lost": ["delivered", null],
+    "op-edited": ["queued", null],
+    "op-started": ["delivered", null],
+  });
+  expect(journal.operationResult("op-edit-leaf")?.receipt.status).toBe("applied");
+  expect(journal.operationResult("op-lost")?.receipt.status).toBe("delivered");
+  expect(journal.operationResult("op-started")?.receipt.status).toBe("delivered");
+  expect(next.writes).toEqual([]);
+  expect(holds(filename)).toEqual(["op-edited", "op-queued"]);
+  journal.close();
+});
+
+test("a settled entry's original key cannot admit it again after compaction", async () => {
+  const filename = journalFile();
+  const journal = open(filename);
+  nativeSession(journal);
+  const h = harness(journal);
+  journal.executeOperation(mappedSend("op-done"));
+  await h.executor.execute(nativeEffect(journal, "op-done"));
+  h.canonical(entry => h.proofFor(entry.entryId));
+  await h.executor.reconcile(conversationId);
+  const add = nativeCommand("op-explicit-done");
+  journal.executeOperation(add); await h.executor.execute(add);
+  await h.executor.reconcile(conversationId);
+  churn(journal);
+  expect(journal.operationResult("op-done")).toBeNull();
+  expect(journal.operationResult("op-explicit-done")).toBeNull();
+  const before = [rawEntry(journal, "op-done"), rawEntry(journal, "op-explicit-done")];
+
+  expect(() => journal.executeOperation(mappedSend("op-done"))).toThrow("retained native queue entry");
+  expect(() => journal.executeOperation(add)).toThrow("retained native queue entry");
+  // Even with native no longer advertised, the id is not a fresh ordinary send.
+  nativeSession(journal, { activeTurnId: null });
+  journal.append({ scope: `session:${conversationId}`, kind: "session-status", payload: {
+    conversationId, sessionKey: { engine: "codex", sessionId: binding.threadId }, hostKind: "codex-app-server",
+    host: "hosted", turn: "idle", activeTurnId: null, accountId: binding.accountId, capabilities: { steer: true, structuredAttention: true },
+  } });
+  expect(() => journal.executeOperation(mappedSend("op-done"))).toThrow("retained native queue entry");
+
+  expect([rawEntry(journal, "op-done"), rawEntry(journal, "op-explicit-done")]).toEqual(before);
+  expect(journal.operationResult("op-done")).toBeNull();
+  expect(journal.effectBatch(100)).toEqual([]);
+  expect(h.writes).toEqual(["thread/queue/add", "thread/queue/add"]);
+  journal.close();
+});
+
+test("a removed entry whose add was compacted no longer wedges the conversation's reconciliation", async () => {
+  const filename = journalFile();
+  const journal = open(filename);
+  nativeSession(journal);
+  const h = harness(journal);
+  const removed = nativeCommand("op-removed");
+  journal.executeOperation(removed); await h.executor.execute(removed);
+  const remove = nativeCommand("op-remove-leaf", { action: "delete", entryId: "op-removed", expectedRevision: 1 });
+  journal.executeOperation(remove); await h.executor.execute(remove);
+  expect(journal.operationResult("op-removed")?.receipt).toMatchObject({ status: "failed", reason: "delivery-discarded" });
+  const waiting = nativeCommand("op-waiting");
+  journal.executeOperation(waiting); await h.executor.execute(waiting);
+  churn(journal);
+  expect(journal.operationResult("op-removed")).toBeNull();
+  expect(journal.operationResult("op-waiting")?.receipt.status).toBe("applied");
+
+  h.canonical(entry => h.proofFor(entry.entryId));
+  h.settled.length = 0;
+  await h.executor.reconcile(conversationId);
+  expect(journal.nativeQueueRead(conversationId).map(entry => [entry.entryId, entry.state])).toEqual([["op-removed", "removed"], ["op-waiting", "delivered"]]);
+  expect(h.settled.map(entry => [entry.entryId, entry.state])).toEqual([["op-removed", "removed"], ["op-waiting", "delivered"]]);
+  journal.close();
+});
+
+test("historical compacted entry settles on exact canonical proof alone, with no operation, effect or engine write", async () => {
+  const filename = journalFile();
+  let journal = open(filename);
+  nativeSession(journal);
+  journal.executeOperation(mappedSend("op-historical", "the original words"));
+  await harness(journal).executor.execute(nativeEffect(journal, "op-historical"));
+  churn(journal);
+  journal.close();
+  compactedBeforeHolds(filename, "op-historical");
+  journal = open(filename);
+  expect(journal.operationResult("op-historical")).toBeNull();
+  expect(journal.nativeQueueRead(conversationId)[0]).toMatchObject({ state: "queued", proof: null, mutationOperationId: null, nativeSubmissionId: "native-1" });
+  const seqBefore = tailSeq(filename);
+
+  const h = harness(journal);
+  h.canonical(entry => h.proofFor(entry.entryId));
+  expect(await h.executor.reconcile(conversationId)).toBeFalse();
+
+  const entry = journal.nativeQueueRead(conversationId)[0]!;
+  expect(entry).toMatchObject({ entryId: "op-historical", state: "delivered", mutationOperationId: null, dispatchedRevision: 1,
+    proof: { clientUserMessageId: "op-historical", threadId: binding.threadId, revision: 1 } });
+  expect(journal.operationResult("op-historical")).toBeNull();
+  expect(journal.effectBatch(100)).toEqual([]);
+  expect(h.writes).toEqual([]);
+  expect(h.settled.map(row => [row.entryId, row.state])).toEqual([["op-historical", "delivered"]]);
+  const appended = eventsAfter(filename, seqBefore);
+  expect(appended.map(event => [event.kind, event.scope])).toEqual([["native-queue-changed", `session:${conversationId}`]]);
+  expect(appended[0]!.payload).toEqual({ conversationId, threadId: binding.threadId, entryId: "op-historical", settledBy: "canonical-proof" });
+
+  // The same proof replays without another write; the entry still owns its id.
+  const replay = journal.nativeQueueSettleCompacted({ conversationId, entryId: "op-historical", binding, proof: entry.proof! });
+  expect(replay).toMatchObject({ operation: "compacted", replayed: true });
+  expect(eventsAfter(filename, seqBefore)).toHaveLength(1);
+  expect(() => journal.nativeQueueSettleCompacted({ conversationId, entryId: "op-historical", binding, proof: { ...entry.proof!, itemId: "other-item" } })).toThrow("proof conflict");
+  expect(() => journal.executeOperation(mappedSend("op-historical", "the original words"))).toThrow("retained native queue entry");
+  expect(() => journal.retryOperation("op-historical")).toThrow("unknown");
+  expect(() => journal.retryOperation("op-historical", "fresh-key")).toThrow("unknown");
+  expect(() => journal.claimDeliveryAction("op-historical", "retry")).toThrow("unknown");
+  journal.close();
+});
+
+test("absent, unreadable, foreign, conflicting and partial evidence leave a historical entry exactly as it was", async () => {
+  const filename = journalFile();
+  let journal = open(filename);
+  nativeSession(journal);
+  const setup = harness(journal);
+  journal.executeOperation(mappedSend("op-held", "held words"));
+  await setup.executor.execute(nativeEffect(journal, "op-held"));
+  // An edit that landed: proof must name revision 2, never the superseded words.
+  const edit = nativeCommand("op-held-edit", { action: "update", entryId: "op-held", expectedRevision: 1, text: "held words, edited" });
+  journal.executeOperation(edit); await setup.executor.execute(edit);
+  churn(journal);
+  journal.close();
+  compactedBeforeHolds(filename, "op-held");
+  journal = open(filename);
+  const original = rawEntry(journal, "op-held");
+  const h = harness(journal);
+  const exact = h.proofFor("op-held");
+  expect(exact.revision).toBe(2);
+
+  const cases: Array<[string, (entry: NativeQueueRecord) => NativeQueueProof | null | Promise<NativeQueueProof | null>]> = [
+    ["absent", () => null],
+    ["foreign thread", () => ({ ...exact, threadId: "another-thread" })],
+    ["foreign client identity", () => ({ ...exact, clientUserMessageId: "another-operation" })],
+    ["conflicting input", () => ({ ...exact, input: [{ type: "text", text: "held words, edited v2 and more" }] })],
+    ["superseded version", entry => ({ ...exact, revision: 1, input: entry.versions[0]!.input! })],
+    ["partial item", () => ({ ...exact, itemId: "" })],
+    ["partial turn", () => ({ ...exact, turnId: "" })],
+  ];
+  for (const [name, answer] of cases) {
+    h.canonical(answer);
+    expect(await h.executor.reconcile(conversationId), name).toBeTrue();
+    expect(rawEntry(journal, "op-held"), name).toBe(original);
+  }
+  h.canonical(() => { throw new Error("history unreadable"); });
+  await expect(h.executor.reconcile(conversationId)).rejects.toThrow("unreadable");
+  expect(rawEntry(journal, "op-held")).toBe(original);
+
+  // An account switch leaves the entry to its own binding.
+  h.canonical(() => exact);
+  h.switchAccount();
+  expect(await h.executor.reconcile(conversationId)).toBeFalse();
+  expect(rawEntry(journal, "op-held")).toBe(original);
+
+  // Direct callers are held to the same identity.
+  const direct = (change: Partial<Parameters<RuntimeJournal["nativeQueueSettleCompacted"]>[0]>) =>
+    () => journal.nativeQueueSettleCompacted({ conversationId, entryId: "op-held", binding, proof: exact, ...change });
+  expect(direct({ conversationId: "conversation_other" })).toThrow("ownership changed");
+  expect(direct({ binding: { ...binding, accountId: "account-b" } })).toThrow("ownership changed");
+  expect(direct({ binding: { ...binding, threadId: "another-thread" } })).toThrow("ownership changed");
+  expect(direct({ entryId: "op-held-edit" })).toThrow("entry is unknown");
+  expect(rawEntry(journal, "op-held")).toBe(original);
+  expect(journal.effectBatch(100)).toEqual([]);
+  expect(h.writes).toEqual([]);
+  expect(h.settled).toEqual([]);
+
+  // The same entry with exact evidence then converges.
+  const exactly = harness(journal);
+  exactly.canonical(() => exact);
+  expect(await exactly.executor.reconcile(conversationId)).toBeFalse();
+  expect(journal.nativeQueueRead(conversationId)[0]).toMatchObject({ state: "delivered", dispatchedRevision: 2 });
+  journal.close();
+});
+
+test("evidence-only settlement never crosses a discard, a refusal, a withdrawal, an unresolved mutation or a live operation", async () => {
+  const filename = journalFile();
+  let journal = open(filename);
+  nativeSession(journal);
+  const h = harness(journal);
+  const ids = ["op-x-removed", "op-x-refused", "op-x-fenced", "op-x-live"];
+  for (const id of ids) {
+    const add = nativeCommand(id);
+    journal.executeOperation(add);
+    if (id === "op-x-refused") await h.executor.execute(add, "native refused this add");
+    else await h.executor.execute(add);
+  }
+  const remove = nativeCommand("op-x-remove-leaf", { action: "delete", entryId: "op-x-removed", expectedRevision: 1 });
+  journal.executeOperation(remove); await h.executor.execute(remove);
+  const fence = nativeCommand("op-x-fence-leaf", { action: "update", entryId: "op-x-fenced", expectedRevision: 1, text: "fenced edit" });
+  journal.executeOperation(fence); h.loseNextReply(); await h.executor.execute(fence);
+  churn(journal);
+  journal.close();
+  for (const id of ["op-x-removed", "op-x-refused", "op-x-fenced"]) compactedBeforeHolds(filename, id);
+  journal = open(filename);
+  const before = Object.fromEntries(ids.map(id => [id, rawEntry(journal, id)]));
+  const settle = (id: string, revision = 1) => () => journal.nativeQueueSettleCompacted({ conversationId, entryId: id, binding,
+    proof: { threadId: binding.threadId, clientUserMessageId: id, revision, turnId: "turn", itemId: "item",
+      input: journal.nativeQueueRead(conversationId).find(row => row.entryId === id)!.versions.find(version => version.revision === revision)!.input! } });
+  expect(settle("op-x-removed")).toThrow("not awaiting canonical proof");
+  expect(settle("op-x-refused")).toThrow();
+  expect(settle("op-x-fenced", 2)).toThrow("unresolved mutation");
+  expect(settle("op-x-live")).toThrow("operation is retained");
+  expect(Object.fromEntries(ids.map(id => [id, rawEntry(journal, id)]))).toEqual(before);
+  expect(journal.operationResult("op-x-fence-leaf")?.receipt.status).toBe("uncertain");
+  journal.close();
+});
+
+test("holds stay bounded by the unsettled-entry admission cap, and a pre-hold journal gains them on open", async () => {
+  const filename = journalFile();
+  // Seeded under a roomy budget so the seed itself is not 2 000 compactions.
+  let journal = open(filename, 1_000_000);
+  nativeSession(journal);
+  const settledCount = 300;
+  const unsettledCount = 2000;
+  const input = [{ type: "text" as const, text: "scale" }];
+  for (let index = 0; index < settledCount + unsettledCount; index++) {
+    const id = `op-scale-${String(index).padStart(5, "0")}`;
+    journal.executeOperation(nativeCommand(id, { text: "scale" }));
+    journal.nativeQueueTransition(id, { phase: "prepared", input });
+    journal.nativeQueueTransition(id, { phase: "acknowledged", nativeSubmissionId: `native-${id}` });
+    if (index < settledCount) {
+      journal.nativeQueueTransition(id, { phase: "proven", proof: { threadId: binding.threadId, clientUserMessageId: id, revision: 1, turnId: "t", itemId: `i-${id}`, input } });
+    }
+  }
+  expect(() => journal.executeOperation(nativeCommand("op-scale-over-cap", { text: "scale" }))).toThrow("admission bound exceeded");
+  journal.close();
+  journal = open(filename, 64);
+  const started = performance.now();
+  churn(journal, 256);
+  const churnMs = performance.now() - started;
+  expect(holds(filename)).toHaveLength(unsettledCount);
+  const count = (sql: string) => { const db = new Database(filename, { readonly: true }); const value = db.query<{ n: number }, []>(sql).get()!.n; db.close(); return value; };
+  expect(count("SELECT COUNT(*) AS n FROM operations")).toBe(unsettledCount);
+  // 256 compacting appends over 2000 held rows: the hold check is an indexed lookup, not an entry scan.
+  expect(churnMs).toBeLessThan(10_000);
+  journal.close();
+
+  // A journal compacted before holds existed: drop them, reopen, and they are rebuilt from the entries.
+  const db = new Database(filename);
+  db.exec("DROP TABLE native_queue_operation_holds");
+  db.close();
+  journal = open(filename, 64);
+  expect(holds(filename)).toHaveLength(unsettledCount);
+  churn(journal, 64);
+  expect(count("SELECT COUNT(*) AS n FROM operations")).toBe(unsettledCount);
+  journal.close();
+}, 120_000);
+
+test("the compacted-proof settlement crosses the production socket with its own answer shape", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "nqcs-"));
+  const filename = path.join(base, "journal.sqlite");
+  let journal = open(filename);
+  nativeSession(journal);
+  journal.executeOperation(mappedSend("op-socket"));
+  await harness(journal).executor.execute(nativeEffect(journal, "op-socket"));
+  journal.close();
+  compactedBeforeHolds(filename, "op-socket");
+  journal = open(filename);
+  const proof = harness(journal).proofFor("op-socket");
+  const socket = path.join(base, "host.sock");
+  const server = serveRuntimeHost(socket, new RuntimeHost(journal, undefined, undefined, true));
+  await once(server, "listening");
+  const client = new UnixRuntimeHostClient(socket);
+  try {
+    await expect(client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof: { ...proof, input: "text" as never } })).rejects.toThrow("compacted proof is invalid");
+    await expect(client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding: { threadId: binding.threadId } as never, proof })).rejects.toThrow("compacted proof is invalid");
+    const settled = await client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof });
+    expect(settled).toMatchObject({ operation: "compacted", replayed: false, entry: { entryId: "op-socket", state: "delivered", proof } });
+    expect(settled).not.toHaveProperty("receipt");
+    expect(await client.operationStatus("op-socket")).toBeNull();
+    expect((await client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof })).replayed).toBeTrue();
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    journal.close();
+  }
+});

--- a/src/runtime-host/nativeQueueCompaction.test.ts
+++ b/src/runtime-host/nativeQueueCompaction.test.ts
@@ -266,6 +266,47 @@ test("every unsettled state holds exactly the ids it still answers through, acro
   journal.close();
 });
 
+test("an edit left unresolved when proof of the earlier version settles the entry keeps replaying under its original key through compaction and restart", async () => {
+  const filename = journalFile();
+  let journal = open(filename);
+  nativeSession(journal);
+  const h = harness(journal);
+  const add = nativeCommand("op-raced");
+  journal.executeOperation(add); await h.executor.execute(add);
+  const edit = nativeCommand("op-raced-edit", { action: "update", entryId: "op-raced", expectedRevision: 1, text: "raced words" });
+  journal.executeOperation(edit);
+  journal.nativeQueueTransition(edit.operationId, { phase: "prepared", input: [{ type: "text", text: "raced words v2" }] });
+  journal.nativeQueueTransition(edit.operationId, { phase: "uncertain", reason: "native reply lost while the turn started" });
+  // Canonical history shows revision 1 delivered; the edit's fate is still unknown.
+  journal.nativeQueueTransition(add.operationId, { phase: "proven", proof: { ...h.proofFor("op-raced"), revision: 1,
+    input: journal.nativeQueueRead(conversationId)[0]!.versions[0]!.input! } });
+  expect(journal.nativeQueueRead(conversationId)[0]).toMatchObject({ state: "delivered", mutationOperationId: "op-raced-edit", dispatchedRevision: 1 });
+  expect(holds(filename)).toEqual(["op-raced-edit"]);
+  const before = journal.executeOperation(edit);
+  expect(before).toMatchObject({ replayed: true, operationId: "op-raced-edit", receipt: { status: "uncertain" } });
+
+  churn(journal);
+  journal.close();
+  journal = open(filename);
+  churn(journal);
+
+  expect(holds(filename)).toEqual(["op-raced-edit"]);
+  expect(journal.operationResult("op-raced")).toBeNull();
+  expect(journal.executeOperation(edit)).toEqual({ ...before });
+  // The id stays a fence: no fresh key can edit the entry past its unresolved mutation.
+  expect(() => journal.executeOperation(nativeCommand("op-raced-edit-2", { action: "update", entryId: "op-raced", expectedRevision: 2, text: "again" }))).toThrow("frozen or unresolved");
+
+  // Once the edit answers, the entry holds nothing and compaction may take the row.
+  journal.nativeQueueTransition(edit.operationId, { phase: "observed-queued",
+    submission: { id: "native-1", clientUserMessageId: "op-raced", input: [{ type: "text", text: "raced words v2" }] } });
+  expect(journal.nativeQueueRead(conversationId)[0]).toMatchObject({ state: "delivered", mutationOperationId: null });
+  expect(holds(filename)).toEqual([]);
+  churn(journal);
+  expect(journal.operationResult("op-raced-edit")).toBeNull();
+  expect(h.writes).toEqual(["thread/queue/add"]);
+  journal.close();
+});
+
 test("a settled entry's original key cannot admit it again after compaction", async () => {
   const filename = journalFile();
   const journal = open(filename);
@@ -518,9 +559,42 @@ test("the compacted-proof settlement crosses the production socket with its own 
   await once(server, "listening");
   const client = new UnixRuntimeHostClient(socket);
   try {
-    await expect(client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof: { ...proof, input: "text" as never } })).rejects.toThrow("compacted proof is invalid");
+    const original = rawEntry(journal, "op-socket");
+    const seqBefore = tailSeq(filename);
+    const malformed: Array<[string, unknown]> = [
+      ["input", { ...proof, input: "text" }],
+      ["empty input", { ...proof, input: [] }],
+      ["turn id", { ...proof, turnId: 42 }],
+      ["item id", { ...proof, itemId: {} }],
+      ["turn and item ids", { ...proof, turnId: 42, itemId: {} }],
+      ["revision", { ...proof, revision: "1" }],
+      ["fractional revision", { ...proof, revision: 1.5 }],
+      ["thread id", { ...proof, threadId: null }],
+      ["client identity", { ...proof, clientUserMessageId: ["op-socket"] }],
+      ["proof", "proof"],
+    ];
+    for (const [name, candidate] of malformed) {
+      await expect(client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof: candidate as never }), name).rejects.toThrow("compacted proof is invalid");
+      // A caller that skips the socket reaches the same rule in the journal.
+      expect(() => journal.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof: candidate as never }), name).toThrow("proof is malformed");
+      expect(rawEntry(journal, "op-socket"), name).toBe(original);
+    }
     await expect(client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding: { threadId: binding.threadId } as never, proof })).rejects.toThrow("compacted proof is invalid");
-    const settled = await client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof });
+    expect(rawEntry(journal, "op-socket")).toBe(original);
+    expect(tailSeq(filename)).toBe(seqBefore);
+
+    // The operation path refuses the same identities before writing anything.
+    await client.command(nativeCommand("op-socket-live"));
+    await harness(journal).executor.execute(nativeCommand("op-socket-live"));
+    const live = rawEntry(journal, "op-socket-live");
+    const liveProof = harness(journal).proofFor("op-socket-live");
+    await expect(client.nativeQueueTransition("op-socket-live", { phase: "proven", proof: { ...liveProof, turnId: 42, itemId: {} } as never })).rejects.toThrow("proof is malformed");
+    expect(rawEntry(journal, "op-socket-live")).toBe(live);
+
+    // Fields beyond the proof's own are not persisted.
+    const settled = await client.nativeQueueSettleCompacted({ conversationId, entryId: "op-socket", binding, proof: { ...proof, note: "extra" } as never });
+    expect(settled.entry.proof).toEqual(proof);
+    expect(settled.replayed).toBeFalse();
     expect(settled).toMatchObject({ operation: "compacted", replayed: false, entry: { entryId: "op-socket", state: "delivered", proof } });
     expect(settled).not.toHaveProperty("receipt");
     expect(await client.operationStatus("op-socket")).toBeNull();

--- a/src/runtime-host/nativeQueueJournal.ts
+++ b/src/runtime-host/nativeQueueJournal.ts
@@ -2,7 +2,7 @@ import { nativeQueueInputMatches } from "@/lib/runtime/nativeQueueContent";
 import type { RuntimeOperationCommand } from "@/lib/runtime/contracts";
 import type { Database } from "bun:sqlite";
 import type { NativeQueueCommand, NativeQueueCompactedProof, NativeQueueProof, NativeQueueRecord, NativeQueueTransition, NativeQueueVersion } from "@/lib/runtime/nativeQueueContracts";
-import { sameNativeQueueBinding } from "@/lib/runtime/nativeQueueContracts";
+import { canonicalNativeQueueProof, sameNativeQueueBinding } from "@/lib/runtime/nativeQueueContracts";
 
 const SETTLED_STATES = ["delivered", "removed", "refused"] as const;
 
@@ -15,13 +15,15 @@ const SETTLED_STATES = ["delivered", "removed", "refused"] as const;
  * operation rows once their effect stops being `pending`, which native
  * admission reaches long before canonical delivery is seen, so these ids are
  * held explicitly.
- * A settled entry holds nothing: its answer is already recorded on the entry.
+ * A settled entry's add holds nothing, since its answer is recorded on the
+ * entry. Its unresolved mutation still does: canonical proof of an earlier
+ * version settles the entry while an edit that raced it stays uncertain, and
+ * that edit's original key must keep replaying its own receipt.
  */
 function heldOperationIds(entry: NativeQueueRecord): string[] {
-  if ((SETTLED_STATES as readonly string[]).includes(entry.state)) return [];
-  return entry.mutationOperationId && entry.mutationOperationId !== entry.entryId
-    ? [entry.entryId, entry.mutationOperationId]
-    : [entry.entryId];
+  const held = (SETTLED_STATES as readonly string[]).includes(entry.state) ? [] : [entry.entryId];
+  if (entry.mutationOperationId && entry.mutationOperationId !== entry.entryId) held.push(entry.mutationOperationId);
+  return held;
 }
 
 /**
@@ -47,15 +49,16 @@ export class NativeQueueJournal {
     CREATE TABLE IF NOT EXISTS native_queue_operation_holds (operation_id TEXT PRIMARY KEY, entry_id TEXT NOT NULL);
     CREATE INDEX IF NOT EXISTS native_queue_operation_holds_entry ON native_queue_operation_holds(entry_id);`);
     /* Rebuilt from the entries on every open, so a journal written before the
-       holds existed gains them before its first compaction. Bounded like the
-       entries it mirrors: at most two ids per unsettled entry, and admission
-       refuses a conversation's 2001st unsettled entry. */
+       holds existed gains them before its first compaction. Bounded by the
+       entries they mirror, which are never deleted: at most two ids per
+       unsettled entry (admission refuses a conversation's 2001st), and at most
+       one, its unresolved mutation, per settled entry. */
     db.exec(`BEGIN IMMEDIATE; DELETE FROM native_queue_operation_holds;
       INSERT OR IGNORE INTO native_queue_operation_holds(operation_id, entry_id)
         SELECT entry_id, entry_id FROM native_queue_entries WHERE json_extract(state_json, '$.state') NOT IN ('delivered', 'removed', 'refused');
       INSERT OR IGNORE INTO native_queue_operation_holds(operation_id, entry_id)
         SELECT json_extract(state_json, '$.mutationOperationId'), entry_id FROM native_queue_entries
-        WHERE json_extract(state_json, '$.state') NOT IN ('delivered', 'removed', 'refused') AND json_extract(state_json, '$.mutationOperationId') IS NOT NULL;
+        WHERE json_extract(state_json, '$.mutationOperationId') IS NOT NULL AND json_extract(state_json, '$.mutationOperationId') <> entry_id;
       COMMIT;`);
   }
 
@@ -100,7 +103,9 @@ export class NativeQueueJournal {
   }
 
   /** Canonical proof of one retained version; the same rule for every caller. */
-  private prove(entry: NativeQueueRecord, proof: NativeQueueProof): void {
+  private prove(entry: NativeQueueRecord, candidate: NativeQueueProof): void {
+    const proof = canonicalNativeQueueProof(candidate);
+    if (!proof) throw new Error("native queue canonical proof is malformed");
     const version = entry.versions.find(v => v.revision === proof.revision);
     if ((entry.dispatchedTurnId && proof.turnId !== entry.dispatchedTurnId) || !version?.input || proof.threadId !== entry.binding.threadId || proof.clientUserMessageId !== entry.clientUserMessageId
       || !proof.turnId || !proof.itemId || JSON.stringify(version.input) !== JSON.stringify(proof.input)) throw new Error("native queue canonical proof mismatch");
@@ -130,16 +135,18 @@ export class NativeQueueJournal {
     const entry = this.get(request.entryId);
     if (entry.entryId !== request.entryId || entry.clientUserMessageId !== entry.entryId) throw new Error("native queue entry is not an original add identity");
     if (entry.conversationId !== request.conversationId || !sameNativeQueueBinding(entry.binding, request.binding)) throw new Error("native queue entry ownership changed");
+    const proof = canonicalNativeQueueProof(request.proof);
+    if (!proof) throw new Error("native queue canonical proof is malformed");
     if (entry.proof) {
-      if (JSON.stringify(entry.proof) !== JSON.stringify(request.proof)) throw new Error("native queue canonical proof conflict");
+      if (JSON.stringify(entry.proof) !== JSON.stringify(proof)) throw new Error("native queue canonical proof conflict");
       return { entry, replayed: true };
     }
     if (entry.state !== "admitted" && entry.state !== "queued" && entry.state !== "dispatching" && entry.state !== "uncertain") {
       throw new Error("native queue entry is not awaiting canonical proof");
     }
     if (entry.mutationOperationId && entry.mutationOperationId !== entry.entryId) throw new Error("native queue entry has an unresolved mutation");
-    if (request.proof.revision !== (entry.dispatchedRevision ?? entry.revision)) throw new Error("native queue canonical proof names another version");
-    this.prove(entry, request.proof);
+    if (proof.revision !== (entry.dispatchedRevision ?? entry.revision)) throw new Error("native queue canonical proof names another version");
+    this.prove(entry, proof);
     this.save(entry);
     return { entry, replayed: false };
   }

--- a/src/runtime-host/nativeQueueJournal.ts
+++ b/src/runtime-host/nativeQueueJournal.ts
@@ -1,8 +1,28 @@
 import { nativeQueueInputMatches } from "@/lib/runtime/nativeQueueContent";
 import type { RuntimeOperationCommand } from "@/lib/runtime/contracts";
 import type { Database } from "bun:sqlite";
-import type { NativeQueueCommand, NativeQueueRecord, NativeQueueTransition, NativeQueueVersion } from "@/lib/runtime/nativeQueueContracts";
+import type { NativeQueueCommand, NativeQueueCompactedProof, NativeQueueProof, NativeQueueRecord, NativeQueueTransition, NativeQueueVersion } from "@/lib/runtime/nativeQueueContracts";
 import { sameNativeQueueBinding } from "@/lib/runtime/nativeQueueContracts";
+
+const SETTLED_STATES = ["delivered", "removed", "refused"] as const;
+
+/**
+ * The operation ids an entry still has to be answered through (#1664).
+ *
+ * An unsettled entry is proven, removed or refused through its add
+ * operation, and an unresolved edit/delete/start/send-now keeps its own
+ * mutation id as the fence nothing else may cross. Journal compaction drops
+ * operation rows once their effect stops being `pending`, which native
+ * admission reaches long before canonical delivery is seen, so these ids are
+ * held explicitly.
+ * A settled entry holds nothing: its answer is already recorded on the entry.
+ */
+function heldOperationIds(entry: NativeQueueRecord): string[] {
+  if ((SETTLED_STATES as readonly string[]).includes(entry.state)) return [];
+  return entry.mutationOperationId && entry.mutationOperationId !== entry.entryId
+    ? [entry.entryId, entry.mutationOperationId]
+    : [entry.entryId];
+}
 
 /**
  * Whether this command is about ONE entry of the journal's.
@@ -23,7 +43,25 @@ export class NativeQueueJournal {
   constructor(private readonly db: Database) {
     db.exec(`CREATE TABLE IF NOT EXISTS native_queue_entries (
       entry_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, state_json TEXT NOT NULL
-    ); CREATE INDEX IF NOT EXISTS native_queue_conversation ON native_queue_entries(conversation_id);`);
+    ); CREATE INDEX IF NOT EXISTS native_queue_conversation ON native_queue_entries(conversation_id);
+    CREATE TABLE IF NOT EXISTS native_queue_operation_holds (operation_id TEXT PRIMARY KEY, entry_id TEXT NOT NULL);
+    CREATE INDEX IF NOT EXISTS native_queue_operation_holds_entry ON native_queue_operation_holds(entry_id);`);
+    /* Rebuilt from the entries on every open, so a journal written before the
+       holds existed gains them before its first compaction. Bounded like the
+       entries it mirrors: at most two ids per unsettled entry, and admission
+       refuses a conversation's 2001st unsettled entry. */
+    db.exec(`BEGIN IMMEDIATE; DELETE FROM native_queue_operation_holds;
+      INSERT OR IGNORE INTO native_queue_operation_holds(operation_id, entry_id)
+        SELECT entry_id, entry_id FROM native_queue_entries WHERE json_extract(state_json, '$.state') NOT IN ('delivered', 'removed', 'refused');
+      INSERT OR IGNORE INTO native_queue_operation_holds(operation_id, entry_id)
+        SELECT json_extract(state_json, '$.mutationOperationId'), entry_id FROM native_queue_entries
+        WHERE json_extract(state_json, '$.state') NOT IN ('delivered', 'removed', 'refused') AND json_extract(state_json, '$.mutationOperationId') IS NOT NULL;
+      COMMIT;`);
+  }
+
+  /** True when this id names a retained entry, settled or not. */
+  retains(operationId: string): boolean {
+    return this.db.query<{ one: number }, [string]>("SELECT 1 AS one FROM native_queue_entries WHERE entry_id = ?").get(operationId) !== null;
   }
 
   read(conversationId: string): NativeQueueRecord[] {
@@ -55,6 +93,55 @@ export class NativeQueueJournal {
   private save(entry: NativeQueueRecord): void {
     this.db.query("INSERT INTO native_queue_entries VALUES (?, ?, ?) ON CONFLICT(entry_id) DO UPDATE SET state_json = excluded.state_json")
       .run(entry.entryId, entry.conversationId, JSON.stringify(entry));
+    this.db.query("DELETE FROM native_queue_operation_holds WHERE entry_id = ?").run(entry.entryId);
+    for (const operationId of heldOperationIds(entry)) {
+      this.db.query("INSERT OR IGNORE INTO native_queue_operation_holds(operation_id, entry_id) VALUES (?, ?)").run(operationId, entry.entryId);
+    }
+  }
+
+  /** Canonical proof of one retained version; the same rule for every caller. */
+  private prove(entry: NativeQueueRecord, proof: NativeQueueProof): void {
+    const version = entry.versions.find(v => v.revision === proof.revision);
+    if ((entry.dispatchedTurnId && proof.turnId !== entry.dispatchedTurnId) || !version?.input || proof.threadId !== entry.binding.threadId || proof.clientUserMessageId !== entry.clientUserMessageId
+      || !proof.turnId || !proof.itemId || JSON.stringify(version.input) !== JSON.stringify(proof.input)) throw new Error("native queue canonical proof mismatch");
+    if (entry.proof && JSON.stringify(entry.proof) !== JSON.stringify(proof)) throw new Error("native queue canonical proof conflict");
+    entry.proof = proof;
+    entry.dispatchedRevision = proof.revision;
+    entry.dispatchedTurnId = proof.turnId;
+    entry.state = "delivered";
+    if (entry.mutationOperationId === entry.entryId) entry.mutationOperationId = null;
+    // An in-flight edit/delete retains its own mutation identity until it answers.
+    entry.reason = null;
+  }
+
+  /**
+   * Settles an entry whose add operation journal compaction already removed
+   * (#1664), on canonical proof alone. Nothing executable is created: no
+   * operation, no effect, no key. The caller has already established that no
+   * operation row exists for `entryId`.
+   *
+   * Narrower than the operation path on purpose, because no receipt is left to
+   * cross-check against: the entry must be the add's own identity, awaiting
+   * proof, under the same conversation and binding, with no other mutation
+   * holding it, and the proof must name exactly the version it would dispatch.
+   * Anything else leaves the entry exactly as it was.
+   */
+  proveCompacted(request: NativeQueueCompactedProof): { entry: NativeQueueRecord; replayed: boolean } {
+    const entry = this.get(request.entryId);
+    if (entry.entryId !== request.entryId || entry.clientUserMessageId !== entry.entryId) throw new Error("native queue entry is not an original add identity");
+    if (entry.conversationId !== request.conversationId || !sameNativeQueueBinding(entry.binding, request.binding)) throw new Error("native queue entry ownership changed");
+    if (entry.proof) {
+      if (JSON.stringify(entry.proof) !== JSON.stringify(request.proof)) throw new Error("native queue canonical proof conflict");
+      return { entry, replayed: true };
+    }
+    if (entry.state !== "admitted" && entry.state !== "queued" && entry.state !== "dispatching" && entry.state !== "uncertain") {
+      throw new Error("native queue entry is not awaiting canonical proof");
+    }
+    if (entry.mutationOperationId && entry.mutationOperationId !== entry.entryId) throw new Error("native queue entry has an unresolved mutation");
+    if (request.proof.revision !== (entry.dispatchedRevision ?? entry.revision)) throw new Error("native queue canonical proof names another version");
+    this.prove(entry, request.proof);
+    this.save(entry);
+    return { entry, replayed: false };
   }
 
   admit(command: NativeQueueCommand, operationId: string): NativeQueueRecord | null {
@@ -108,18 +195,7 @@ export class NativeQueueJournal {
       return entry;
     }
     if (transition.phase === "proven") {
-      const proof = transition.proof;
-      const version = entry.versions.find(v => v.revision === proof.revision);
-      if ((entry.dispatchedTurnId && proof.turnId !== entry.dispatchedTurnId) || !version?.input || proof.threadId !== entry.binding.threadId || proof.clientUserMessageId !== entry.clientUserMessageId
-        || !proof.turnId || !proof.itemId || JSON.stringify(version.input) !== JSON.stringify(proof.input)) throw new Error("native queue canonical proof mismatch");
-      if (entry.proof && JSON.stringify(entry.proof) !== JSON.stringify(proof)) throw new Error("native queue canonical proof conflict");
-      entry.proof = proof;
-      entry.dispatchedRevision = proof.revision;
-      entry.dispatchedTurnId = proof.turnId;
-      entry.state = "delivered";
-      if (entry.mutationOperationId === entry.entryId) entry.mutationOperationId = null;
-      // An in-flight edit/delete retains its own mutation identity until it answers.
-      entry.reason = null;
+      this.prove(entry, transition.proof);
       this.save(entry);
       return entry;
     }


### PR DESCRIPTION
Closes #1664.

## What was wrong

`RuntimeJournal.compact()` deletes an operation row once its effect is no longer `pending`. A native queue add reaches that point when native acknowledges it, which is long before canonical delivery shows up. After enough journal traffic, a queued entry's add operation was gone, and `nativeQueueTransition(entryId, proven)` answered `runtime operation is unknown`. The entry could never converge, even once the history reader could see the delivered item.

An isolated journal reproduced this at the merge base, along with two other failures on the same path:

- **Replay of the original request after compaction re-admitted it.** The entry was reset to `admitted`, its native submission id was dropped, and a new operation row was minted. Once the stale producer receipt is swept, that becomes a second executable native add of the same input.
- **Reconciliation wedged on removed entries.** `reconcile()` asked for the `removed` transition on every retained removed entry whose add had been compacted, and that threw on every pass. No later entry of the conversation could settle.

## What changes

- **Unsettled entries hold their operation ids.** A new indexed table, `native_queue_operation_holds`, keeps the add id and any unresolved edit/delete/start/send-now id. It is maintained on every entry save and honoured by compaction. It is rebuilt from the entries on every journal open, so existing journals get holds before their next compaction. A settled entry (delivered, removed, refused) releases its add id, since its answer is on the entry, but keeps an unresolved mutation id: canonical proof of an earlier version can settle the entry while an edit that raced it is still uncertain, and that edit's original key has to keep replaying its receipt. The table is bounded by the entries, which are never deleted: two ids per unsettled entry (2000-unsettled-entry admission cap), one per settled entry with an unresolved mutation.
- **A retained entry's id cannot be re-admitted.** It is refused with an idempotency conflict, including when native is no longer advertised for the session.
- **An explicit evidence-only contract for entries that were already compacted.** `native-queue-settle-compacted` (`RuntimeJournal.nativeQueueSettleCompacted`, `RuntimeHostClient.nativeQueueSettleCompacted`) answers `NativeQueueCompactedSettlement { operation: "compacted", entry, replayed }`, not an operation receipt. It writes the entry and one `native-queue-changed` event. It never creates an operation, effect, key, delivery action or engine write. It is refused unless all of these hold:
  - the operation row is absent;
  - the entry is the original add identity (`clientUserMessageId === entryId`);
  - conversation and binding are the same;
  - the entry is awaiting proof;
  - no other mutation holds the entry;
  - the proof names exactly the version it would dispatch, with identical input and a full turn/item identity.
  - the proof is well formed: non-empty string thread, client, turn and item ids, a positive integer revision and a non-empty input list. Only those fields are stored. The operation path's `proven` transition applies the same rule, so a malformed identity is refused on either path before anything is written.
  - A repeat of the same proof replays; a different proof conflicts.
- **The executor routes each proof.** It goes through the retained operation when that exists, otherwise through the contract above, and only from the host whose native reader is bound to the entry's thread. One refused entry no longer blocks the rest.

The registry side is unchanged: the controller's existing `settled` port records `delivered` for the entry's original operation id. A non-absorbing `failed`/unverified reservation becomes `delivered`, and an operator discard or migration cancellation stays as it is.

## Verification

Everything ran under the Dockerfile-pinned Bun 1.4.0, with fully isolated HOME/XDG/LLV state and no runtime-host socket. Files were run by path, one per invocation.

- `src/runtime-host/nativeQueueCompaction.test.ts` (new, 10 tests): real on-disk journal with a 12-event budget, compaction and restart.
  - Covers ordinary sends mapped to native and explicit native adds; queued, uncertain, edit-leaf and dispatching states; original-key replay; settled-entry replay refusal; the removed-entry wedge; and an edit left uncertain when proof of the earlier version settles the entry, whose original key still replays its `uncertain` receipt after compaction and restart and whose hold is released once it answers.
  - Historical evidence-only settlement, checked for no operation, no effect and no native write.
  - Negative controls, each leaving the entry byte-identical: absent, unreadable, foreign thread, client id, account, conversation; conflicting input or version; partial turn or item; removed, refused, fenced-mutation and live-operation entries.
  - Scale at the admission cap: 2000 held and 300 settled entries. 256 compacting appends take about 0.65 s; seeding takes about 22 s, which is the existing per-admission read, not the holds. Holds are rebuilt after being dropped.
  - Socket round-trip with invalid-parameter rejection: non-string turn/item ids, a string or fractional revision, a null thread id, an array client id, an empty or non-array input and a non-object proof each leave the entry byte-identical and append no event, on the socket and directly on the journal. A malformed `proven` transition over the socket is refused the same way, and fields beyond the proof's own are not persisted.
- `src/lib/runtime/nativeQueueCompaction.integration.test.ts` (new):
  - With the real `AgentRegistry`: `holdDelivery` → `beginDeliveryAttempt` → `terminalizeHeldDelivery` gives the production `failed`/unverified reservation. Canonical proof turns it `delivered` (owner disposition `delivered`). An operator-discarded reservation stays discarded, and an entry absent from history stays unchanged.
  - With **real Codex 0.154**: native dispatches one entry itself while another waits behind the running turn. Both operation rows are then removed, which is the pre-fix residue. Hidden history leaves both unchanged. Visible history settles the dispatched entry and its registry reservation. The waiting entry stays queued in native and in the journal. No `thread/queue/*` or `turn/*` write happens after the residue.
- RED check: all 12 new tests fail on the merge-base sources, and pass at head. The two review probes (a delivered entry's uncertain edit replaying after compaction, and `turnId: 42` / `itemId: {}` over the real socket) fail on the previous head `0109aa29` and pass at head.
- Unchanged suites pass:
  - `nativeQueueRuntime` 26, `nativeQueueJournal` 1, `nativeQueueHost.integration` 3 with real Codex (the #1661 image, first-dispatch and history scenarios);
  - `codexAppServerHost` 138, `codexHistoryReader` 21 (+1 skip), `nativeCodexQueue` 55, `structuredDeliveryQueue` 68, `sendSettlement` 25;
  - `journal` 80, `journalCompact` 9, `journalRetention` 6, `journalSnapshotBounds` 1, `journalVacuum` 2, `receiptSweep` 4, `socket` 5;
  - `runtimeImageStore` 30, `structuredMessageDelivery.accountReseat` 25, `structuredDeliveryLegacyVerdict.integration` 1.
- CI job, run locally:
  - `scripts/verify-native-codex-runtime.ts` with Codex 0.154: 672 runtime tests across 31 files and 141 DOM tests pass, with no skips. The new files are added to its list, so the `bun-runtime` job runs them.
  - `scripts/verify-runtime-host.ts --runtime <bun 1.4.0>`: succession completed, and 27/27 answers came back on both the listener and the socket.
  - `scripts/bun-runtime-workflow.test.ts`: 5 tests pass.
- `tsc --noEmit` is clean. `privacy-publication-gate --check-commits` from the merge base passes.

## Notes

- Production rows are not touched by this change. They settle through ordinary reconciliation once a runtime host and Viewer carrying this change run. The historical rows still need to be validated after deploy.
- If the journal settles an entry and the process dies before the registry `settled` port runs, the reservation keeps its prior state. The existing `proven` path has the same ordering.
- A delivered entry's uncertain edit may never resolve, since native may already have consumed the queued item. Its operation row is then kept for as long as the entry is, at one row per such entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

