### PR TITLE
Group a task band's pipelines into enclosed sections and bound stage expansion (#1668)

### DIFF
--- a/src/components/pipelines/StageCompletedCard.tsx
+++ b/src/components/pipelines/StageCompletedCard.tsx
@@ -29,7 +29,16 @@ import {
  * difference from the eventual live conversation), the settled state/verdict, and
  * an affordance that opens the full transcript on demand.
  */
-export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?: () => void }) {
+export function StageCompletedCard({ slot, onOpen, disclosed }: { slot: StageSlot; onOpen?: () => void;
+  /** Rendered underneath its own {@link StageStatusRow} as that row's
+      disclosure (#1668). The row directly above already names the stage and
+      states how it ended, so repeating both here read as two cards for one
+      stage and pushed the transcript control to the bottom of a mostly blank
+      box. In this mode the card drops the duplicated heading and state badge and
+      adds only what the row cannot carry: the runtime, the verdict, and the
+      prompt that was actually sent — which scrolls, so the whole prompt is
+      still reachable inside a bounded surface. */
+  disclosed?: boolean }) {
   const { t } = useLocale();
   const { pipeline, stage, attempt } = slot;
   const state = stageChipState(pipeline, stage);
@@ -58,7 +67,7 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
       style={{ borderColor: tone.color }}
     >
       <span aria-hidden className="h-1 w-full shrink-0 opacity-60" style={{ backgroundColor: tint.color }} />
-      <header className="flex h-10 shrink-0 items-center gap-1.5 border-b border-border px-2.5" style={{ backgroundColor: tint.soft }}>
+      {disclosed ? null : <header className="flex h-10 shrink-0 items-center gap-1.5 border-b border-border px-2.5" style={{ backgroundColor: tint.soft }}>
         <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: tone.color }} title={t(`pipelineChipState.${state}`)} />
         <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-caption font-bold capitalize text-muted">
           {stage.effectiveRole.engine}
@@ -69,14 +78,26 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
         <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-caption font-bold uppercase tracking-wide text-muted">
           {review ? `⟳ ${t("groupOverride.reviewKind")}` : t("groupOverride.runKind")}
         </span>
-      </header>
+      </header>}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-3">
         <div className="mb-3 flex items-center justify-between gap-2">
-          <span className="flex items-center gap-1.5">
-            <span className="rounded-full px-3 py-1 text-body font-bold" style={{ backgroundColor: tone.soft, color: tone.color }}>
-              {attempt ? attemptStateLabel(t, attempt.state) : t(`pipelineChipState.${state}`)}
-            </span>
+          <span className="flex min-w-0 items-center gap-1.5">
+            {disclosed ? (
+              /* What the row above does NOT say: which engine and kind ran it. */
+              <>
+                <span className="shrink-0 rounded-full border border-border bg-card/70 px-2 py-0.5 text-caption font-bold capitalize text-muted">
+                  {stage.effectiveRole.engine}
+                </span>
+                <span className="shrink-0 rounded-full border border-border bg-card/70 px-2 py-0.5 text-caption font-bold uppercase tracking-wide text-muted">
+                  {review ? `⟳ ${t("groupOverride.reviewKind")}` : t("groupOverride.runKind")}
+                </span>
+              </>
+            ) : (
+              <span className="rounded-full px-3 py-1 text-body font-bold" style={{ backgroundColor: tone.soft, color: tone.color }}>
+                {attempt ? attemptStateLabel(t, attempt.state) : t(`pipelineChipState.${state}`)}
+              </span>
+            )}
             {verdict ? (
               <span
                 className="rounded-full px-2 py-1 text-label font-bold"
@@ -90,14 +111,19 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
             {modelLabel}{effort ? ` · ${effort}` : ""}
           </span>
         </div>
-        <div className="ml-auto max-w-[88%] min-h-0 overflow-hidden rounded-[14px] rounded-br-[4px] bg-accent/10 px-3 py-2.5 text-ui leading-5 text-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-accent)_18%,transparent)]">
+        <div
+          {...(disclosed ? { "data-pan-ignore": true } : {})}
+          className={`ml-auto max-w-[88%] min-h-0 rounded-[14px] rounded-br-[4px] bg-accent/10 px-3 py-2.5 text-ui leading-5 text-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-accent)_18%,transparent)] ${
+            disclosed ? "flex-1 overflow-y-auto" : "overflow-hidden"
+          }`}
+        >
           <p className="mb-1 text-caption font-bold uppercase tracking-wide text-accent">{t("pipelineSlot.promptLabel")}</p>
-          <p className="line-clamp-[12] whitespace-pre-wrap break-words">{promptPreview}</p>
+          <p className={disclosed ? "whitespace-pre-wrap break-words" : "line-clamp-[12] whitespace-pre-wrap break-words"}>{promptPreview}</p>
         </div>
         <button
           type="button"
           data-scheme-ui
-          className="mt-auto inline-flex h-8 items-center justify-center gap-1 self-center rounded-control border border-border bg-canvas px-3 text-label font-bold text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
+          className={`${disclosed ? "mt-3" : "mt-auto"} inline-flex h-8 shrink-0 items-center justify-center gap-1 self-center rounded-control border border-border bg-canvas px-3 text-label font-bold text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40`}
           disabled={!onOpen}
           onClick={() => onOpen?.()}
         >

--- a/src/components/pipelines/StageStatusRow.tsx
+++ b/src/components/pipelines/StageStatusRow.tsx
@@ -61,7 +61,14 @@ export function StageStatusRow({
           <span aria-hidden>{STAGE_GLYPH[state]}</span>
           {t(`pipelineChipState.${state}`)}
         </span>
-        <span className="order-first w-full min-w-0 truncate text-ui font-semibold text-secondary" title={title}>
+        {/* Two lines (#1668): a stage title is `role · stage-id · position`, and
+            cutting it at one line left several stages of one pipeline reading
+            identically. */}
+        <span
+          className="order-first w-full min-w-0 text-ui font-semibold leading-[18px] text-secondary"
+          style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+          title={title}
+        >
           {title}
         </span>
         {onToggle ? (
@@ -81,7 +88,13 @@ export function StageStatusRow({
           </button>
         ) : null}
       </div>
-      <p className="min-w-0 truncate text-label text-muted" title={reason}>
+      {/* The explanation the row exists for: a full sentence over two lines
+          rather than a truncated fragment. */}
+      <p
+        className="min-w-0 text-label leading-[15px] text-muted"
+        style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+        title={reason}
+      >
         {reason}
       </p>
     </section>

--- a/src/components/pipelines/pipelineModel.test.ts
+++ b/src/components/pipelines/pipelineModel.test.ts
@@ -1640,8 +1640,41 @@ describe("stage surface titles and settled rows (#658)", () => {
 
     const bare = pipeline({ stages, runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed" } as never] }] });
     expect(stageOutcomeReason(fakeT, bare, buildStage)).toBe("pipelineChipState.passed");
-    /* Attemptless: the chip state itself, so the row is never blank. */
-    expect(stageOutcomeReason(fakeT, pipeline({ stages }), buildStage)).toBe("pipelineChipState.pending");
+    /* Attemptless: never blank, and never the badge's own word repeated (#1668). */
+    expect(stageOutcomeReason(fakeT, pipeline({ stages }), buildStage)).toBe("pipelineSlot.reasonNotStarted");
+  });
+
+  /* #1668. A stage with no attempt used to explain itself with the single word
+     its own badge already showed — "pending" beside a `pending` chip — which
+     collapsed four different situations into one. Each of these says the stage
+     has NOT started, because none of them has; none of them may read as
+     progress or completion. */
+  test("a stage that never ran states what it is waiting for, never the badge's own word (#1668)", () => {
+    const later = stage("verify");
+    const stages = [buildStage, later];
+    const chain = (over: Partial<Pipeline>) => pipeline({ stages, ...over });
+
+    /* Queued behind the stage the cursor is on: named, with its position. */
+    const running = chain({ state: "running", cursor: { stageId: buildStage.id, state: "running", input: null, activatedBy: null } as never });
+    expect(stageOutcomeReason(fakeT, running, later))
+      .toBe(`pipelineSlot.reasonQueuedAfter:${JSON.stringify({ title: "roleCopy.builder.name", k: 1, n: 2 })}`);
+    /* The cursor stage itself is not waiting for anything — it is the work in
+       flight, and its live state is what the row must say. */
+    expect(stageOutcomeReason(fakeT, running, buildStage)).toBe("pipelineChipState.running");
+
+    /* Held, not merely later in the chain: these need the operator. */
+    expect(stageOutcomeReason(fakeT, chain({ state: "needs_decision" }), later)).toBe("pipelineSlot.reasonHeldDecision");
+    expect(stageOutcomeReason(fakeT, chain({ state: "paused", pausedState: "running" }), later)).toBe("pipelineSlot.reasonHeldPaused");
+    expect(stageOutcomeReason(fakeT, chain({ state: "draft" }), later)).toBe("pipelineSlot.reasonPlanned");
+
+    /* The chain is over and this stage has no attempt: it was never reached. */
+    for (const state of ["completed", "closed"] as const) {
+      expect(stageOutcomeReason(fakeT, chain({ state }), later)).toBe("pipelineSlot.reasonNeverRan");
+    }
+
+    /* A stage that DID run keeps reading from its own record, untouched. */
+    const ran = chain({ runs: [{ stageId: later.id, attempts: [{ n: 1, state: "passed", output: "green" } as never] }] });
+    expect(stageOutcomeReason(fakeT, ran, later)).toBe("green");
   });
 });
 

--- a/src/components/pipelines/pipelineModel.ts
+++ b/src/components/pipelines/pipelineModel.ts
@@ -861,7 +861,31 @@ export function stageOutcomeReason(
   if (output) return output;
   if (attempt?.verdict) return verdictStatusLabel(t, attempt.verdict.status);
   if (attempt) return attemptStateLabel(t, attempt.state);
-  return t(`pipelineChipState.${stageChipState(pipeline, stage)}`);
+  const state = stageChipState(pipeline, stage);
+  return state === "pending" ? stageNotStartedReason(t, pipeline, stage) : t(`pipelineChipState.${state}`);
+}
+
+/**
+ * Why a stage that has never run has not run (#1668). Repeating the badge's own
+ * word — a `pending` chip beside the line "pending" — told the operator nothing,
+ * and the two situations it collapsed are genuinely different: a stage queued
+ * behind the one the chain is on, and a stage nothing will reach until the
+ * operator answers. Both are stated as not started, because they are; this never
+ * describes unstarted work as finished, and it never claims a stage is blocked
+ * when it is merely later in the chain.
+ */
+export function stageNotStartedReason(t: TFunction, pipeline: Pipeline, stage: PipelineStage): string {
+  if (pipeline.state === "needs_decision") return t("pipelineSlot.reasonHeldDecision");
+  if (pipeline.state === "paused") return t("pipelineSlot.reasonHeldPaused");
+  if (pipeline.state === "draft") return t("pipelineSlot.reasonPlanned");
+  /* The chain is over and this stage has no attempt: it was never reached. */
+  if (pipeline.state === "completed" || pipeline.state === "closed") return t("pipelineSlot.reasonNeverRan");
+  const index = pipeline.stages.findIndex((entry) => entry.id === stage.id);
+  const cursorIndex = pipeline.cursor ? pipeline.stages.findIndex((entry) => entry.id === pipeline.cursor!.stageId) : -1;
+  const current = cursorIndex >= 0 && index > cursorIndex ? pipeline.stages[cursorIndex] : null;
+  return current
+    ? t("pipelineSlot.reasonQueuedAfter", { title: stageChipLabel(t, current), k: cursorIndex + 1, n: pipeline.stages.length })
+    : t("pipelineSlot.reasonNotStarted");
 }
 
 /* A cursorless pipeline rests on its last in-flight stage; the live attempt states

--- a/src/components/pipelines/stageCardAria.render.test.tsx
+++ b/src/components/pipelines/stageCardAria.render.test.tsx
@@ -3,8 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { StageSlot } from "@/components/scheme/layout";
 import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
+import { BOARD_SURFACE, stageDetailsCardHeight, stageSurface } from "@/components/scheme/boardPresentation";
 
 import { StageCompletedCard } from "./StageCompletedCard";
+import { StageStatusRow } from "./StageStatusRow";
 import { StagePlaceholderPane } from "./StagePlaceholderPane";
 
 /*
@@ -38,6 +40,11 @@ function slot(index: number, presentation: "placeholder" | "completed"): StageSl
 }
 
 const ariaLabels = (html: string) => [...html.matchAll(/aria-label="([^"]+)"/g)].map((match) => match[1]!);
+/** Rendered text only: attribute values (titles, accessible names) are not what
+    the operator sees twice. */
+const visible = (html: string) => html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ");
+/** The settled-state badge a stage card paints in its own tone. */
+const STATE_BADGE = 'style="background-color:var(--color-success-soft);color:var(--color-success)"';
 
 test("two same-role stages expose distinct accessible names on their cards", () => {
   const first = ariaLabels(renderToStaticMarkup(<StagePlaceholderPane slot={slot(0, "placeholder")} interactive={false} />));
@@ -49,4 +56,72 @@ test("two same-role stages expose distinct accessible names on their cards", () 
 test("a completed stage card names itself by role, stage and position too", () => {
   const html = renderToStaticMarkup(<StageCompletedCard slot={slot(0, "completed")} />);
   expect(ariaLabels(html)).toContain("Completed stage Builder · integrate_v3_voice · stage 1/2 — open to review");
+});
+
+/*
+ * #1668. Disclosed from its own status row, the card used to repeat the stage
+ * heading and the state badge the row was already showing — two cards for one
+ * stage — and push its transcript control to the bottom of a 620px box that was
+ * mostly blank. Disclosed, it carries only what the row cannot.
+ */
+test("a disclosed completed card repeats neither the row's heading nor its state badge (#1668)", () => {
+  const row = renderToStaticMarkup(<StageStatusRow slot={slot(0, "completed")} expanded />);
+  const disclosed = renderToStaticMarkup(<StageCompletedCard slot={slot(0, "completed")} disclosed />);
+  const standalone = renderToStaticMarkup(<StageCompletedCard slot={slot(0, "completed")} />);
+
+  /* The row is what names the stage and states how it ended. */
+  expect(visible(row)).toContain("Builder · integrate_v3_voice · stage 1/2");
+  expect(visible(row)).toContain("passed");
+  /* The disclosure repeats neither: no second heading, no second state badge.
+     The accessible name is NOT duplication — it is how the card is identified
+     when the row above it cannot be read. */
+  expect(visible(disclosed)).not.toContain("Builder · integrate_v3_voice · stage 1/2");
+  expect(disclosed).not.toContain(STATE_BADGE);
+  /* Standing alone at a stage position it still carries both. */
+  expect(visible(standalone)).toContain("Builder · integrate_v3_voice · stage 1/2");
+  expect(standalone).toContain(STATE_BADGE);
+
+  /* What the row cannot carry stays: the runtime that ran it, and the prompt —
+     which scrolls, so the whole prompt is reachable in a bounded surface. */
+  expect(disclosed).toContain("codex");
+  expect(disclosed).toContain("Stage prompt");
+  expect(disclosed).toContain("overflow-y-auto");
+  expect(disclosed).not.toContain("line-clamp-[12]");
+  /* The transcript control follows the prompt instead of being pushed to the
+     bottom of an oversized box. */
+  expect(disclosed).not.toContain("mt-auto");
+  expect(standalone).toContain("mt-auto");
+  /* Both keep the accessible name the stage is identified by. */
+  expect(ariaLabels(disclosed)).toContain("Completed stage Builder · integrate_v3_voice · stage 1/2 — open to review");
+});
+
+/*
+ * The reserved rectangle and the drawn card must agree: the row, the deliberate
+ * gap and the card together are exactly the footprint the layout gave the
+ * disclosure, and a settled stage's is bounded well below the planned stage's
+ * full editor.
+ */
+test("the disclosed footprint is the row plus a deliberate gap plus the card (#1668)", () => {
+  for (const presentation of ["completed", "placeholder"] as const) {
+    const surface = stageSurface(true, presentation);
+    expect(BOARD_SURFACE.stage.h + BOARD_SURFACE.stageDetailsGap + stageDetailsCardHeight(presentation)).toBe(surface.h);
+  }
+  expect(BOARD_SURFACE.stageDetailsGap).toBeGreaterThan(0);
+  expect(stageDetailsCardHeight("completed")).toBeLessThan(stageDetailsCardHeight("placeholder"));
+  /* Collapsed, a stage reserves only its row. */
+  expect(stageSurface(false, "completed").h).toBe(BOARD_SURFACE.stage.h);
+});
+
+/*
+ * #1668. The row is the only thing a settled stage shows until it is opened, so
+ * both of the things it says must survive a long value: a stage title is
+ * `role · stage-id · position`, and the explanation is a sentence. Cutting each
+ * to one truncated line left several stages of one pipeline reading identically.
+ */
+test("a stage status row gives its title and its explanation two lines each (#1668)", () => {
+  const html = renderToStaticMarkup(<StageStatusRow slot={slot(0, "completed")} expanded={false} />);
+  expect(html).not.toContain("truncate");
+  expect([...html.matchAll(/-webkit-line-clamp:2/g)]).toHaveLength(2);
+  /* The full strings stay reachable as tooltips whatever the clamp hides. */
+  expect(html).toContain('title="Builder · integrate_v3_voice · stage 1/2"');
 });

--- a/src/components/scheme/GroupsLayer.render.test.tsx
+++ b/src/components/scheme/GroupsLayer.render.test.tsx
@@ -154,3 +154,48 @@ test("a draft pipeline keeps a scheme-only draft treatment and one compact heade
   expect(html.split(">Refactor the scheme<").length - 1).toBe(1);
   expect(html).toContain('data-pipeline-group-header="p1"');
 });
+
+/* #1668. Inside a task band a container is a SECTION of its parent task: its
+   rect encloses its own heading and its own stage rows. It used to render as a
+   floating pill over a hidden region — four of them stacked above one
+   undifferentiated grid of every pipeline's cards — so nothing tied a colour to
+   the cards it owned. */
+test("a band container draws a visible region with its heading attached, not a detached pill (#1668)", () => {
+  const banded: SchemeGroup = { ...pipelineGroup, pipeline: planPipeline, bandHeader: true, h: 300 };
+  const html = render([banded], true);
+  /* The region is drawn, not hidden: the frame is what shows ownership. */
+  expect(html).toMatch(/class="absolute inset-0 rounded-\[14px\] border"/);
+  expect(html).toContain("background-color:color-mix(in srgb, hsl(24 62% 42%) 6%, var(--surface-well))");
+  /* The heading is a full-width bar on that region, addressable on the board. */
+  expect(html).toContain('data-scheme-group-heading="group::pipeline::p1"');
+  expect(html).toMatch(/data-scheme-group-heading[^>]*class="[^"]*\bw-full\b/);
+  /* It carries the container's own colour, so the tint reads as this pipeline's
+     territory rather than as a tag floating over someone else's cards. */
+  expect(html).toContain("background-color:color-mix(in srgb, hsl(24 62% 42%) 10%, var(--surface-card))");
+  /* Progress reads in words, and the title is clamped to two lines instead of
+     being cut to one. */
+  expect(html).toContain("stage 2 of 2");
+  expect(html).toContain("-webkit-line-clamp:2");
+  /* Every control the pill carried is still here. */
+  expect(html).toContain('data-pipeline-group-header="p1"');
+  expect(html).toContain("data-pipeline-progress");
+  expect(html).toContain("data-pipeline-lifecycle");
+  expect(html).toContain('aria-haspopup="dialog"');
+});
+
+/* A board key is an identifier, never a name. */
+test("a container with no recorded goal names its kind, never its board key (#1668)", () => {
+  const html = render([{ ...pipelineGroup, pipeline: planPipeline, bandHeader: true, label: "" }], true);
+  expect(html).not.toMatch(/>[^<]*group::pipeline::p1[^<]*</);
+  expect(html).toContain("Pipeline without a recorded goal");
+  const flow = render([{ ...flowGroup, bandHeader: true, label: "" }], true);
+  expect(flow).toContain("Review loop without a recorded subject");
+});
+
+/* Outside a band the free-map halo keeps the counter-scaled pill it always had. */
+test("a free-map container keeps its counter-scaled label pill (#1668 leaves the map alone)", () => {
+  const html = render([pipelineGroup], true);
+  expect(html).toContain("rounded-full");
+  expect(html).toContain("truncate");
+  expect(html).not.toContain("data-scheme-group-heading");
+});

--- a/src/components/scheme/boardPresentation.ts
+++ b/src/components/scheme/boardPresentation.ts
@@ -8,15 +8,44 @@ import type { TaskBand } from "./taskBands";
 export const BOARD_SURFACE = {
   summary: { w: 360, h: 88 },
   stage: { w: 360, h: 104 },
-  stageDetails: { w: 600, h: 724 },
+  /** A disclosed PLANNED stage: the whole draft-agent editor — engine chips,
+      role section, runtime controls and the prompt field — which needs the
+      height to be usable at all. */
+  stageDetails: { w: 600, h: 748 },
+  /** A disclosed SETTLED stage (#1668). The status row directly above already
+      states which stage it is and how it ended, so the disclosure only adds the
+      prompt that was sent, the runtime it ran on and the transcript link. It is
+      bounded: the prompt scrolls inside the card instead of the card growing to
+      hold it, which is what left a 620px box mostly blank and stretched every
+      connector attached to the stage down the board. */
+  stageSettledDetails: { w: 600, h: 460 },
+  /** Separation between a stage's status row and the surface it discloses, so
+      the card reads as a detail OF that row rather than glued to it. */
+  stageDetailsGap: 12,
   header: 96,
-  groupHeader: 40,
+  /** A container section's own heading bar, inside the section's region. Two
+      lines of title at 16px leading plus its padding: a pipeline goal is a
+      sentence, and hard-truncating it to one line is what made four stacked
+      headings interchangeable. */
+  groupHeader: 56,
   roleSpace: 28,
   navigationSpace: 28,
 } as const;
 
-export function stageSurface(expanded: boolean) {
-  return { ...(expanded ? BOARD_SURFACE.stageDetails : BOARD_SURFACE.stage), detailsExpanded: expanded };
+export type StagePresentation = "placeholder" | "completed";
+
+export function stageSurface(expanded: boolean, presentation: StagePresentation = "placeholder") {
+  if (!expanded) return { ...BOARD_SURFACE.stage, detailsExpanded: false };
+  const surface = presentation === "completed" ? BOARD_SURFACE.stageSettledDetails : BOARD_SURFACE.stageDetails;
+  return { ...surface, detailsExpanded: true };
+}
+
+/** Height the disclosed card gets inside {@link stageSurface}'s expanded
+ * footprint. Placement and rendering read the same function, so the reserved
+ * rectangle and the drawn card can never disagree. */
+export function stageDetailsCardHeight(presentation: StagePresentation): number {
+  const surface = presentation === "completed" ? BOARD_SURFACE.stageSettledDetails : BOARD_SURFACE.stageDetails;
+  return surface.h - BOARD_SURFACE.stage.h - BOARD_SURFACE.stageDetailsGap;
 }
 
 /** Epoch ms of a recorded date; null when it is absent or unreadable. */

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -1437,10 +1437,16 @@ export function buildSchemeLayout(
     }
     return [...out];
   };
+  /* The heading a container is read by. A board key (`group::pipeline::<id>`) is
+     an identifier, never a name, so a container with no record of its own
+     reports an EMPTY label and the heading names the kind in the operator's
+     language instead (#1668). 120 characters because the band heading wraps to
+     two lines: a pipeline goal is a sentence, and cutting it at 60 made several
+     headings in one band interchangeable. */
   const groupLabel = (spec: SchemeGroupSpec): string => {
-    if (spec.pipeline) return cleanTitle(spec.pipeline.task, 60);
-    if (spec.flow) return cleanTitle(byAll.get(spec.flow.implementerPath)?.title ?? spec.flow.project, 60);
-    return spec.key;
+    if (spec.pipeline) return cleanTitle(spec.pipeline.task, 120);
+    if (spec.flow) return cleanTitle(byAll.get(spec.flow.implementerPath)?.title ?? spec.flow.project, 120);
+    return "";
   };
   /* Every planned stage's placeholder is a member of its pipeline halo, so the
      colored region grows to enclose the future stages that sit beside the live

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { bandEdgePorts } from "./taskBands";
-import { BOARD_SURFACE, historicalAttemptLabels } from "./boardPresentation";
+import { BOARD_SURFACE, historicalAttemptLabels, stageDetailsCardHeight } from "./boardPresentation";
 
 import { Check, Layers } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useState, type ComponentProps, type CSSProperties } from "react";
@@ -510,6 +510,15 @@ export const GroupsLayer = memo(function GroupsLayer({
         const color = draft ? "var(--color-warning)" : `hsl(${group.hue} 62% 42%)`;
         const soft = draft ? "var(--color-warning-soft)" : `hsl(${group.hue} 62% 42% / 0.055)`;
         const open = openGroup?.id === group.id;
+        /* Inside a task band the group is a SECTION of its parent task (#1668):
+           its rect encloses its own heading and its own stage rows, so the
+           heading is a bar attached to the top of that region instead of a pill
+           floating over a grid it does not visibly own. */
+        const banded = Boolean(group.bandHeader);
+        /* A container with no record of its own must never headline a board key
+           (`group::pipeline::<id>`). The layout leaves the label empty and the
+           heading names the kind instead. */
+        const label = group.label || t(group.kind === "pipeline" ? "bands.unnamedPipeline" : "bands.unnamedFlow");
         return (
           /* Positioned with left/top rather than a transform: a transform would
              create a stacking context that traps the chip beneath the later
@@ -529,7 +538,7 @@ export const GroupsLayer = memo(function GroupsLayer({
                 (and drop targets elsewhere), which keep the warning halo. */}
             <div
               aria-hidden
-              className={`absolute inset-0 rounded-[20px] ${group.bandHeader ? "hidden" : ""} ${draft ? "border-2 border-dashed" : "border"}`}
+              className={`absolute inset-0 ${banded ? "rounded-[14px]" : "rounded-[20px]"} ${draft ? "border-2 border-dashed" : "border"}`}
               style={
                 draft
                   ? {
@@ -547,22 +556,73 @@ export const GroupsLayer = memo(function GroupsLayer({
                 lifecycle, and the disclosure control — no second stage graph and
                 no white body below. The real stage conversations and planned
                 placeholders live inside the region itself. */}
+            {banded ? (
+              /* Section heading: a full-width bar on the region it names, so the
+                 colour reads as this pipeline's territory rather than as a
+                 detached tag. The title wraps to two lines — a pipeline goal is
+                 a sentence, and truncating it to one line is what made several
+                 headings in a band interchangeable. Progress and lifecycle sit
+                 on the right in words, never an identifier. */
+              <button
+                data-scheme-ui
+                data-pipeline-group-header={group.pipeline ? group.id : undefined}
+                data-scheme-group-heading={group.key}
+                className={`absolute left-0 top-0 flex w-full items-start gap-2 rounded-t-[13px] border-b px-3 py-2 text-left text-[11.5px] font-bold hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default ${
+                  interactive ? "pointer-events-auto" : ""
+                }`}
+                style={{
+                  height: BOARD_SURFACE.groupHeader,
+                  color,
+                  borderColor: `color-mix(in srgb, ${color} 34%, var(--border-default))`,
+                  backgroundColor: `color-mix(in srgb, ${color} 10%, var(--surface-card))`,
+                  borderBottomStyle: draft ? "dashed" : "solid",
+                }}
+                aria-expanded={open}
+                aria-haspopup="dialog"
+                disabled={!interactive}
+                onClick={() => group.taskId ? onOpenTaskHistory?.(group.taskId) : setOpenId((value) => (value === group.id ? null : group.id))}
+              >
+                <span aria-hidden className="mt-[1px] shrink-0">{group.kind === "task" ? "▤" : group.kind === "pipeline" ? "⇢" : "⟳"}</span>
+                <span
+                  className="min-w-0 flex-1 leading-[16px]"
+                  style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+                  title={label}
+                >
+                  {group.historical ? `${t("bands.historicalRun")} · ` : ""}{label}
+                </span>
+                {group.pipeline ? (
+                  <span className="mt-[1px] flex shrink-0 items-center gap-1.5">
+                    <span
+                      data-pipeline-progress
+                      className="shrink-0 rounded-full px-1.5 py-[1px] tabular-nums"
+                      style={{ backgroundColor: soft }}
+                    >
+                      {(() => { const p = pipelineStagePosition(group.pipeline!); return t("bands.stageProgress", { k: p.k, n: p.n }); })()}
+                    </span>
+                    <span data-pipeline-lifecycle className="shrink-0 font-semibold opacity-85">
+                      {pipelineStateLabel(t, group.pipeline.state)}
+                    </span>
+                  </span>
+                ) : null}
+                <span aria-hidden className="mt-[1px] shrink-0 opacity-70">▾</span>
+              </button>
+            ) : (
             <button
               data-scheme-ui
               data-pipeline-group-header={group.pipeline ? group.id : undefined}
-              className={`absolute ${group.bandHeader ? "top-1 left-0" : "-top-3 left-5"} z-[8] inline-flex max-w-[26em] items-center gap-[0.4em] rounded-full bg-card px-[0.7em] py-[0.15em] font-bold shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default ${
+              className={`absolute -top-3 left-5 z-[8] inline-flex max-w-[26em] items-center gap-[0.4em] rounded-full bg-card px-[0.7em] py-[0.15em] font-bold shadow-1 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default ${
                 interactive ? "pointer-events-auto" : ""
               }`}
               /* Font fully counter-scaled (constant on-screen at any zoom); border
                  and padding are in em so the whole chip holds its on-screen size. */
-              style={{ maxWidth: group.bandHeader ? "100%" : "min(26em, calc(100% - 40px))", borderColor: color, color, borderWidth: "0.18em", borderStyle: draft ? "dashed" : "solid", fontSize: group.bandHeader ? 11 : groupLabelFontSize() }}
+              style={{ maxWidth: "min(26em, calc(100% - 40px))", borderColor: color, color, borderWidth: "0.18em", borderStyle: draft ? "dashed" : "solid", fontSize: groupLabelFontSize() }}
               aria-expanded={open}
               aria-haspopup="dialog"
               disabled={!interactive}
               onClick={() => group.taskId ? onOpenTaskHistory?.(group.taskId) : setOpenId((value) => (value === group.id ? null : group.id))}
             >
               <span aria-hidden>{group.kind === "task" ? "▤" : group.kind === "pipeline" ? "⇢" : "⟳"}</span>
-              <span className="truncate">{group.historical ? `${t("bands.historicalRun")} · ` : ""}{group.label}</span>
+              <span className="truncate">{group.historical ? `${t("bands.historicalRun")} · ` : ""}{label}</span>
               {group.pipeline ? (
                 <>
                   <span
@@ -579,6 +639,7 @@ export const GroupsLayer = memo(function GroupsLayer({
               ) : null}
               <span aria-hidden className="shrink-0 opacity-70">▾</span>
             </button>
+            )}
           </div>
         );
       })}
@@ -1541,9 +1602,14 @@ function StageSlotShell({ slot, lite, dimmed, files, onSelect, onToggleDetails }
         <StageStatusRow slot={slot} expanded={slot.detailsExpanded} controls={`${slot.key}::details`}
           onToggle={!lite ? () => onToggleDetails?.(slot.key) : undefined} />
       </div>
-      {slot.detailsExpanded ? <div id={`${slot.key}::details`} data-stage-row-card className="flex flex-col" style={{ height: BOARD_SURFACE.stageDetails.h - BOARD_SURFACE.stage.h }}>
+      {/* The disclosure is separated from the row it belongs to and bounded to the
+          height the layout reserved for this presentation (#1668): a settled
+          stage adds a short card whose prompt scrolls, a planned stage the full
+          editor. Both were previously the same 620px box glued to the row. */}
+      {slot.detailsExpanded ? <div id={`${slot.key}::details`} data-stage-row-card className="flex flex-col"
+        style={{ height: stageDetailsCardHeight(slot.presentation), marginTop: BOARD_SURFACE.stageDetailsGap }}>
         <EscapeToClose onClose={() => onToggleDetails?.(slot.key)} />
-        <div className="flex min-h-0 flex-1">{slot.presentation === "completed" ? <StageCompletedCard slot={slot} onOpen={file && !lite ? () => onSelect(file) : undefined} /> : <StagePlaceholderPane slot={slot} interactive={!lite} />}</div>
+        <div className="flex min-h-0 flex-1">{slot.presentation === "completed" ? <StageCompletedCard slot={slot} disclosed onOpen={file && !lite ? () => onSelect(file) : undefined} /> : <StagePlaceholderPane slot={slot} interactive={!lite} />}</div>
         {canAdd ? <div data-scheme-ui className="flex h-9 shrink-0 items-center gap-2 bg-card px-2">
           {last ? <button type="button" className="rounded border border-border px-2 py-1 text-label" disabled={busy} onClick={() => addAfter("run")}>{t("pipelineSlot.addAgent")}</button> : null}
           {slot.stage.kind === "run" ? <button type="button" className="rounded border border-border px-2 py-1 text-label" disabled={busy || !canAddReview} onClick={() => addAfter("review-loop")}>{t("pipelineSlot.addReview")}</button> : null}

--- a/src/components/scheme/taskBands.test.ts
+++ b/src/components/scheme/taskBands.test.ts
@@ -1,4 +1,4 @@
-import { historicalAttemptLabels } from "./boardPresentation";
+import { BOARD_SURFACE, historicalAttemptLabels } from "./boardPresentation";
 import { expect, test } from "bun:test";
 
 import type { BoardTask } from "@/lib/tasks/types";
@@ -407,6 +407,89 @@ test("a container halo stays inside its own band: a stage worker assigned to ano
   expect(halo.members.sort()).toEqual([files[0]!.path, pipelineBand.mirrors[0]!.key].sort());
 });
 
+
+/**
+ * #1668. A task band that owns several pipelines used to stack every container
+ * heading at the top of its body and then flow EVERY container's cards through
+ * one wrap loop, so a five-stage pipeline and a two-stage one interleaved in the
+ * same rows and the headings above named nothing in particular. Each container is
+ * now a section: its own heading, its own rows, and a region enclosing both.
+ */
+test("each pipeline of a task is its own enclosed section: no shared rows, headings above their own cards (#1668)", () => {
+  const files = Array.from({ length: 4 }, (_, index) => file(index));
+  const first = pipelineWith("alpha", files.slice(0, 2), ["t"]);
+  const second = pipelineWith("beta", files.slice(2, 4), ["t"]);
+  const tasks = [task("t", "2026-01-01T00:00:00Z", [])];
+  const layout = base(files);
+  layout.groups = [
+    { key: "group::pipeline::alpha", kind: "pipeline", id: "alpha", hue: 10, members: files.slice(0, 2).map((entry) => entry.path), label: "Pipeline alpha", pipeline: first, x: 0, y: 0, w: 0, h: 0 },
+    { key: "group::pipeline::beta", kind: "pipeline", id: "beta", hue: 200, members: files.slice(2, 4).map((entry) => entry.path), label: "Pipeline beta", pipeline: second, x: 0, y: 0, w: 0, h: 0 },
+  ];
+  const projection = projectTaskWorkflows(tasks, [first, second], [], files);
+  const bands = rankBands(buildTaskBands(layout, { tasks, projection, untitled: "Untitled task" }));
+  const band = bands.find((entry) => entry.id === "task:t")!;
+  expect(band.groups).toEqual(["group::pipeline::alpha", "group::pipeline::beta"]);
+
+  /* 1440 is wide enough that three 360px tiles share a row, so a single flat
+     wrap WOULD put alpha's two stages and beta's first on one row — the exact
+     interleaving this test exists to forbid. */
+  const scene = layoutTaskBands(layout, bands, { mode: "intermediate", viewportWidth: 1440, reader: null });
+  const regionOf = (id: string) => scene.layout.groups.find((group) => group.id === id)!;
+  const cardsOf = (indices: readonly number[]) => indices.map((index) => scene.layout.byPath.get(files[index]!.path)!);
+  const placed = scene.bands.find((entry) => entry.id === "task:t")!;
+  const alpha = { region: regionOf("alpha"), cards: cardsOf([0, 1]) };
+  const beta = { region: regionOf("beta"), cards: cardsOf([2, 3]) };
+
+  for (const section of [alpha, beta]) {
+    expect(section.region.bandHeader).toBe(true);
+    for (const card of section.cards) {
+      /* Inside its own region, and below the heading bar the region carries. */
+      expect(contains(section.region, card)).toBe(true);
+      expect(card.y).toBeGreaterThanOrEqual(section.region.y + BOARD_SURFACE.groupHeader - 0.001);
+      /* Inside the band that owns the section. */
+      expect(contains(placed.geometry.rect, card)).toBe(true);
+    }
+    expect(contains(placed.geometry.rect, section.region)).toBe(true);
+  }
+  /* A region encloses exactly its own container's cards. */
+  expect(alpha.region.members.slice().sort()).toEqual(files.slice(0, 2).map((entry) => entry.path).sort());
+  expect(beta.region.members.slice().sort()).toEqual(files.slice(2, 4).map((entry) => entry.path).sort());
+  /* Both of alpha's stages share a row; neither shares it with any of beta's. */
+  expect(alpha.cards[0]!.y).toBeCloseTo(alpha.cards[1]!.y, 6);
+  expect(beta.cards[0]!.y).toBeCloseTo(beta.cards[1]!.y, 6);
+  for (const a of alpha.cards) for (const b of beta.cards) expect(overlapping(a, b)).toBe(false);
+  expect(beta.cards[0]!.y).toBeGreaterThan(alpha.cards[0]!.y);
+
+  /* Deliberate separation between the two sections, and no overlap at all. */
+  expect(overlapping(alpha.region, beta.region)).toBe(false);
+  expect(beta.region.y - (alpha.region.y + alpha.region.h)).toBeCloseTo(BAND.sectionGap, 6);
+  /* Both sections span the same width, so the frames stack as one column. */
+  expect(beta.region.w).toBeCloseTo(alpha.region.w, 6);
+  expect(alpha.region.x).toBeCloseTo(beta.region.x, 6);
+
+  /* The same holds at every width the board renders at and every semantic zoom:
+     narrowing the band wraps a pipeline's stages WITHIN its own section instead
+     of spilling them into its neighbour's. */
+  for (const viewportWidth of [375, 680, 830, 1024, 1440, 1920]) {
+    for (const mode of ["overview", "intermediate", "near"] as const) {
+      const at = layoutTaskBands(layout, bands, { mode, viewportWidth, reader: null });
+      const band = at.bands.find((entry) => entry.id === "task:t")!;
+      const regions = at.layout.groups.filter((group) => group.kind === "pipeline");
+      expect(regions).toHaveLength(2);
+      for (const region of regions) {
+        expect(contains(band.geometry.rect, region)).toBe(true);
+        const own = new Set(regions.find((entry) => entry.id === region.id)!.members);
+        for (const key of own) expect(contains(region, at.layout.byPath.get(key)!)).toBe(true);
+        /* No card of another section is inside — or even touching — this frame. */
+        for (const other of regions) {
+          if (other.id === region.id) continue;
+          expect(overlapping(region, other)).toBe(false);
+          for (const key of other.members) expect(overlapping(region, at.layout.byPath.get(key)!)).toBe(false);
+        }
+      }
+    }
+  }
+});
 
 test("a hidden EMPTY task draws no band; a hidden task holding an agent still does (#1614 item 1)", () => {
   const files = [file(0, "busy"), file(1)];
@@ -865,8 +948,8 @@ test("placeholder disclosure reserves its actual surface and reflows the followi
   const compact = layoutTaskBands(layout, bands, options);
   expect(compact.layout.slots[0]!.h).toBe(104);
   const expanded = layoutTaskBands(layout, bands, { ...options, expandedStages: new Set([key]) });
-  expect(expanded.layout.slots[0]!.h).toBe(724);
-  expect(expanded.bands[1]!.geometry.rect.y - compact.bands[1]!.geometry.rect.y).toBe(620);
+  expect(expanded.layout.slots[0]!.h).toBe(BOARD_SURFACE.stageDetails.h);
+  expect(expanded.bands[1]!.geometry.rect.y - compact.bands[1]!.geometry.rect.y).toBe(BOARD_SURFACE.stageDetails.h - BOARD_SURFACE.stage.h);
   expect(layoutTaskBands(layout, bands, options).bands.map(band => band.geometry)).toEqual(compact.bands.map(band => band.geometry));
   expect(pipeline.state).toBe("needs_decision");
 });

--- a/src/components/scheme/taskBands.ts
+++ b/src/components/scheme/taskBands.ts
@@ -473,6 +473,14 @@ export const BAND = {
      whose row of members ends early stops there instead of ruling a line across
      the whole canvas. Both are CSS pixels, like every other constant here. */
   minBandW: 620,
+  /* Inset of a container section's cards from the region that frames them
+     (#1668): a pipeline's stages sit visibly INSIDE the heading that names
+     them, which is the whole point of the frame. */
+  sectionPad: 14,
+  /* Separation between two container sections of the same task. Deliberately
+     larger than `rowGap`, so a wrapped row inside one pipeline never reads as a
+     boundary between two. */
+  sectionGap: 28,
 } as const;
 
 export interface BandGeometry {
@@ -644,10 +652,15 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
      (a draft pane, a planned stage slot, a deck, a reader tile on a board the
      dock has narrowed) is scaled down uniformly, contents included, so no
      surface ever extends past the band that holds it. */
-  const fitted = (w: number, h: number): { w: number; h: number; fit: number } => {
-    const fit = w > maxInnerW ? maxInnerW / w : 1;
+  const fitted = (w: number, h: number, usable: number = maxInnerW): { w: number; h: number; fit: number } => {
+    const fit = w > usable ? usable / w : 1;
     return { w: w * fit, h: h * fit, fit };
   };
+  /* A framed container section insets its cards on both sides, so an item that
+     lands in one has that much less room than the band's raw inner width
+     (#1668). Measuring against the wider figure let a scaled-down card overhang
+     the very frame that names it on a phone-width board. */
+  const sectionInnerW = Math.max(1, maxInnerW - BAND.sectionPad * 2);
   /* A review-round deck that renders as its one-line verdict chip must reserve
      the chip's height, not the full deck box it would need expanded, or a
      collapsed review loop leaves a task frame almost entirely empty. Which decks
@@ -670,6 +683,32 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     const historyCollapsed = historyAvailable && historyChoice !== true
       && !(historyChoice === undefined && band.members.some(member => member.kind === "deck" && options.expandedDecks?.has(member.key)))
       && !bandContainsTarget(band, base, options.revealTarget ?? reader);
+    /* SECTIONS (#1668). A band is the task; each pipeline/flow it owns is a
+       section INSIDE it, and a section is the only thing that wraps. Previously
+       every heading was stacked at the top of the body and then every container's
+       members were flowed through ONE wrap loop, so a five-stage pipeline and a
+       two-stage one interleaved in the same rows and the headings above named
+       nothing in particular. Now a section owns its heading, its own rows and a
+       framed region enclosing both, and sections are separated by `sectionGap`.
+       Items belonging to no container keep their own unframed section after
+       them. The rectangle a heading reports IS the region, so `GroupsLayer`
+       draws the frame the operator reads ownership from. */
+    const sectionOf = new Map<string, string>();
+    for (const key of band.groups) {
+      const group = base.groups.find(entry => entry.key === key);
+      for (const memberKey of group?.members ?? []) if (!sectionOf.has(memberKey)) sectionOf.set(memberKey, key);
+      bandOf.set(key, band.id);
+    }
+    /* A mirror stands in for a member of the same container, so it belongs in
+       that container's section rather than drifting into the loose remainder. */
+    for (const mirror of band.mirrors) {
+      const owner = sectionOf.get(mirror.ofKey);
+      if (owner && !sectionOf.has(mirror.key)) sectionOf.set(mirror.key, owner);
+    }
+    /* Room an item gets: inside a framed section it is the section's, not the
+       band's. */
+    const usableFor = (key: string) => (sectionOf.has(key) ? sectionInnerW : maxInnerW);
+
     const items: { key: string; w: number; h: number; fit?: number; kind: "member" | "mirror"; node?: SchemeNode }[] = [];
     for (const member of historyCollapsed ? [] : band.members) {
       if (member.kind === "node") {
@@ -677,9 +716,11 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
         /* The selected conversation reads natively from the intermediate scale
            up: clicking a tile opens it in place, siblings stay tiles. */
         const presentation = mode === "overview" ? "chip" : member.key === reader ? "native" : "summary";
+        const usable = usableFor(member.key);
         const natural = fitted(
-          presentation === "chip" ? BAND.chipW : presentation === "native" ? Math.max(BAND.nativeMinW, Math.min(BAND.nativeW, maxInnerW)) : BAND.summaryW,
+          presentation === "chip" ? BAND.chipW : presentation === "native" ? Math.max(BAND.nativeMinW, Math.min(BAND.nativeW, usable)) : BAND.summaryW,
           presentation === "chip" ? BAND.chipH : presentation === "native" ? BAND.nativeH : BAND.summaryH,
+          usable,
         );
         items.push({ key: member.key, w: natural.w, h: natural.h, kind: "member", node: { ...node, presentation, readerScale: natural.fit, w: natural.w, h: natural.h } });
         continue;
@@ -690,55 +731,73 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
       const rect = baseRect.get(member.key);
       if (!rect) continue;
       const slot = member.kind === "slot" ? base.slots.find(slot => slot.key === member.key) : undefined;
-      const surface = slot ? stageSurface(options.expandedStages?.has(member.key) ?? false) : rect;
+      const surface = slot ? stageSurface(options.expandedStages?.has(member.key) ?? false, slot.presentation) : rect;
       const shellH = member.kind === "deck" && collapsedDecks.has(member.key) ? BAND.collapsedDeckH : surface.h;
-      const natural = fitted(surface.w, shellH);
+      const natural = fitted(surface.w, shellH, usableFor(member.key));
       items.push({ key: member.key, w: natural.w, h: natural.h, fit: natural.fit, kind: "member" });
     }
     for (const mirror of historyCollapsed ? [] : band.mirrors) {
-      const natural = fitted(mode === "overview" ? BAND.mirrorChipW : BAND.mirrorW, mode === "overview" ? BAND.chipH : BAND.mirrorH);
+      const natural = fitted(mode === "overview" ? BAND.mirrorChipW : BAND.mirrorW, mode === "overview" ? BAND.chipH : BAND.mirrorH, usableFor(mirror.key));
       items.push({ key: mirror.key, w: natural.w, h: natural.h, kind: "mirror" });
     }
-    // Each container gets a dedicated heading before its members. A heading
-    // never borrows the task title row or spans another container's cards.
-    const groupHeadroom = band.groups.length * BOARD_SURFACE.groupHeader;
     const hasNative = items.some(item => item.node?.presentation === "native");
     const hasRole = band.members.some(member => member.kind === "deck" || (member.kind === "node" && (
       base.loops.some(loop => loop.flow.implementerPath === member.key)
       || base.groups.some(group => group.pipeline?.runs.some(run => run.attempts.some(attempt => attempt.agentPath === member.key)))
     )));
     const roleSpace = mode === "overview" ? 0 : hasNative ? 64 : hasRole ? BOARD_SURFACE.roleSpace : 0;
-    const bodyTop = cursorY + headerH + groupHeadroom + (items.length ? roleSpace : 0);
-    for (const [index, key] of band.groups.entries()) {
-      containerSlots.set(key, { x: innerX0, y: cursorY + headerH + index * BOARD_SURFACE.groupHeader, w: Math.min(680, maxInnerW), h: BOARD_SURFACE.groupHeader });
-      bandOf.set(key, band.id);
-    }
-    let x = innerX0;
-    let y = bodyTop;
-    let rowH = 0;
-    let rows = items.length ? 1 : 0;
+
+    const LOOSE = "";
+    const sectionKeys = [...band.groups, LOOSE];
+    const bySection = new Map<string, typeof items>(sectionKeys.map(key => [key, [] as typeof items]));
+    for (const item of items) bySection.get(sectionOf.get(item.key) ?? LOOSE)!.push(item);
+
+    let rows = 0;
     /* Rightmost inked edge across every row, so the band can be trimmed to the
        content it actually holds instead of to the width it was measured in. */
     let contentRight = innerX0;
-    for (const item of items) {
-      if (x + item.w > innerRight + 0.001 && x > innerX0) {
-        x = innerX0;
-        y += rowH + rowGap + roleSpace;
-        rowH = 0;
-        rows += 1;
+    let sectionTop = cursorY + headerH;
+    let bodyBottom = sectionTop;
+    for (const sectionKey of sectionKeys) {
+      const list = bySection.get(sectionKey)!;
+      const framed = sectionKey !== LOOSE;
+      /* A container with nothing placed (overview scale, an unmaterialized
+         draft) still reserves its heading, so its controls always have a place. */
+      if (!framed && !list.length) continue;
+      const inset = framed ? BAND.sectionPad : 0;
+      const headingH = framed ? BOARD_SURFACE.groupHeader : 0;
+      const left = innerX0 + inset;
+      const sectionRight = innerRight - inset;
+      let x = left;
+      let y = sectionTop + headingH + inset + (list.length ? roleSpace : 0);
+      let rowH = 0;
+      if (list.length) rows += 1;
+      for (const item of list) {
+        if (x + item.w > sectionRight + 0.001 && x > left) {
+          x = left;
+          y += rowH + rowGap + roleSpace;
+          rowH = 0;
+          rows += 1;
+        }
+        const rect: SchemeRect = { x, y, w: item.w, h: item.h, ...(item.fit !== undefined && item.fit !== 1 ? { fit: item.fit } : {}) };
+        placed.set(item.key, rect);
+        shown.add(item.key);
+        bandOf.set(item.key, band.id);
+        if (item.kind === "mirror") mirrorRects.set(item.key, rect);
+        if (item.node) nodeRects.set(item.key, { ...item.node, x, y });
+        contentRight = Math.max(contentRight, x + item.w + inset);
+        const reviewGap = base.loops.some(loop => loop.flow.implementerPath === item.key) ? FLOW_HUB.w + 16 : itemGap;
+        x += item.w + Math.max(itemGap, reviewGap);
+        rowH = Math.max(rowH, item.h);
       }
-      const rect: SchemeRect = { x, y, w: item.w, h: item.h, ...(item.fit !== undefined && item.fit !== 1 ? { fit: item.fit } : {}) };
-      placed.set(item.key, rect);
-      shown.add(item.key);
-      bandOf.set(item.key, band.id);
-      if (item.kind === "mirror") mirrorRects.set(item.key, rect);
-      if (item.node) nodeRects.set(item.key, { ...item.node, x, y });
-      contentRight = Math.max(contentRight, x + item.w);
-      const reviewGap = base.loops.some(loop => loop.flow.implementerPath === item.key) ? FLOW_HUB.w + 16 : itemGap;
-      x += item.w + Math.max(itemGap, reviewGap);
-      rowH = Math.max(rowH, item.h);
+      const contentBottom = list.length ? y + rowH : sectionTop + headingH;
+      const sectionBottom = contentBottom + inset;
+      if (framed) containerSlots.set(sectionKey, { x: innerX0, y: sectionTop, w: Math.min(680, maxInnerW), h: sectionBottom - sectionTop });
+      bodyBottom = Math.max(bodyBottom, sectionBottom);
+      sectionTop = sectionBottom + BAND.sectionGap;
     }
-    let bandH = y - cursorY + rowH + (items.length ? BOARD_SURFACE.navigationSpace + pad : 0);
+
+    let bandH = bodyBottom - cursorY + (items.length ? BOARD_SURFACE.navigationSpace + pad : 0);
     if (mode === "overview") bandH = Math.max(bandH, BAND.minOverviewH);
     /* The band ends where its content ends. The floor keeps the header
        readable — title and header controls have dedicated rows — and the ceiling is the width it was measured in, so
@@ -746,9 +805,10 @@ export function layoutTaskBands(base: SchemeLayout, orderedBands: readonly TaskB
     const bandW = Math.min(maxBandW, Math.max(minBandW, contentRight + pad - gutter));
     const rect = { x: bandX, y: cursorY, w: bandW, h: bandH };
     const header = { x: bandX, y: cursorY, w: bandW, h: headerH };
+    /* Every section spans the same width, so the frames stack as one column. */
     for (const key of band.groups) {
-      const heading = containerSlots.get(key);
-      if (heading) heading.w = bandW - pad * 2;
+      const region = containerSlots.get(key);
+      if (region) region.w = bandW - pad * 2;
     }
     if (band.task) taskRects.set(`task::${band.task.id}`, header);
     placedBands.push({ ...band, geometry: { rect, header, rows, historyAvailable, historyCollapsed } });

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1548,6 +1548,12 @@ export const en = {
   // settled stages collapsed to one status row (#658)
   "pipelineSlot.rowAria": "Finished stage {title}",
   "pipelineSlot.reasonSkipped": "Skipped by the operator — the chain moved on",
+  "pipelineSlot.reasonNotStarted": "Not started yet",
+  "pipelineSlot.reasonQueuedAfter": "Not started — queued behind {title} (stage {k} of {n})",
+  "pipelineSlot.reasonHeldDecision": "Not started — the pipeline is waiting for your decision",
+  "pipelineSlot.reasonHeldPaused": "Not started — the pipeline is paused",
+  "pipelineSlot.reasonPlanned": "Planned — the pipeline has not been started yet",
+  "pipelineSlot.reasonNeverRan": "Never ran — the pipeline ended before reaching this stage",
   "pipelineSlot.rowExpand": "Show the full stage card",
   "pipelineSlot.rowCollapse": "Collapse back to the status row",
   "pipelineTemplates.planBuildReview": "Plan → Build → Review",
@@ -1740,6 +1746,9 @@ export const en = {
   "bands.continuesIn": "Continues in {title}",
   "bands.continuesFrom": "Comes from {title}",
   "bands.crossLinks": { one: "{count} link to another task", other: "{count} links to other tasks" },
+  "bands.unnamedPipeline": "Pipeline without a recorded goal",
+  "bands.unnamedFlow": "Review loop without a recorded subject",
+  "bands.stageProgress": "stage {k} of {n}",
 
   // scheme/BulkActionBar (selection session)
   "bulk.selectedCount": { one: "{count} selected", other: "{count} selected" },

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1493,6 +1493,12 @@ export const uk: Record<keyof typeof en, Message> = {
   // згорнуті завершені стадії в один рядок статусу (#658)
   "pipelineSlot.rowAria": "Завершений етап {title}",
   "pipelineSlot.reasonSkipped": "Пропущено оператором — ланцюжок пішов далі",
+  "pipelineSlot.reasonNotStarted": "Ще не починався",
+  "pipelineSlot.reasonQueuedAfter": "Не починався — чекає в черзі за етапом «{title}» ({k} з {n})",
+  "pipelineSlot.reasonHeldDecision": "Не починався — пайплайн чекає на ваше рішення",
+  "pipelineSlot.reasonHeldPaused": "Не починався — пайплайн на паузі",
+  "pipelineSlot.reasonPlanned": "Заплановано — пайплайн ще не запускали",
+  "pipelineSlot.reasonNeverRan": "Не запускався — пайплайн завершився, не дійшовши до цього етапу",
   "pipelineSlot.rowExpand": "Показати повну картку етапу",
   "pipelineSlot.rowCollapse": "Згорнути назад до рядка статусу",
   "pipelineTemplates.planBuildReview": "План → Збірка → Рев’ю",
@@ -1682,6 +1688,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "bands.continuesIn": "Продовжується у {title}",
   "bands.continuesFrom": "Походить із {title}",
   "bands.crossLinks": { one: "{count} зв’язок з іншою задачею", few: "{count} зв’язки з іншими задачами", many: "{count} зв’язків з іншими задачами", other: "{count} зв’язків з іншими задачами" },
+  "bands.unnamedPipeline": "Пайплайн без записаної мети",
+  "bands.unnamedFlow": "Цикл рев’ю без записаного предмета",
+  "bands.stageProgress": "етап {k} з {n}",
 
   "bulk.selectedCount": { one: "Вибрано {count}", few: "Вибрано {count}", many: "Вибрано {count}", other: "Вибрано {count}" },
   "bulk.placeholder": "одне повідомлення кожному вибраному агенту…",


### PR DESCRIPTION
Closes #1668.

## What changed

**A task band's pipelines are now enclosed sections, not a shared grid.** Every container heading used to be stacked at the top of the band body, after which every container's cards were flowed through *one* wrap loop. Four narrow coloured pills floated above one undifferentiated grid in which a five-stage pipeline and a two-stage one interleaved in the same rows — the only way to attribute a stage was to read every card's `k/n`. Each container now owns a section: its heading, its own rows, and a framed region enclosing both, with `BAND.sectionGap` between sections. Items belonging to no container keep an unframed section after them. Section items are measured against the *section's* usable width (`maxInnerW - 2 × sectionPad`), so a card scaled down on a phone-width board cannot overhang the frame that names it.

**The heading is attached to its region.** It keeps the container's colour — now tinting the territory it actually owns rather than floating as a detached tag — wraps its title to two lines instead of hard-truncating, and states progress in words (`stage 2 of 2`) next to the lifecycle. Every control the pill carried (disclosure, `data-pipeline-group-header`, progress, lifecycle) is unchanged. Outside a band the free-map halo keeps the counter-scaled pill it always had.

**Technical identifiers left the headline.** `groupLabel` returned `spec.key` — a raw `group::pipeline::<id>` — for a container with no record; it now returns an empty label and the heading names the kind ("Pipeline without a recorded goal"). The pipeline goal is cleaned to 120 characters rather than 60, because the heading wraps to two lines.

**Stage expansion is bounded and stops duplicating its own row.** `stageSurface(true)` reserved `600 × 724` and glued the card to the row with no gap. A settled stage's disclosure is now `600 × 460`: a deliberate `stageDetailsGap` below the row, no repeated heading, no repeated state badge, and only what the row cannot carry — engine, kind, model/effort, verdict, and the prompt, which scrolls inside the bounded card so the whole prompt stays reachable. The transcript link follows the prompt instead of sitting at the bottom of a mostly blank box. A planned stage keeps the full editor height it needs. Placement and rendering read one function (`stageDetailsCardHeight`), so the reserved rectangle and the drawn card cannot disagree.

**Unstarted stages explain themselves truthfully.** A stage with no attempt used to render `pending` in the badge and `pending` as its whole explanation. It now states what it is waiting for: queued behind a named stage, held for a decision, paused, planned, or never reached because the chain ended first. Every one of those says the stage has **not** started, because none of them has — nothing here presents unstarted work as finished, and nothing claims a stage is blocked when it is merely later in the chain. The row gives its title and its explanation two lines each, with the full strings still reachable as tooltips.

The stage graph, connectors, navigation, selection, disclosure state and every control behave exactly as before; this changes where surfaces are placed and what they say, not what they do.

## Tests

New focused coverage:

* `taskBands.test.ts` — two pipelines of one task get no shared rows; each region encloses exactly its own cards below its own heading; the sections do not overlap and sit `sectionGap` apart at equal width. Repeated across widths 375 / 680 / 830 / 1024 / 1440 / 1920 × overview / intermediate / near: no card of one section ever touches another section's frame.
* `GroupsLayer.render.test.tsx` — a band container draws a visible region with a full-width heading in its own colour, progress in words, a two-line clamp and no truncation, keeping every control; a container with no goal names its kind rather than its board key; the free-map halo is untouched.
* `stageCardAria.render.test.tsx` — a disclosed card repeats neither the row's heading (in *visible* text; the accessible name is deliberately retained) nor its state badge, scrolls its prompt, and drops `mt-auto`; the reserved footprint equals row + gap + card for both presentations, and a settled disclosure is bounded below a planned one.
* `pipelineModel.test.ts` — each not-started case yields its own sentence, the cursor stage still reports its live state, and a stage that did run still reads from its own record.

Verification:

| check | result |
| --- | --- |
| `bunx tsc --noEmit` | exit 0 |
| `taskBands.test.ts` | 40 pass / 0 fail |
| `GroupsLayer.render.test.tsx` | 13 pass / 0 fail |
| `pipelineModel.test.ts` | 124 pass / 0 fail |
| `stageCardAria.render.test.tsx` | 5 pass / 0 fail |
| `SchemeBoard.bands.dom.test.tsx` | 11 pass / 0 fail |
| `RoundDeck.dom.test.tsx` | 7 pass / 0 fail |
| `i18n.test.ts` | 20 pass / 0 fail |
| `privacy:check` | PASS |

`bun test src/components/scheme/ src/components/pipelines/` is **19 fail / 992 pass** on this branch and **23 fail / … ** at the merge base with the same command. Comparing the two failure sets name-by-name, this branch introduces **zero** new failures; the four that differ are cross-file ordering flakes that fail at the merge base and not here. Every one of the 19 is red on `main` before this branch exists.

## Browser evidence

Driven against a dev server on the real board through raw CDP on headless Chrome, at 1600 / 980 / 700 CSS px and on the phone surface. Rasters are not committed (the gate requires generator provenance for images), so the measured geometry and what the frames show:

**Desktop, one task owning five pipelines.** One outer task container carries the title, `assigned`, `0 working · 4 conversations · 4 planned`, `Details` and `+ Agent`. Inside it, five separately framed sections in five hues, each headed by its own bar (`Preserve complete attachment submissions through send and reload` · `stage 1 of 2` · `needs a decision ▾`) with that pipeline's two stage cards inside the frame beneath it. No card sits in a row with another pipeline's card. Pending cards read `Not started — the pipeline is waiting for your decision`.

**Narrow (980 and 700).** The band narrows to one card per row and each pipeline wraps *within its own frame* — stage 1 above stage 2, joined by the handoff connector, both inside the section. Headings wrap to two lines; the longest clamps with an ellipsis and keeps the full string as its tooltip. No overlap, no overflow past any frame.

**Expanded stage.** Measured at 58% board zoom: row `h≈60`, gap `7` (= 12 board px), card `h≈200` — the row states `Builder · finish · stage 1/2` / `✓ passed` / `Reproduced your P1 exactly, then fixed it.`, and the card below carries `Claude` `RUN` `pass` · `Opus 5 · high`, the stage prompt, and `Open conversation` directly under it. No repeated heading, no repeated `passed`, no blank lower area.

**Phone (430 × 932).** The board renders the mobile list surface, which carries no band or section nodes at all — 49 controls, none under 28 px tall, `scrollWidth - clientWidth = 0`. This change does not reach it.

## Not done here

No merge, no deploy. Nothing outside board task/pipeline presentation was touched; no task prose was written, no board state mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
